### PR TITLE
Fix `RecursionError` in `AttrDict` by properly raising `AttributeError` to prevent infinite recursion in AttrDict.__getattr__ 

### DIFF
--- a/src/ramses_tx/const.py
+++ b/src/ramses_tx/const.py
@@ -276,7 +276,9 @@ class AttrDict(dict):  # type: ignore[type-arg]
             return self._forward[name[1:]]
         elif name.isupper() and name.lower() in self._reverse:  # map.DHW_SENSOR -> "0D"
             return self[name.lower()]
-        return self.__getattribute__(name)
+        raise AttributeError(
+            f"'{type(self).__name__}' object has no attribute '{name}'"
+        )
 
     def _hex(self, key: str) -> str:
         """Return the key/ID (2-byte hex string) of the two-way dict (e.g. '04').

--- a/tests/tests_tx/test_const.py
+++ b/tests/tests_tx/test_const.py
@@ -1,0 +1,50 @@
+"""Test suite for ramses_tx.const module, focusing on AttrDict stability."""
+
+import pytest
+
+from ramses_tx.const import AttrDict
+
+
+class TestAttrDict:
+    """Tests for the AttrDict utility class."""
+
+    def test_attr_dict_lookup_happy_path(self) -> None:
+        """Test that AttrDict resolves attributes from the lookup tables."""
+        # Setup: Pass data directly into the tables via __init__
+        # Structure: main_table={slug: {code: ...}}, attr_table={name: value}
+        mock_main = {"DHW": {"0D": "Hot Water"}}
+        mock_attr = {"custom_key": "custom_value"}
+
+        attr_dict = AttrDict(mock_main, mock_attr)
+
+        # Verify dot notation lookup works via __getattr__ logic
+        assert attr_dict.custom_key == "custom_value"
+        # Verify main_table lookup logic (based on your __getattr__ code: list(keys)[0])
+        assert attr_dict.DHW == "0D"
+
+    def test_getattr_recursion_fix(self) -> None:
+        """Test that accessing a missing attribute raises AttributeError, not RecursionError.
+
+        This verifies the fix for TX-CONST-01.
+        """
+        attr_dict = AttrDict({}, {})
+
+        # This should raise AttributeError immediately.
+        # If the bug exists, this would crash with RecursionError.
+        with pytest.raises(
+            AttributeError, match=r"'AttrDict' object has no attribute 'missing'"
+        ):
+            _ = attr_dict.missing
+
+    def test_getattr_raises_correct_exception_type(self) -> None:
+        """Ensure standard AttributeError is raised, satisfying protocol expectations."""
+        attr_dict = AttrDict({}, {})
+
+        try:
+            _ = attr_dict.non_existent_key
+        except AttributeError:
+            pass  # This is the expected behavior
+        except RecursionError:
+            pytest.fail(
+                "AttrDict raised RecursionError (Stack Overflow) instead of AttributeError"
+            )


### PR DESCRIPTION
### The Problem:
The `AttrDict` class in `src/ramses_tx/const.py` contains a logic bug in its `__getattr__` method. When an attribute is not found in the custom lookup tables (`_main_table`, `_attr_table`, etc.), the code attempts to return `self.__getattribute__(name)`. Since `__getattr__` is only called *after* `__getattribute__` has already failed, this triggers a recursive loop that continues until the Python interpreter crashes with a `RecursionError` (Stack Overflow).
### Consequences:
Any attempt to access a non-existent attribute on a packet or device object (which uses `AttrDict`) causes the entire application/Home Assistant integration to crash immediately. This creates a severe stability risk, especially when processing malformed packets or during development when inspecting objects.
### The Fix:
Modified `AttrDict.__getattr__` to explicitly raise a standard Python `AttributeError` when a lookup fails, breaking the recursion loop.
### Technical Implementation:
- File: `src/ramses_tx/const.py`
- Method: `AttrDict.__getattr__`
- Change: Removed the fallback return statement `return self.__getattribute__(name)` and replaced it with `raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")`.
### Testing Performed:
- **Manual Verification:** Verified locally by running the client against a packet log. Confirmed that the engine starts and processes packets without crashing (previously, invalid lookups during debug or logging could trigger the crash).
- **Unit Tests:** Ran the full project test suite (`pytest`), confirming that core packet parsing and command generation (which rely heavily on `AttrDict`) continue to function correctly.
### Risks of NOT Implementing:
The codebase remains fragile. A single typo in variable access or a malformed packet structure could take down the entire service, making the library unreliable for production use.
### Risks of Implementing:
Low. This change restores standard Python object behavior. The only theoretical risk is if some existing code *relied* on the infinite recursion behavior (which is impossible as it results in a crash) or if it relied on `__getattr__` successfully retrieving standard attributes that `__getattribute__` somehow missed (which is inconsistent with Python's data model).
### Mitigation Steps:
The change adheres to the standard implementation pattern for `__getattr__` in Python. Existing unit tests cover the happy paths for `AttrDict` lookups, ensuring valid attributes are still retrieved correctly.