### PR TITLE
Fix/mqtt startup stability

### DIFF
--- a/src/ramses_tx/protocol.py
+++ b/src/ramses_tx/protocol.py
@@ -66,7 +66,7 @@ class _BaseProtocol(asyncio.Protocol):
         self._msg_handler = msg_handler
         self._msg_handlers: list[MsgHandlerT] = []
 
-        self._transport: RamsesTransportT = None  # type: ignore[assignment]
+        self._transport: RamsesTransportT | None = None
         self._loop = asyncio.get_running_loop()
 
         self._pause_writing = False  # FIXME: Start in R/O mode as no connection yet?
@@ -258,6 +258,10 @@ class _BaseProtocol(asyncio.Protocol):
         self, frame: str, num_repeats: int = 0, gap_duration: float = 0.0
     ) -> None:  # _send_frame() -> transport
         """Write to the transport."""
+
+        if self._transport is None:
+            raise exc.ProtocolSendFailed("Transport is not connected")
+
         await self._transport.write_frame(frame)
         for _ in range(num_repeats - 1):
             await asyncio.sleep(gap_duration)

--- a/src/ramses_tx/protocol.py
+++ b/src/ramses_tx/protocol.py
@@ -140,7 +140,14 @@ class _BaseProtocol(asyncio.Protocol):
         received or the connection was aborted or closed).
         """
 
-        assert self._wait_connection_lost  # mypy
+        # FIX: Check if _wait_connection_lost exists before asserting
+        # This handles cases where connection was never fully established
+        if not self._wait_connection_lost:
+            _LOGGER.debug(
+                "connection_lost called but no connection was established (ignoring)"
+            )
+            self._wait_connection_made = self._loop.create_future()
+            return
 
         if self._wait_connection_lost.done():  # BUG: why is callback invoked twice?
             return
@@ -555,8 +562,17 @@ class PortProtocol(_DeviceIdFilterMixin, _BaseProtocol):
         super().connection_made(transport)
         # TODO: needed? self.resume_writing()
 
-        self._set_active_hgi(self._transport.get_extra_info(SZ_ACTIVE_HGI))
-        self._is_evofw3 = self._transport.get_extra_info(SZ_IS_EVOFW3)
+        # ROBUSTNESS FIX: Ensure self._transport is set even if the wait future was cancelled
+        if self._transport is None:
+            _LOGGER.warning(
+                f"{self}: Transport bound after wait cancelled (late connection)"
+            )
+            self._transport = transport
+
+        # Safe access with check (optional but recommended)
+        if self._transport:
+            self._set_active_hgi(self._transport.get_extra_info(SZ_ACTIVE_HGI))
+            self._is_evofw3 = self._transport.get_extra_info(SZ_IS_EVOFW3)
 
         if not self._context:
             return

--- a/src/ramses_tx/protocol.py
+++ b/src/ramses_tx/protocol.py
@@ -141,12 +141,14 @@ class _BaseProtocol(asyncio.Protocol):
         """
 
         # FIX: Check if _wait_connection_lost exists before asserting
-        # This handles cases where connection was never fully established
+        # This handles cases where connection was never fully established (e.g. timeout)
         if not self._wait_connection_lost:
             _LOGGER.debug(
                 "connection_lost called but no connection was established (ignoring)"
             )
-            self._wait_connection_made = self._loop.create_future()
+            # Reset the connection made future for next attempt
+            if self._wait_connection_made.done():
+                self._wait_connection_made = self._loop.create_future()
             return
 
         if self._wait_connection_lost.done():  # BUG: why is callback invoked twice?

--- a/tests/tests_rf/test_protocol_fsm.py
+++ b/tests/tests_rf/test_protocol_fsm.py
@@ -174,6 +174,9 @@ async def async_pkt_received(  # type: ignore[no-any-unimported]
 
 
 async def _test_flow_30x(protocol: PortProtocol) -> None:
+    assert (
+        protocol._transport is not None
+    )  # mypy: fixture ensures transport is connected
     # STEP 0: Setup...
     rf: VirtualRf = protocol._transport._extra["virtual_rf"]
     ser = serial.Serial(rf.ports[1])


### PR DESCRIPTION
## Description
Improves the stability of the MQTT transport layer.

1. **Fix Zombie Connections:** If `wait_for_connection_made` times out (default increased to 60s), the transport is now explicitly closed. This prevents the transport from connecting successfully *after* the timeout and triggering callbacks on a cancelled future, which previously caused `AttributeError: 'NoneType'` crashes in `PortProtocol`.
2. **Robustness:** `PortProtocol.connection_made` now safely checks if `transport` is set before accessing it, handling edge cases where initialization was interrupted.
3. **Read-Only Support:** The `disable_sending` flag is now correctly passed to `MqttTransport`, ensuring read-only configuration is respected.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)