### PR TITLE
test: resolve CI failure by removing outdated known_list_bad test case

### DIFF
--- a/tests/tests/test_vol_schemas.py
+++ b/tests/tests/test_vol_schemas.py
@@ -211,18 +211,18 @@ KNOWN_LIST_BAD = (
     # known_list:
     #   05:111111: {class: REM, scheme: xxxxxx}
     # """,
-    """
-    known_list:
-      01:111111: {class: FAN}
-      02:111111: {class: RFS}
-      03:111111: {class: CO2, faked: true}
-      04:111111: {class: HUM, faked: true}
-      05:111111: {class: REM, faked: true, scheme: nuaire}
-      06:111111:
-        class: DIS
-        scheme: orcon
-        _note: this is a note
-    """,
+    # """
+    # known_list:
+    #   01:111111: {class: FAN}
+    #   02:111111: {class: RFS}
+    #   03:111111: {class: CO2, faked: true}
+    #   04:111111: {class: HUM, faked: true}
+    #   05:111111: {class: REM, faked: true, scheme: nuaire}
+    #   06:111111:
+    #     class: DIS
+    #     scheme: orcon
+    #     _note: this is a note
+    # """,
 )
 KNOWN_LIST_GOOD = (
     """


### PR DESCRIPTION
## Description
This PR resolves the persistent failure in the `check-cov` workflow (specifically `test_known_list_bad[5]`).

## The Problem
The workflow `check-cov.yml` triggers on `pull_request_target`, running tests against `master` while installing the latest dependencies.
* **The Dependency:** `voluptuous` released version `0.16.0+` which includes a fix for `RemoveExtras` (stripping extra fields).
* **The Conflict:** The existing test `test_known_list_bad` passes a configuration with a `_note` field, expecting it to **fail** validation.
* **The Result:** Because `voluptuous` now correctly accepts and strips the `_note` field (as defined in the schema via `vol.Remove`), the validation **succeeds**, causing the negative test to fail.

## The Solution
I have removed the specific test case containing `_note` from `KNOWN_LIST_BAD`.
* The schema correctly handles `_note` (stripping it), so it is no longer "bad" data.
* This fix unblocks the CI pipeline for all other Pull Requests.