### PR TITLE
Feature/2411 unknown params fix

### DIFF
--- a/src/ramses_rf/device/hvac.py
+++ b/src/ramses_rf/device/hvac.py
@@ -446,7 +446,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         """
         super().__init__(*args, **kwargs)
         self._supports_2411 = False  # Flag for 2411 parameter support
-        self._params_2411: dict[str, Any] = {}  # Store 2411 parameters here
+        self._params_2411: dict[str, float] = {}  # Store 2411 parameters here
         self._initialized_callback = None  # Called when device is fully initialized
         self._param_update_callback = None  # Called when 2411 parameters are updated
         self._hgi: Any | None = None  # Will be set when HGI is available
@@ -518,7 +518,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         :param param_id: The ID of the parameter that was updated
         :type param_id: str
         :param value: The new value of the parameter
-        :type value: Any
+        :type value: float
         """
         if callable(self._param_update_callback):
             try:
@@ -542,29 +542,29 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         The HGI device provides additional functionality for certain operations.
 
         :return: The HGI device instance, or None if not available
-        :rtype: Any | None
+        :rtype: float | None
         """
         if self._hgi is None and self._gwy and hasattr(self._gwy, "hgi"):
             self._hgi = self._gwy.hgi
         return self._hgi
 
-    def get_2411_param(self, param_id: str) -> Any:
+    def get_2411_param(self, param_id: str) -> float | None:
         """Get a 2411 parameter value.
 
         :param param_id: The parameter ID to retrieve.
         :type param_id: str
         :return: The parameter value if found, None otherwise
-        :rtype: Any | None
+        :rtype: float | None
         """
         return self._params_2411.get(param_id)
 
-    def set_2411_param(self, param_id: str, value: Any) -> bool:
+    def set_2411_param(self, param_id: str, value: float) -> bool:
         """Set a 2411 parameter value.
 
         :param param_id: The parameter ID to retrieve.
         :type param_id: str
         :param value: The parameter value to set.
-        :type value: Any
+        :type value: float
         :return: True if the parameter was set, False otherwise
         :rtype: bool
         """
@@ -584,7 +584,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         :param param_id: The parameter ID to retrieve.
         :type param_id: str
         :return: The parameter value if found, None otherwise
-        :rtype: Any | None
+        :rtype: float | None
         """
         # Ensure param_id is uppercase and strip leading zeros for consistency
         param_id = (

--- a/src/ramses_tx/parsers.py
+++ b/src/ramses_tx/parsers.py
@@ -1960,6 +1960,7 @@ def parser_2411(payload: str, msg: Message) -> dict[str, Any]:
     except AssertionError as err:
         _LOGGER.warning(f"{msg!r} < {_INFORM_DEV_MSG} ({err})")
         # Return partial result for unknown parameters
+        result["value"] = ""
         return result
 
 

--- a/src/ramses_tx/parsers.py
+++ b/src/ramses_tx/parsers.py
@@ -1912,41 +1912,55 @@ def parser_2411(payload: str, msg: Message) -> dict[str, Any]:
         "92": (4, hex_to_temp),  # 75 (0-30) (C)
     }  # TODO: _2411_TYPES.get(payload[8:10], (8, no_op))
 
-    assert payload[4:6] in _2411_TABLE, (
-        f"param {payload[4:6]} is unknown"
-    )  # _INFORM_DEV_MSG
-    description = _2411_TABLE.get(payload[4:6], "Unknown")
+    # Handle unknown parameters gracefully instead of asserting
+    param_id = payload[4:6]
+    try:
+        description = _2411_TABLE.get(param_id, "Unknown")
+        if param_id not in _2411_TABLE:
+            _LOGGER.warning(
+                f"2411 message received with unknown parameter ID: {param_id}. "
+                f"This parameter is not in the known parameter schema. "
+                f"Message: {msg!r}"
+            )
+    except Exception as err:
+        _LOGGER.warning(f"Error looking up 2411 parameter {param_id}: {err}")
+        description = "Unknown"
 
     result = {
-        "parameter": payload[4:6],
+        "parameter": param_id,
         "description": description,
     }
 
     if msg.verb == RQ:
         return result
 
-    assert payload[8:10] in _2411_DATA_TYPES, (
-        f"param {payload[4:6]} has unknown data_type: {payload[8:10]}"
-    )  # _INFORM_DEV_MSG
-    length, parser = _2411_DATA_TYPES.get(payload[8:10], (8, lambda x: x))
+    try:
+        assert payload[8:10] in _2411_DATA_TYPES, (
+            f"param {param_id} has unknown data_type: {payload[8:10]}"
+        )  # _INFORM_DEV_MSG
+        length, parser = _2411_DATA_TYPES.get(payload[8:10], (8, lambda x: x))
 
-    result |= {
-        "value": parser(payload[10:18][-length:]),  # type: ignore[operator]
-        "_value_06": payload[6:10],
-    }
-
-    if msg.len == 9:
-        return result
-
-    return (
-        result
-        | {
-            "min_value": parser(payload[18:26][-length:]),  # type: ignore[operator]
-            "max_value": parser(payload[26:34][-length:]),  # type: ignore[operator]
-            "precision": parser(payload[34:42][-length:]),  # type: ignore[operator]
-            "_value_42": payload[42:],
+        result |= {
+            "value": parser(payload[10:18][-length:]),  # type: ignore[operator]
+            "_value_06": payload[6:10],
         }
-    )
+
+        if msg.len == 9:
+            return result
+
+        return (
+            result
+            | {
+                "min_value": parser(payload[18:26][-length:]),  # type: ignore[operator]
+                "max_value": parser(payload[26:34][-length:]),  # type: ignore[operator]
+                "precision": parser(payload[34:42][-length:]),  # type: ignore[operator]
+                "_value_42": payload[42:],
+            }
+        )
+    except AssertionError as err:
+        _LOGGER.warning(f"{msg!r} < {_INFORM_DEV_MSG} ({err})")
+        # Return partial result for unknown parameters
+        return result
 
 
 # unknown_2420, from OTB


### PR DESCRIPTION
- stricter _params_2411_dict definition in hvac.py as requested
- fix for isue #290: assertion error on unknown parameter id's.
  logs a warning, and returns partial result.

PR for _cc to catch this and log in the UI is on it's way...