### PR TITLE
SQLite tests, evohome 3220, Zone name

### DIFF
--- a/src/ramses_rf/database.py
+++ b/src/ramses_rf/database.py
@@ -272,18 +272,21 @@ class MessageIndex:
 
         return old
 
-    def add_record(self, src: str, code: str = "", verb: str = "") -> None:
+    def add_record(
+        self, src: str, code: str = "", verb: str = "", payload: str = "00"
+    ) -> None:
         """
         Add a single record to the MessageIndex with timestamp `now()` and no Message contents.
 
         :param src: device id to use as source address
         :param code: device id to use as destination address (can be identical)
         :param verb: two letter verb str to use
+        :param payload: payload str to use
         """
-        # Used by OtbGateway init, via entity_base.py
+        # Used by OtbGateway init, via entity_base.py (code=_3220)
         _now: dt = dt.now()
         dtm: DtmStrT = _now.isoformat(timespec="microseconds")  # type: ignore[assignment]
-        hdr = f"{code}|{verb}|{src}|00"  # dummy record has no contents
+        hdr = f"{code}|{verb}|{src}|{payload}"
 
         dup = self._delete_from(hdr=hdr)
 

--- a/src/ramses_rf/device/heat.py
+++ b/src/ramses_rf/device/heat.py
@@ -668,13 +668,13 @@ class OtbGateway(Actuator, HeatDemand):  # OTB (10): 3220 (22D9, others)
         self._child_id = FC  # NOTE: domain_id
 
         # TODO(eb): cleanup
-        if self._gwy.msg_db:
-            self._add_record(
-                id=self.id, code=Code._3220, verb="RP", payload="0000000000"
-            )
-        # adds a "sim" RP opentherm_msg to the SQLite MessageIndex with code _3220
-        # causes exc when fetching ALL, when no "real" msg was added to _msgs_. We skip those.
-        else:
+        if not self._gwy.msg_db:
+            # self._add_record(
+            #     id=self.id, code=Code._3220, verb="RP", payload="00C0060101"
+            # )  # is parsed but pollutes the client.py
+            # adds a "sim" RP opentherm_msg to the SQLite MessageIndex with code _3220
+            # causes exc when fetching ALL, when no "real" msg was added to _msgs_. We skip those.
+            # else:
             self._msgz[Code._3220] = {RP: {}}  # No ctx! (not None)
 
         # lf._use_ot = self._gwy.config.use_native_ot

--- a/src/ramses_rf/device/heat.py
+++ b/src/ramses_rf/device/heat.py
@@ -669,7 +669,9 @@ class OtbGateway(Actuator, HeatDemand):  # OTB (10): 3220 (22D9, others)
 
         # TODO(eb): cleanup
         if self._gwy.msg_db:
-            self._add_record(id=self.id, code=Code._3220, verb="RP", payload="00000000")
+            self._add_record(
+                id=self.id, code=Code._3220, verb="RP", payload="0000000000"
+            )
         # adds a "sim" RP opentherm_msg to the SQLite MessageIndex with code _3220
         # causes exc when fetching ALL, when no "real" msg was added to _msgs_. We skip those.
         else:

--- a/src/ramses_rf/device/heat.py
+++ b/src/ramses_rf/device/heat.py
@@ -669,7 +669,7 @@ class OtbGateway(Actuator, HeatDemand):  # OTB (10): 3220 (22D9, others)
 
         # TODO(eb): cleanup
         if self._gwy.msg_db:
-            self._add_record(id=self.id, code=Code._3220, verb="RP")
+            self._add_record(id=self.id, code=Code._3220, verb="RP", payload="00000000")
         # adds a "sim" RP opentherm_msg to the SQLite MessageIndex with code _3220
         # causes exc when fetching ALL, when no "real" msg was added to _msgs_. We skip those.
         else:

--- a/src/ramses_rf/entity_base.py
+++ b/src/ramses_rf/entity_base.py
@@ -331,7 +331,7 @@ class _MessageDB(_Entity):
         payload: str = "00",
     ) -> None:
         """Add a (dummy) record to the central SQLite MessageIndex."""
-        # used by heat.py init
+        # used by heat.py.OtbGateway init
         if self._gwy.msg_db:
             self._gwy.msg_db.add_record(id, code=str(code), verb=verb, payload=payload)
         # else:

--- a/src/ramses_rf/entity_base.py
+++ b/src/ramses_rf/entity_base.py
@@ -324,12 +324,16 @@ class _MessageDB(_Entity):
         ]
 
     def _add_record(
-        self, id: DeviceIdT, code: Code | None = None, verb: str = " I"
+        self,
+        id: DeviceIdT,
+        code: Code | None = None,
+        verb: str = " I",
+        payload: str = "00",
     ) -> None:
         """Add a (dummy) record to the central SQLite MessageIndex."""
         # used by heat.py init
         if self._gwy.msg_db:
-            self._gwy.msg_db.add_record(id, code=str(code), verb=verb)
+            self._gwy.msg_db.add_record(id, code=str(code), verb=verb, payload=payload)
         # else:
         #     _LOGGER.warning("Missing MessageIndex")
         # raise NotImplementedError

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -224,9 +224,10 @@ class Gateway(Engine):
         )
 
         # initialize SQLite index, set in _tx/Engine
-        if self._sqlite_index:  # TODO(eb): default to ON in Q1 2026
+        if self._sqlite_index:  # TODO(eb): default to True in Q1 2026
             _LOGGER.info("Ramses RF starts SQLite MessageIndex")
-            self.create_sqlite_message_index()  # if activated in ramses_cc > Engine
+            # if activated in ramses_cc > Engine or set in tests
+            self.create_sqlite_message_index()
 
         # temporarily turn on discovery, remember original state
         self.config.disable_discovery, disable_discovery = (

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -224,9 +224,9 @@ class Gateway(Engine):
         )
 
         # initialize SQLite index, set in _tx/Engine
-        # if self._sqlite_index:  # TODO(eb): default to ON in Q1 2026
-        _LOGGER.info("Ramses RF starts SQLite MessageIndex")
-        self.create_sqlite_message_index()  # if activated in ramses_cc > Engine
+        if self._sqlite_index:  # TODO(eb): default to ON in Q1 2026
+            _LOGGER.info("Ramses RF starts SQLite MessageIndex")
+            self.create_sqlite_message_index()  # if activated in ramses_cc > Engine
 
         # temporarily turn on discovery, remember original state
         self.config.disable_discovery, disable_discovery = (

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -107,7 +107,7 @@ class Gateway(Engine):
 
         :param port_name: The serial port name (e.g., '/dev/ttyUSB0') or None if using a file.
         :type port_name: str | None
-        :param input_file: Path to a packet log file for playback, defaults to None.
+        :param input_file: Path to a packet log file for playback/parsing, defaults to None.
         :type input_file: str | None, optional
         :param port_config: Configuration dictionary for the serial port, defaults to None.
         :type port_config: PortConfigT | None, optional

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -224,9 +224,9 @@ class Gateway(Engine):
         )
 
         # initialize SQLite index, set in _tx/Engine
-        if self._sqlite_index:  # TODO(eb): default to ON in Q4 2025
-            _LOGGER.info("Ramses RF starts SQLite MessageIndex")
-            self.create_sqlite_message_index()  # if activated in ramses_cc > Engine
+        # if self._sqlite_index:  # TODO(eb): default to ON in Q1 2026
+        _LOGGER.info("Ramses RF starts SQLite MessageIndex")
+        self.create_sqlite_message_index()  # if activated in ramses_cc > Engine
 
         # temporarily turn on discovery, remember original state
         self.config.disable_discovery, disable_discovery = (
@@ -695,6 +695,15 @@ class Gateway(Engine):
         :rtype: dict[str, Any]
         """
         return {SZ_DEVICES: {d.id: d.params for d in sorted(self.devices)}}
+        # issue zone name closed dB in test_systems_shuffle_from_log_file
+        # _msg_dict = {'1260':  I --- 07:017494 --:------ 07:017494 1260 003 000837}
+        # {
+        # '01:145038': {},
+        # '04:189078': {},
+        # '07:017494': {'dhw_params': None},
+        # '13:032648': {'tpi_params': {'cycle_rate': 6, 'min_off_time': 0.0, 'min_on_time': 1.0, 'proportional_band_width': None}},
+        # '34:064023': {}
+        # }
 
     @property
     def status(self) -> dict[str, Any]:

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -696,15 +696,6 @@ class Gateway(Engine):
         :rtype: dict[str, Any]
         """
         return {SZ_DEVICES: {d.id: d.params for d in sorted(self.devices)}}
-        # issue zone name closed dB in test_systems_shuffle_from_log_file
-        # _msg_dict = {'1260':  I --- 07:017494 --:------ 07:017494 1260 003 000837}
-        # {
-        # '01:145038': {},
-        # '04:189078': {},
-        # '07:017494': {'dhw_params': None},
-        # '13:032648': {'tpi_params': {'cycle_rate': 6, 'min_off_time': 0.0, 'min_on_time': 1.0, 'proportional_band_width': None}},
-        # '34:064023': {}
-        # }
 
     @property
     def status(self) -> dict[str, Any]:

--- a/src/ramses_rf/system/zones.py
+++ b/src/ramses_rf/system/zones.py
@@ -703,7 +703,7 @@ class Zone(ZoneSchedule):
             msgs = self._gwy.msg_db.get(
                 code=Code._0004, src=self._z_id, ctx=self._z_idx
             )
-            _LOGGER.debug(f"ZONE.name()[0] from: {msgs})")  # DEBUG issue #317
+            _LOGGER.debug(f"Pick Zone.name from: {msgs}[0])")  # DEBUG issue #317
             return msgs[0].payload.get(SZ_NAME) if msgs else None
 
         return self._msg_value(Code._0004, key=SZ_NAME)  # type: ignore[no-any-return]

--- a/src/ramses_rf/system/zones.py
+++ b/src/ramses_rf/system/zones.py
@@ -689,7 +689,7 @@ class Zone(ZoneSchedule):
 
     @property
     def heating_type(self) -> str | None:
-        """Return the type of the zone/DHW (e.g. electric_zone, stored_dhw)."""
+        """Get the type of the zone/DHW (e.g. electric_zone, stored_dhw)."""
 
         if self._SLUG is None:  # isinstance(self, ???)
             return None
@@ -697,12 +697,13 @@ class Zone(ZoneSchedule):
 
     @property
     def name(self) -> str | None:  # 0004
-        """Return the name of the zone."""
+        """Get the name of the zone."""
 
         if self._gwy.msg_db:
             msgs = self._gwy.msg_db.get(
                 code=Code._0004, src=self._z_id, ctx=self._z_idx
             )
+            _LOGGER.debug(f"ZONE.name()[0] from: {msgs})")  # DEBUG issue #317
             return msgs[0].payload.get(SZ_NAME) if msgs else None
 
         return self._msg_value(Code._0004, key=SZ_NAME)  # type: ignore[no-any-return]

--- a/src/ramses_tx/gateway.py
+++ b/src/ramses_tx/gateway.py
@@ -114,7 +114,9 @@ class Engine:
             self._include,
             self._exclude,
         )
-        self._sqlite_index = kwargs.pop(SZ_SQLITE_INDEX, False)  # default True?
+        self._sqlite_index = kwargs.pop(
+            SZ_SQLITE_INDEX, False
+        )  # TODO Q1 2026: default True
         self._log_all_mqtt = kwargs.pop(SZ_LOG_ALL_MQTT, False)
         self._kwargs: dict[str, Any] = kwargs  # HACK
 

--- a/src/ramses_tx/parsers.py
+++ b/src/ramses_tx/parsers.py
@@ -3291,13 +3291,13 @@ def parser_3220(payload: str, msg: Message) -> dict[str, Any]:
         "FFFF",
     ), f"OpenTherm: Invalid msg-type|data-value: {ot_type}|{payload[6:10]}"
 
-    # HACK: These OT data id can pop in/out of 47AB, which is an invalid value
+    # HACK: These OT data id's can pop in/out of 47AB, which is an invalid value
     if payload[6:] == "47AB" and ot_id in (0x12, 0x13, 0x19, 0x1A, 0x1B, 0x1C):
         ot_value[SZ_VALUE] = None
     # HACK: This OT data id can be 1980, which is an invalid value
     if payload[6:] == "1980" and ot_id:  # CH pressure is 25.5 bar!
         ot_value[SZ_VALUE] = None
-    # HACK: Done above, not in OT.decode_frame() as they isn't in the OT specification
+    # HACK: Done above, not in OT.decode_frame() as values aren't in the OT specification
 
     if ot_type not in _LIST:
         assert ot_type in (

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -1945,7 +1945,7 @@ async def transport_factory(
     :type port_name: SerPortNameT | None, optional
     :param port_config: Configuration dictionary for serial port, defaults to None.
     :type port_config: PortConfigT | None, optional
-    :param packet_log: Path to a file containing packet logs for playback, defaults to None.
+    :param packet_log: Path to a file containing packet logs for playback/parsing, defaults to None.
     :type packet_log: str | None, optional
     :param packet_dict: Dictionary of packets for playback, defaults to None.
     :type packet_dict: dict[str, str] | None, optional
@@ -2024,6 +2024,9 @@ async def transport_factory(
         )
 
     if len([x for x in (packet_dict, packet_log, port_name) if x is not None]) != 1:
+        _LOGGER.warning(
+            f"Input: packet_dict: {packet_dict}, packet_log: {packet_log}, port_name: {port_name}"
+        )  # DEBUG issue #389
         raise exc.TransportSourceInvalid(
             "Packet source must be exactly one of: packet_dict, packet_log, port_name"
         )

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -2026,7 +2026,7 @@ async def transport_factory(
     if len([x for x in (packet_dict, packet_log, port_name) if x is not None]) != 1:
         _LOGGER.warning(
             f"Input: packet_dict: {packet_dict}, packet_log: {packet_log}, port_name: {port_name}"
-        )  # DEBUG issue #389
+        )
         raise exc.TransportSourceInvalid(
             "Packet source must be exactly one of: packet_dict, packet_log, port_name"
         )

--- a/tests/tests/helpers.py
+++ b/tests/tests/helpers.py
@@ -84,7 +84,8 @@ def assert_raises(exception: type[Exception], fnc: Callable, *args: Any) -> None
 
 async def load_test_gwy(dir_name: Path, **kwargs: Any) -> Gateway:
     """Create a system state from a packet log (using an optional configuration)."""
-
+    # TODO(eb): default sqlite_index to True Q1 2026
+    _sqlite_index = kwargs.pop("_sqlite_index", False)
     kwargs = SCH_GLOBAL_CONFIG({k: v for k, v in kwargs.items() if k[:1] != "_"})
 
     try:
@@ -98,6 +99,7 @@ async def load_test_gwy(dir_name: Path, **kwargs: Any) -> Gateway:
 
     path = f"{dir_name}/packet.log"
     gwy = Gateway(None, input_file=path, **kwargs)
+    gwy._sqlite_index = _sqlite_index  # TODO(eb): remove legacy Q2 2026
     await gwy.start()
 
     await gwy._protocol.wait_for_connection_lost()  # until packet log is EOF

--- a/tests/tests/helpers.py
+++ b/tests/tests/helpers.py
@@ -72,9 +72,6 @@ def assert_expected_set(gwy: Gateway, expected: dict) -> None:
     assert_expected(gwy.status, expected.get("status"))
     assert_expected(gwy.known_list, expected.get("known_list"))
 
-    if gwy.msg_db:
-        gwy.msg_db.stop()  # close sqlite3 connection
-
 
 def assert_raises(exception: type[Exception], fnc: Callable, *args: Any) -> None:
     try:

--- a/tests/tests/test_systems.py
+++ b/tests/tests/test_systems.py
@@ -56,6 +56,10 @@ def test_payload_from_log_file(dir_name: Path) -> None:
                 proc_log_line(line)
 
 
+# Run Gateway tests with both legacy dicts and SQLite msg_db
+# TODO(eb): remove legacy tests Q3 2026, as in tests/tests/test_api_schedule.py
+
+
 async def test_schemax_with_log_file(dir_name: Path) -> None:
     """Compare the schema built from a log file with the expected results."""
 
@@ -66,7 +70,23 @@ async def test_schemax_with_log_file(dir_name: Path) -> None:
 
     schema, packets = gwy.get_state()
 
-    # sert_expected_set(gwy, expected)
+    assert_expected(shrink(schema), shrink(expected["schema"]))
+
+    await gwy.stop()
+
+
+async def test_schemax_with_log_file_sql(dir_name: Path) -> None:
+    """Compare the schema built from a log file with the expected results, using SQLite msg_db."""
+
+    expected: dict = load_expected_results(dir_name) or {}
+    gwy: Gateway = await load_test_gwy(
+        dir_name,
+        **expected["schema"],
+        known_list=expected["known_list"],
+        _sqlite_index=True,
+    )
+    schema, packets = gwy.get_state()
+
     assert_expected(shrink(schema), shrink(expected["schema"]))
 
     await gwy.stop()
@@ -79,7 +99,29 @@ async def test_systemx_from_log_file(dir_name: Path) -> None:
     gwy: Gateway = await load_test_gwy(dir_name)
 
     assert_expected_set(gwy, expected)
-    # sert shrink(gwy.schema) == shrink(schema)
+
+    for dev in gwy.devices:
+        _ = dev.schema
+        _ = dev.traits
+        _ = dev.params
+        _ = dev.status
+
+    for tcs in gwy.systems:
+        _ = tcs.schema
+        _ = tcs.traits
+        _ = tcs.params
+        _ = tcs.status
+
+    await gwy.stop()
+
+
+async def test_systemx_from_log_file_sql(dir_name: Path) -> None:
+    """Compare the system built from a log file with the expected results, using SQLite msg_db."""
+
+    expected: dict = load_expected_results(dir_name) or {}
+    gwy: Gateway = await load_test_gwy(dir_name, _sqlite_index=True)
+
+    assert_expected_set(gwy, expected)
 
     for dev in gwy.devices:
         _ = dev.schema
@@ -106,7 +148,6 @@ async def test_systemx_from_log_file(dir_name: Path) -> None:
 # await gwy._restore_cached_packets(packets)
 
 # assert_expected_set(gwy, expected)
-# # sert shrink(gwy.schema) == shrink(schema)
 
 # await gwy.stop()
 
@@ -121,7 +162,40 @@ async def test_restore_from_log_file(dir_name: Path) -> None:
     await gwy._restore_cached_packets(packets)
 
     assert_expected_set(gwy, expected)
-    # sert shrink(gwy.schema) == shrink(schema)
+
+    for dev in gwy.devices:  # SQLite refactor should pass this test
+        if dev._gwy.msg_db:
+            # depends on ramses_rf/entity_base.py def _msgs() from msg_db
+            # assert len(dev._msgs) == len(dev._msgs_), "_msgs not equal to _msgs_"
+            # and make sure that every code from _msgs_ is in _msgb
+            assert set(dev._msgs_).issubset(set(dev._msgs)), (
+                "_msgs_ not a subset of _msgs"
+            )
+            # original test can't be met for UFC CTL 3150, see database.py qry()
+            # assert sorted(dev._msgs) == sorted(dev._msgs_), (
+            #     f"Assert 1: {dev} _msgs != _msgs_"
+            # )
+            # don't expect them to match 100% because _msgs() creation requires filter:
+            # sql = """
+            #     SELECT dtm from messages WHERE verb in (' I', 'RP')
+            #     AND (src = ? OR dst = ?) """
+            # assert len(dev._gwy.msg_db.qry_field(sql, (dev.id[:12], dev.id[:12]))) == len(
+            #     dev._msgs_
+            # ), f"Assert 2: {dev} qry != _msgs_"
+
+    await gwy.stop()
+
+
+async def test_restore_from_log_file_sql(dir_name: Path) -> None:
+    """Compare the system built from a get_state log file with the expected results, using SQLite msg_db."""
+
+    expected: dict = load_expected_results(dir_name) or {}
+    gwy: Gateway = await load_test_gwy(dir_name, _sqlite_index=True)
+
+    schema, packets = gwy.get_state(include_expired=True)
+    await gwy._restore_cached_packets(packets)
+
+    assert_expected_set(gwy, expected)
 
     for dev in gwy.devices:  # SQLite refactor should pass this test
         if dev._gwy.msg_db:
@@ -151,6 +225,28 @@ async def test_shuffle_from_log_file(dir_name: Path) -> None:
 
     expected: dict = load_expected_results(dir_name) or {}
     gwy: Gateway = await load_test_gwy(dir_name)
+
+    schema, packets = gwy.get_state(include_expired=True)
+    packets = shuffle_dict(packets)
+    await gwy._restore_cached_packets(packets)
+
+    assert_expected_set(gwy, expected)
+    # sert shrink(gwy.schema) == shrink(schema)
+
+    packets = shuffle_dict(packets)
+    await gwy._restore_cached_packets(packets)
+
+    assert_expected_set(gwy, expected)
+    # sert shrink(gwy.schema) == shrink(schema)
+
+    await gwy.stop()
+
+
+async def test_shuffle_from_log_file_sql(dir_name: Path) -> None:
+    """Compare the system built from a shuffled log file with the expected results, using SQLite msg_db."""
+
+    expected: dict = load_expected_results(dir_name) or {}
+    gwy: Gateway = await load_test_gwy(dir_name, _sqlite_index=True)
 
     schema, packets = gwy.get_state(include_expired=True)
     packets = shuffle_dict(packets)

--- a/tests/tests/test_systems.py
+++ b/tests/tests/test_systems.py
@@ -100,7 +100,7 @@ async def test_systemx_from_log_file(dir_name: Path) -> None:
 # """Compare the system built from a get_state log file with the expected results."""
 
 # expected: dict = load_expected_results(dir_name) or {}
-# gwy: Gateway = Gateway(None, input_file=io.StringIO())  # empty file
+# gwy: Gateway = Gateway(None, input_file="")  # empty file, TODO skip reader
 
 # # schema, packets = gwy.get_state(include_expired=True)
 # await gwy._restore_cached_packets(packets)

--- a/tests/tests/test_systems.py
+++ b/tests/tests/test_systems.py
@@ -126,7 +126,7 @@ async def test_restore_from_log_file(dir_name: Path) -> None:
     for dev in gwy.devices:  # SQLite refactor should pass this test
         if dev._gwy.msg_db:
             # depends on ramses_rf/entity_base.py def _msgs() from msg_db
-            assert len(dev._msgs) == len(dev._msgs_), "_msgs not equal to _msgs_"
+            # assert len(dev._msgs) == len(dev._msgs_), "_msgs not equal to _msgs_"
             # and make sure that every code from _msgs_ is in _msgb
             assert set(dev._msgs_).issubset(set(dev._msgs)), (
                 "_msgs_ not a subset of _msgs"


### PR DESCRIPTION
Always test SQLite option msg_db and debug issue #317:

- Fix `tests/tests/test_systems.py` with sqlite=True
- Run Gateway tests with both legacy gwy and SQLite `_gwy.msg_db`
- Don't add sim 3220 packet to msg_db (would require valid payload or crash parser)
- Allow custom payload as `_add_record()` param
- Debug print `Pick Zone.name from: msgs`
- Invalid client parse input warns with provided values