### PR TITLE
fix(deps): pin voluptuous < 0.16.0 to resolve CI test failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@
     "colorlog>=6.9.0",              # latest
     "paho-mqtt>=2.1.0",             # latest
     "pyserial-asyncio-fast>=0.16",  # latest
-    "voluptuous>=0.15.2",           # latest
+    "voluptuous>=0.15.2,<0.16.0",   # pinned to fix CI failures
   ]
 
 #

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -17,7 +17,7 @@
   mypy >= 1.18.0                                 # HA uses  1.19.0a4 !
   types-colorama >= 0.4.15
   types-PyYAML >= 6.0.12                         # HA uses 6.0.12.20250516
-  voluptuous >= 0.15.2                           # HA uses 0.15.2
+  voluptuous >= 0.15.2, < 0.16.0                 # HA uses 0.15.2
 
 # used for testing
   pytest >= 8.4.2                                # HA uses 8.4.2


### PR DESCRIPTION
## Description
Pins the `voluptuous` dependency to `< 0.16.0` in `requirements/requirements_dev.txt`.

## Problem
The recent release of `voluptuous` 0.16.0 introduced breaking changes regarding how extra keys are handled in schema validation. This caused `tests/tests/test_vol_schemas.py::test_known_list_bad` to fail because invalid configurations were no longer being rejected by the validator.

## Solution
Restricting the version to `< 0.16.0` ensures the test suite runs against a compatible version of the library, resolving the build failures on CI.