### PR TITLE
Replace `pre-commit` hook with `prek`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       # Run `python-typing-update` hook manually from time to time
       # to update python typing syntax.
       # Will require manual work, before submitting changes!
-      # pre-commit run --hook-stage manual python-typing-update --all-files
+      # prek run --hook-stage manual python-typing-update --all-files
       - id: python-typing-update
         stages: [manual]
         args:
@@ -39,6 +39,10 @@ repos:
     hooks:
       - id: check-executables-have-shebangs
       # id: check-json  # don't enable this one
+      - id: no-commit-to-branch
+        args:
+          - --branch=master
+          - --branch=stable
       - id: check-toml
       - id: check-yaml
       - id: debug-statements

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,10 +39,10 @@ repos:
     hooks:
       - id: check-executables-have-shebangs
       # id: check-json  # don't enable this one
-      - id: no-commit-to-branch
-        args:
-          - --branch=master
-          - --branch=stable
+      # - id: no-commit-to-branch
+      #   args:
+      #     - --branch=master
+      #     - --branch=stable
       - id: check-toml
       - id: check-yaml
       - id: debug-statements

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -1,5 +1,5 @@
 # Requirements to dev/test the source code
-# - last checked/updated: 2026-01-11 (c.f. HA 2026.1.0)
+# - last checked/updated: 2026-01-21 (c.f. HA 2026.1.2)
 # - HA core reqs: https://github.com/home-assistant/core/blob/dev/requirements.txt
 
 # for using the ramses_rf library with CLI
@@ -10,7 +10,7 @@
 # - pip list | grep -E 'pre-commit|ruff|mypy|types-|voluptuous|pytest|hatch'
 
 # used for development (linting)
-  prek==0.2.28                                   # same as ramses_cc and HA core 2026.1.2
+  prek == 0.2.28                                   # same as ramses_cc and HA core 2026.1.2
   # pre-commit >= 4.3.0                          # replaced by prek 2026.1
   ruff >= 0.13.0                                 # HA uses 0.13.0 ! also in: pre-commit-config.yaml
 

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -10,8 +10,8 @@
 # - pip list | grep -E 'pre-commit|ruff|mypy|types-|voluptuous|pytest|hatch'
 
 # used for development (linting)
-  prek==0.2.28                                   # same as ramses_cc and HA core 2026.1.2
-  # pre-commit >= 4.3.0                          # replaced by prek 2026.1
+  # prek==0.2.28                                   # same as ramses_cc and HA core 2026.1.2
+  pre-commit >= 4.3.0                          # replaced by prek 2026.1
   ruff >= 0.13.0                                 # HA uses 0.13.0 ! also in: pre-commit-config.yaml
 
 # used for development (typing)

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -10,7 +10,8 @@
 # - pip list | grep -E 'pre-commit|ruff|mypy|types-|voluptuous|pytest|hatch'
 
 # used for development (linting)
-  pre-commit >= 4.2.0                            # HA (core) uses 4.2.0
+  prek==0.2.28                                   # same as ramses_cc and HA core 2026.1.2
+  # pre-commit >= 4.3.0                          # replaced by prek 2026.1
   ruff >= 0.13.0                                 # HA uses 0.13.0 ! also in: pre-commit-config.yaml
 
 # used for development (typing)

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -10,8 +10,8 @@
 # - pip list | grep -E 'pre-commit|ruff|mypy|types-|voluptuous|pytest|hatch'
 
 # used for development (linting)
-  # prek==0.2.28                                   # same as ramses_cc and HA core 2026.1.2
-  pre-commit >= 4.3.0                          # replaced by prek 2026.1
+  prek==0.2.28                                   # same as ramses_cc and HA core 2026.1.2
+  # pre-commit >= 4.3.0                          # replaced by prek 2026.1
   ruff >= 0.13.0                                 # HA uses 0.13.0 ! also in: pre-commit-config.yaml
 
 # used for development (typing)


### PR DESCRIPTION
Implements issue #407
Aligns with HA Core as of 2026.1
Add prek to reqs, pre-commit-config (drop-in)

Developers should run
```
pip install -r requirements/requirements_dev.txt 
prek install -f
```
to update their local IDE pre-commit-hook.