### PR TITLE
Show/hide all MQTT traffic in log

### DIFF
--- a/src/ramses_tx/gateway.py
+++ b/src/ramses_tx/gateway.py
@@ -117,7 +117,7 @@ class Engine:
         )
         self._sqlite_index = kwargs.pop(SZ_SQLITE_INDEX, False)  # default True?
         if not kwargs.pop(SZ_LOG_ALL_MQTT, False):
-            _LOGGER.addFilter(BlockMqttFilter())
+            logging.getLogger("transport").addFilter(BlockMqttFilter())
         self._kwargs: dict[str, Any] = kwargs  # HACK
 
         self._engine_lock = Lock()  # FIXME: threading lock, or asyncio lock?

--- a/src/ramses_tx/gateway.py
+++ b/src/ramses_tx/gateway.py
@@ -195,6 +195,7 @@ class Engine:
             pkt_source[SZ_PACKET_LOG] = self._input_file  # filename as string
 
         _log_all: int = 1 if self._log_all_mqtt else 0
+        _LOGGER.info(f"Log MQTT: {_log_all}")
         # incl. await protocol.wait_for_connection_made(timeout=5)
         self._transport = await transport_factory(
             self._protocol,

--- a/src/ramses_tx/gateway.py
+++ b/src/ramses_tx/gateway.py
@@ -34,7 +34,7 @@ from .schemas import (
     SZ_DISABLE_QOS,
     SZ_DISABLE_SENDING,
     SZ_ENFORCE_KNOWN_LIST,
-    SZ_LOG_ALL_MQTT,
+    # SZ_LOG_ALL_MQTT,
     SZ_PACKET_LOG,
     SZ_PORT_CONFIG,
     SZ_PORT_NAME,
@@ -115,7 +115,7 @@ class Engine:
             self._exclude,
         )
         self._sqlite_index = kwargs.pop(SZ_SQLITE_INDEX, False)  # default True?
-        self._log_all_mqtt = kwargs.pop(SZ_LOG_ALL_MQTT, False)
+        self._log_all_mqtt = True  # kwargs.pop(SZ_LOG_ALL_MQTT, False)
         self._kwargs: dict[str, Any] = kwargs  # HACK
 
         self._engine_lock = Lock()  # FIXME: threading lock, or asyncio lock?

--- a/src/ramses_tx/gateway.py
+++ b/src/ramses_tx/gateway.py
@@ -34,7 +34,7 @@ from .schemas import (
     SZ_DISABLE_QOS,
     SZ_DISABLE_SENDING,
     SZ_ENFORCE_KNOWN_LIST,
-    # SZ_LOG_ALL_MQTT,
+    SZ_LOG_ALL_MQTT,
     SZ_PACKET_LOG,
     SZ_PORT_CONFIG,
     SZ_PORT_NAME,
@@ -115,7 +115,7 @@ class Engine:
             self._exclude,
         )
         self._sqlite_index = kwargs.pop(SZ_SQLITE_INDEX, False)  # default True?
-        self._log_all_mqtt = True  # kwargs.pop(SZ_LOG_ALL_MQTT, False)
+        self._log_all_mqtt = kwargs.pop(SZ_LOG_ALL_MQTT, False)
         self._kwargs: dict[str, Any] = kwargs  # HACK
 
         self._engine_lock = Lock()  # FIXME: threading lock, or asyncio lock?

--- a/src/ramses_tx/gateway.py
+++ b/src/ramses_tx/gateway.py
@@ -27,6 +27,7 @@ from .const import (
     SZ_ACTIVE_HGI,
     Priority,
 )
+from .logger import BlockMqttFilter
 from .message import Message
 from .packet import Packet
 from .protocol import protocol_factory
@@ -34,6 +35,7 @@ from .schemas import (
     SZ_DISABLE_QOS,
     SZ_DISABLE_SENDING,
     SZ_ENFORCE_KNOWN_LIST,
+    SZ_LOG_ALL_MQTT,
     SZ_PACKET_LOG,
     SZ_PORT_CONFIG,
     SZ_PORT_NAME,
@@ -114,6 +116,8 @@ class Engine:
             self._exclude,
         )
         self._sqlite_index = kwargs.pop(SZ_SQLITE_INDEX, False)  # default True?
+        if not kwargs.pop(SZ_LOG_ALL_MQTT, False):
+            _LOGGER.addFilter(BlockMqttFilter())
         self._kwargs: dict[str, Any] = kwargs  # HACK
 
         self._engine_lock = Lock()  # FIXME: threading lock, or asyncio lock?

--- a/src/ramses_tx/gateway.py
+++ b/src/ramses_tx/gateway.py
@@ -195,7 +195,7 @@ class Engine:
             pkt_source[SZ_PACKET_LOG] = self._input_file  # filename as string
 
         _log_all: int = 1 if self._log_all_mqtt else 0
-        _LOGGER.info(f"Log MQTT: {_log_all}")
+        _LOGGER.info("Log MQTT: %s", _log_all)
         # incl. await protocol.wait_for_connection_made(timeout=5)
         self._transport = await transport_factory(
             self._protocol,

--- a/src/ramses_tx/gateway.py
+++ b/src/ramses_tx/gateway.py
@@ -194,14 +194,12 @@ class Engine:
         else:  # if self._input_file:
             pkt_source[SZ_PACKET_LOG] = self._input_file  # filename as string
 
-        _log_all: int = 1 if self._log_all_mqtt else 0
-        _LOGGER.info("Log MQTT: %s", _log_all)
         # incl. await protocol.wait_for_connection_made(timeout=5)
         self._transport = await transport_factory(
             self._protocol,
             disable_sending=self._disable_sending,
             loop=self._loop,
-            log_all=_log_all,
+            log_all=self._log_all_mqtt,
             **pkt_source,
             **self._kwargs,  # HACK: odd/misc params, e.g. comms_params
         )

--- a/src/ramses_tx/logger.py
+++ b/src/ramses_tx/logger.py
@@ -162,6 +162,13 @@ class StdOutFilter(logging.Filter):  # record.levelno < logging.WARNING
         return record.levelno < logging.WARNING
 
 
+class BlockMqttFilter(logging.Filter):
+    """Block all mqtt traffic"""
+
+    def filter(self, record):
+        return not record.getMessage().startswith("mq Rx:")
+
+
 class TimedRotatingFileHandler(_TimedRotatingFileHandler):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)

--- a/src/ramses_tx/logger.py
+++ b/src/ramses_tx/logger.py
@@ -163,10 +163,11 @@ class StdOutFilter(logging.Filter):  # record.levelno < logging.WARNING
 
 
 class BlockMqttFilter(logging.Filter):
-    """Block all mqtt traffic"""
+    """Block mqtt traffic"""
 
-    def filter(self, record):
-        return not record.getMessage().startswith("mq Rx:")
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Return True if the record is to be processed."""
+        return not record.getMessage().startswith("mq Rx: ")
 
 
 class TimedRotatingFileHandler(_TimedRotatingFileHandler):

--- a/src/ramses_tx/schemas.py
+++ b/src/ramses_tx/schemas.py
@@ -428,6 +428,9 @@ SCH_ENGINE_DICT = {
     vol.Optional(
         SZ_SQLITE_INDEX, default=False
     ): bool,  # temporary 0.52.x dev config option
+    vol.Optional(
+        SZ_LOG_ALL_MQTT, default=False
+    ): bool,  # log all incoming MQTT traffic config option
     vol.Optional(SZ_USE_REGEX): dict,  # vol.All(ConvertNullToDict(), dict),
     vol.Optional(SZ_COMMS_PARAMS): SCH_COMMS_PARAMS,
 }

--- a/src/ramses_tx/schemas.py
+++ b/src/ramses_tx/schemas.py
@@ -413,6 +413,7 @@ SZ_EVOFW_FLAG: Final = "evofw_flag"
 SZ_SQLITE_INDEX: Final = (
     "sqlite_index"  # temporary 0.52.x SQLite dev config option in ramses_cc
 )
+SZ_LOG_ALL_MQTT: Final = "log_all_mqtt"
 SZ_USE_REGEX: Final = "use_regex"
 
 SCH_ENGINE_DICT = {

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -1067,7 +1067,7 @@ class MqttTransport(_FullTransport, _MqttTransportAbstractor):
         self._num_tokens: float = self._MAX_TOKENS * 2
 
         # set log MQTT flag
-        self._log_all = kwargs["log_all"]
+        self._log_all = kwargs.pop("log_all", False)
 
         # instantiate a paho mqtt client
         self.client = mqtt.Client(
@@ -1511,7 +1511,7 @@ async def transport_factory(
     disable_sending: bool | None = False,
     extra: dict[str, Any] | None = None,
     loop: asyncio.AbstractEventLoop | None = None,
-    log_all: int = 0,
+    log_all: bool = False,
     **kwargs: Any,  # HACK: odd/misc params
 ) -> RamsesTransportT:
     """Create and return a Ramses-specific async packet Transport."""
@@ -1572,7 +1572,7 @@ async def transport_factory(
 
     # MQTT
     if port_name[:4] == "mqtt":  # TODO: handle disable_sending
-        _LOGGER.info("transport_factory starting MQTT, log_all: %s", log_all)  # 1 here
+        _LOGGER.info("transport_factory starting MQTT, log_all: %s", log_all)
         transport = MqttTransport(
             port_name, protocol, extra=extra, loop=loop, log_all=log_all, **kwargs
         )

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -499,6 +499,7 @@ class _MqttTransportAbstractor:
         self._protocol = protocol
         self._loop = loop or asyncio.get_event_loop()
         self._log_all = log_all > 0
+        _LOGGER.info("_MqttTransportAbstractor _log_all: %s", self._log_all)
 
 
 # ### Base classes (common to all Transports) #########################################
@@ -1079,6 +1080,7 @@ class MqttTransport(_FullTransport, _MqttTransportAbstractor):
         self.client.username_pw_set(self._username, self._password)
         # connect to the mqtt server
         self._attempt_connection()
+        _LOGGER.info("Connected to MQTT log_all: %s", self._log_all)
 
     def _attempt_connection(self) -> None:
         """Attempt to connect to the MQTT broker."""
@@ -1571,6 +1573,7 @@ async def transport_factory(
 
     # MQTT
     if port_name[:4] == "mqtt":  # TODO: handle disable_sending
+        _LOGGER.info("transport_factory starting MQTT, log_all: %s", log_all)
         transport = MqttTransport(
             port_name, protocol, extra=extra, loop=loop, log_all=log_all, **kwargs
         )

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -489,7 +489,6 @@ class _MqttTransportAbstractor:
         self,
         broker_url: str,
         protocol: RamsesProtocolT,
-        log_all: int = 0,
         loop: asyncio.AbstractEventLoop | None = None,
     ) -> None:
         # per().__init__(extra=extra)  # done in _BaseTransport
@@ -498,11 +497,6 @@ class _MqttTransportAbstractor:
 
         self._protocol = protocol
         self._loop = loop or asyncio.get_event_loop()
-        _LOGGER.info(log_all)
-        self._log_all = log_all
-        _LOGGER.info(
-            "_MqttTransportAbstractor _log_all: %s from %s", self._log_all, log_all
-        )
 
 
 # ### Base classes (common to all Transports) #########################################
@@ -1072,6 +1066,9 @@ class MqttTransport(_FullTransport, _MqttTransportAbstractor):
         self._max_tokens: float = self._MAX_TOKENS * 2  # allow for the initial burst
         self._num_tokens: float = self._MAX_TOKENS * 2
 
+        # set log MQTT flag
+        self._log_all = kwargs["log_all"]
+
         # instantiate a paho mqtt client
         self.client = mqtt.Client(
             protocol=mqtt.MQTTv5, callback_api_version=CallbackAPIVersion.VERSION2
@@ -1083,9 +1080,6 @@ class MqttTransport(_FullTransport, _MqttTransportAbstractor):
         self.client.username_pw_set(self._username, self._password)
         # connect to the mqtt server
         self._attempt_connection()
-        _LOGGER.info(
-            "Connected to MQTT log_all: %s (%s)", self._log_all, kwargs["log_all"]
-        )
 
     def _attempt_connection(self) -> None:
         """Attempt to connect to the MQTT broker."""

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -1283,8 +1283,11 @@ class MqttTransport(_FullTransport, _MqttTransportAbstractor):
 
         if _DBG_FORCE_FRAME_LOGGING:
             _LOGGER.warning("Rx: %s", msg.payload)
-        elif _LOGGER.getEffectiveLevel() == logging.INFO:  # log for INFO not DEBUG
-            _LOGGER.info("Rx: %s", msg.payload)
+        elif (
+            _LOGGER.getEffectiveLevel() == logging.INFO and _LOGGER._log_all_mqtt
+        ):  # EBR set in ramses_cc
+            # log for INFO not DEBUG
+            _LOGGER.info("mq Rx: %s", msg.payload)
 
         if msg.topic[-3:] != "/rx":  # then, e.g. 'RAMSES/GATEWAY/18:017804'
             if msg.payload == b"offline":

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -498,9 +498,10 @@ class _MqttTransportAbstractor:
 
         self._protocol = protocol
         self._loop = loop or asyncio.get_event_loop()
-        self._log_all = log_all > 0
+        self.log_all = log_all
+        self._log_all = self.log_all > 0
         _LOGGER.info(
-            "_MqttTransportAbstractor _log_all: %s from %s", self._log_all, log_all
+            "_MqttTransportAbstractor _log_all: %s from %s", self._log_all, self.log_all
         )
 
 

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -490,7 +490,7 @@ class _MqttTransportAbstractor:
         broker_url: str,
         protocol: RamsesProtocolT,
         loop: asyncio.AbstractEventLoop | None = None,
-        log_all: int = 0,
+        log_all_mqtt: int = 0,
     ) -> None:
         # per().__init__(extra=extra)  # done in _BaseTransport
 
@@ -498,7 +498,7 @@ class _MqttTransportAbstractor:
 
         self._protocol = protocol
         self._loop = loop or asyncio.get_event_loop()
-        self.log_all = log_all
+        self.log_all = log_all_mqtt
         self._log_all = self.log_all > 0
         _LOGGER.info(
             "_MqttTransportAbstractor _log_all: %s from %s", self._log_all, self.log_all
@@ -1578,7 +1578,7 @@ async def transport_factory(
     if port_name[:4] == "mqtt":  # TODO: handle disable_sending
         _LOGGER.info("transport_factory starting MQTT, log_all: %s", log_all)
         transport = MqttTransport(
-            port_name, protocol, extra=extra, loop=loop, log_all=log_all, **kwargs
+            port_name, protocol, extra=extra, loop=loop, log_all_mqtt=log_all, **kwargs
         )
 
         # TODO: remove this? better to invoke timeout after factory returns?

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -1283,10 +1283,7 @@ class MqttTransport(_FullTransport, _MqttTransportAbstractor):
 
         if _DBG_FORCE_FRAME_LOGGING:
             _LOGGER.warning("Rx: %s", msg.payload)
-        elif (
-            _LOGGER.getEffectiveLevel() == logging.INFO and _LOGGER._log_all_mqtt
-        ):  # EBR set in ramses_cc
-            # log for INFO not DEBUG
+        elif _LOGGER.getEffectiveLevel() == logging.INFO:  # log for INFO not DEBUG
             _LOGGER.info("mq Rx: %s", msg.payload)
 
         if msg.topic[-3:] != "/rx":  # then, e.g. 'RAMSES/GATEWAY/18:017804'

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -498,10 +498,11 @@ class _MqttTransportAbstractor:
 
         self._protocol = protocol
         self._loop = loop or asyncio.get_event_loop()
-        self.log_all = log_all_mqtt
-        self._log_all = self.log_all > 0
+        _LOGGER.info(log_all_mqtt)
+        self.log_all_store: int = log_all_mqtt  # =0 here????
+        self._log_all = self.log_all_store > 0
         _LOGGER.info(
-            "_MqttTransportAbstractor _log_all: %s from %s", self._log_all, self.log_all
+            "_MqttTransportAbstractor _log_all: %s from %s", self._log_all, log_all_mqtt
         )
 
 
@@ -1576,7 +1577,7 @@ async def transport_factory(
 
     # MQTT
     if port_name[:4] == "mqtt":  # TODO: handle disable_sending
-        _LOGGER.info("transport_factory starting MQTT, log_all: %s", log_all)
+        _LOGGER.info("transport_factory starting MQTT, log_all: %s", log_all)  # 1 here
         transport = MqttTransport(
             port_name, protocol, extra=extra, loop=loop, log_all_mqtt=log_all, **kwargs
         )

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -489,8 +489,8 @@ class _MqttTransportAbstractor:
         self,
         broker_url: str,
         protocol: RamsesProtocolT,
+        log_all_mqtt: int,
         loop: asyncio.AbstractEventLoop | None = None,
-        log_all_mqtt: int = 0,
     ) -> None:
         # per().__init__(extra=extra)  # done in _BaseTransport
 
@@ -1084,9 +1084,7 @@ class MqttTransport(_FullTransport, _MqttTransportAbstractor):
         self.client.username_pw_set(self._username, self._password)
         # connect to the mqtt server
         self._attempt_connection()
-        _LOGGER.info(
-            "Connected to MQTT log_all: %s (%s)", self._log_all, kwargs.items()
-        )
+        _LOGGER.info("Connected to MQTT log_all: %s (%s)", self._log_all, kwargs)
 
     def _attempt_connection(self) -> None:
         """Attempt to connect to the MQTT broker."""

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -490,7 +490,7 @@ class _MqttTransportAbstractor:
         broker_url: str,
         protocol: RamsesProtocolT,
         loop: asyncio.AbstractEventLoop | None = None,
-        log_all: int = 1,  # 0,
+        log_all: int = 0,
     ) -> None:
         # per().__init__(extra=extra)  # done in _BaseTransport
 

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -1084,7 +1084,9 @@ class MqttTransport(_FullTransport, _MqttTransportAbstractor):
         self.client.username_pw_set(self._username, self._password)
         # connect to the mqtt server
         self._attempt_connection()
-        _LOGGER.info("Connected to MQTT log_all: %s", self._log_all)
+        _LOGGER.info(
+            "Connected to MQTT log_all: %s (%s)", self._log_all, kwargs.items()
+        )
 
     def _attempt_connection(self) -> None:
         """Attempt to connect to the MQTT broker."""

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -499,7 +499,9 @@ class _MqttTransportAbstractor:
         self._protocol = protocol
         self._loop = loop or asyncio.get_event_loop()
         self._log_all = log_all > 0
-        _LOGGER.info("_MqttTransportAbstractor _log_all: %s", self._log_all)
+        _LOGGER.info(
+            "_MqttTransportAbstractor _log_all: %s from %s", self._log_all, log_all
+        )
 
 
 # ### Base classes (common to all Transports) #########################################
@@ -1037,7 +1039,7 @@ class MqttTransport(_FullTransport, _MqttTransportAbstractor):
     _TOKEN_RATE: Final[float] = _MAX_TOKENS / _TIME_WINDOW
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        # _LOGGER.error("__init__(%s, %s)", args, kwargs)
+        _LOGGER.error("__init__(%s, %s)", args, kwargs)
 
         super().__init__(*args, **kwargs)
 

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -490,7 +490,7 @@ class _MqttTransportAbstractor:
         broker_url: str,
         protocol: RamsesProtocolT,
         loop: asyncio.AbstractEventLoop | None = None,
-        log_all: int = 0,
+        log_all: int = 1,  # 0,
     ) -> None:
         # per().__init__(extra=extra)  # done in _BaseTransport
 

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -489,7 +489,7 @@ class _MqttTransportAbstractor:
         self,
         broker_url: str,
         protocol: RamsesProtocolT,
-        log_all_mqtt: int,
+        log_all: int = 0,
         loop: asyncio.AbstractEventLoop | None = None,
     ) -> None:
         # per().__init__(extra=extra)  # done in _BaseTransport
@@ -498,11 +498,10 @@ class _MqttTransportAbstractor:
 
         self._protocol = protocol
         self._loop = loop or asyncio.get_event_loop()
-        _LOGGER.info(log_all_mqtt)
-        self.log_all_store: int = log_all_mqtt  # =0 here????
-        self._log_all = self.log_all_store > 0
+        _LOGGER.info(log_all)
+        self._log_all = log_all
         _LOGGER.info(
-            "_MqttTransportAbstractor _log_all: %s from %s", self._log_all, log_all_mqtt
+            "_MqttTransportAbstractor _log_all: %s from %s", self._log_all, log_all
         )
 
 
@@ -1041,7 +1040,7 @@ class MqttTransport(_FullTransport, _MqttTransportAbstractor):
     _TOKEN_RATE: Final[float] = _MAX_TOKENS / _TIME_WINDOW
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        _LOGGER.error("__init__(%s, %s)", args, kwargs)
+        # _LOGGER.error("__init__(%s, %s)", args, kwargs)
 
         super().__init__(*args, **kwargs)
 
@@ -1084,7 +1083,9 @@ class MqttTransport(_FullTransport, _MqttTransportAbstractor):
         self.client.username_pw_set(self._username, self._password)
         # connect to the mqtt server
         self._attempt_connection()
-        _LOGGER.info("Connected to MQTT log_all: %s (%s)", self._log_all, kwargs)
+        _LOGGER.info(
+            "Connected to MQTT log_all: %s (%s)", self._log_all, kwargs["log_all"]
+        )
 
     def _attempt_connection(self) -> None:
         """Attempt to connect to the MQTT broker."""
@@ -1579,7 +1580,7 @@ async def transport_factory(
     if port_name[:4] == "mqtt":  # TODO: handle disable_sending
         _LOGGER.info("transport_factory starting MQTT, log_all: %s", log_all)  # 1 here
         transport = MqttTransport(
-            port_name, protocol, extra=extra, loop=loop, log_all_mqtt=log_all, **kwargs
+            port_name, protocol, extra=extra, loop=loop, log_all=log_all, **kwargs
         )
 
         # TODO: remove this? better to invoke timeout after factory returns?


### PR DESCRIPTION
Adds a param for MQTT Transport to show/hide all MQTT traffic picked up logged to the system console.
Option is set in `ramses_cc`, default is off to prevent HA warning #324 

Squash merge