### PR TITLE
feat: Inject custom HGI Device ID via Gateway constructor

### DIFF
--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -102,6 +102,7 @@ class Gateway(Engine):
         known_list: DeviceListT | None = None,
         loop: asyncio.AbstractEventLoop | None = None,
         transport_constructor: Callable[..., Awaitable[RamsesTransportT]] | None = None,
+        hgi_id: str | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the Gateway instance.
@@ -122,6 +123,8 @@ class Gateway(Engine):
         :type loop: asyncio.AbstractEventLoop | None, optional
         :param transport_constructor: A factory for creating the transport layer, defaults to None.
         :type transport_constructor: Callable[..., Awaitable[RamsesTransportT]] | None, optional
+        :param hgi_id: The Device ID to use for the HGI (gateway), overriding defaults.
+        :type hgi_id: str | None, optional
         :param kwargs: Additional configuration parameters passed to the engine and schema.
         :type kwargs: Any
         """
@@ -139,6 +142,7 @@ class Gateway(Engine):
             block_list=block_list,
             known_list=known_list,
             loop=loop,
+            hgi_id=hgi_id,
             transport_constructor=transport_constructor,
             **SCH_ENGINE_CONFIG(config),
         )

--- a/src/ramses_tx/gateway.py
+++ b/src/ramses_tx/gateway.py
@@ -79,6 +79,7 @@ class Engine:
         packet_log: PktLogConfigT | None = None,
         block_list: DeviceListT | None = None,
         known_list: DeviceListT | None = None,
+        hgi_id: str | None = None,
         loop: asyncio.AbstractEventLoop | None = None,
         **kwargs: Any,
     ) -> None:
@@ -119,6 +120,10 @@ class Engine:
         self._log_all_mqtt = kwargs.pop(SZ_LOG_ALL_MQTT, False)
         self._kwargs: dict[str, Any] = kwargs  # HACK
 
+        self._hgi_id = hgi_id
+        if self._hgi_id:
+            self._kwargs[SZ_ACTIVE_HGI] = self._hgi_id
+
         self._engine_lock = asyncio.Lock()
         self._engine_state: (
             tuple[_MsgHandlerT | None, bool | None, *tuple[Any, ...]] | None
@@ -135,6 +140,9 @@ class Engine:
         self._set_msg_handler(self._msg_handler)  # sets self._protocol
 
     def __str__(self) -> str:
+        if self._hgi_id:
+            return f"{self._hgi_id} ({self.ser_name})"
+
         if not self._transport:
             return f"{HGI_DEV_ADDR.id} ({self.ser_name})"
 

--- a/tests/tests/test_hgi_id.py
+++ b/tests/tests/test_hgi_id.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Test the injection of a custom HGI Device ID into the Gateway."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ramses_rf import Gateway
+from ramses_tx.address import HGI_DEV_ADDR
+from ramses_tx.const import SZ_ACTIVE_HGI
+
+TEST_HGI_ID = "18:005960"
+
+
+@pytest.mark.asyncio
+async def test_hgi_id_injection() -> None:
+    """Check that the custom HGI ID is passed correctly to the Engine/Transport."""
+
+    # Mock the transport factory to avoid creating a real connection/transport
+    # We want to inspect the kwargs passed to it.
+    with patch("ramses_tx.gateway.transport_factory") as mock_transport_factory:
+        # Setup the mock transport to be returned by the factory
+        mock_transport = MagicMock()
+        mock_transport.get_extra_info.return_value = TEST_HGI_ID
+
+        # Configure the factory mock to return our transport mock (as an async result)
+        mock_transport_factory.return_value = mock_transport
+
+        # 1. Instantiate Gateway with the custom hgi_id
+        # We must provide a dummy port_name to satisfy Engine.__init__ validation
+        gwy = Gateway("/dev/ttyMOCK", input_file=None, hgi_id=TEST_HGI_ID)
+
+        # 2. Check that the Engine (Gateway base class) has stored the ID
+        assert gwy._hgi_id == TEST_HGI_ID
+
+        # 3. Check the string representation reflects the custom ID
+        # Note: Before start(), it uses the stored _hgi_id
+        assert str(gwy).startswith(TEST_HGI_ID)
+
+        # 4. Start the gateway to trigger the transport factory call
+        # We patch the protocol's wait method to bypass the handshake timeout
+        with patch.object(
+            gwy._protocol, "wait_for_connection_made", new_callable=AsyncMock
+        ):
+            await gwy.start()
+
+        # 5. Verify transport_factory was called with the correct kwarg
+        _, kwargs = mock_transport_factory.call_args
+
+        assert SZ_ACTIVE_HGI in kwargs
+        assert kwargs[SZ_ACTIVE_HGI] == TEST_HGI_ID
+
+        # Cleanup
+        await gwy.stop()
+
+
+@pytest.mark.asyncio
+async def test_hgi_id_default_behavior() -> None:
+    """Check that the Gateway defaults to the hardcoded ID when no custom ID is provided."""
+
+    with patch("ramses_tx.gateway.transport_factory") as mock_transport_factory:
+        # Setup the mock transport
+        mock_transport = MagicMock()
+        # Default behavior: if get_extra_info is called for HGI, it might return None or default
+        mock_transport.get_extra_info.return_value = HGI_DEV_ADDR.id
+
+        mock_transport_factory.return_value = mock_transport
+
+        # 1. Instantiate Gateway WITHOUT the custom hgi_id
+        gwy = Gateway("/dev/ttyMOCK", input_file=None)
+
+        # 2. Check that the Engine has NO stored custom ID
+        assert gwy._hgi_id is None
+
+        # 3. Check the string representation falls back to the default constant
+        assert str(gwy).startswith(HGI_DEV_ADDR.id)
+
+        # 4. Start the gateway
+        # We patch the protocol's wait method to bypass the handshake timeout
+        with patch.object(
+            gwy._protocol, "wait_for_connection_made", new_callable=AsyncMock
+        ):
+            await gwy.start()
+
+        # 5. Verify transport_factory was called WITHOUT the active_gwy override
+        _, kwargs = mock_transport_factory.call_args
+
+        # The key should NOT be present if we didn't inject it
+        assert SZ_ACTIVE_HGI not in kwargs
+
+        # Cleanup
+        await gwy.stop()


### PR DESCRIPTION
### The Problem:

Currently, when `ramses_rf` is used with a virtual transport (e.g., MQTT in Home Assistant), it defaults to using a hardcoded "Sentinel" device ID of `18:000730` for the gateway (HGI). However, the actual hardware transmitting signals often uses a specific, real Device ID (e.g., `18:005960`). This mismatch forces downstream integrations like `ramses_cc` to "patch" packets on the fly—swapping IDs during transmission and reception—to trick the library into accepting them.

### Consequences:

If this is not fixed, the reliance on packet patching leads to:
- **Echo Mismatches:** The state machine fails to correlate transmitted commands with their echoes because the IDs do not match expectations.
- **Race Conditions:** Timing issues arise as the patching logic fights with the protocol state machine.
- **Protocol Instability:** The integration becomes fragile, potentially causing command failures or incorrect state reporting in Home Assistant.

### The Fix:

I have refactored the `Gateway` and `Engine` classes to accept an optional `hgi_id` argument. If provided, this custom ID allows the library to natively recognize the gateway's real address without needing external packet manipulation. If omitted, the library defaults to the existing behavior to ensure backward compatibility.

### Technical Implementation:
- **`src/ramses_rf/gateway.py`**: Updated the `Gateway.__init__` method to accept `hgi_id: str | None`. This argument is passed down to the parent `Engine` class.
- **`src/ramses_tx/gateway.py`**:
  - Updated `Engine.__init__` to store the `hgi_id`.
  - If `hgi_id` is present, it is injected into the transport configuration via `_kwargs[SZ_ACTIVE_HGI]`, ensuring the transport layer (and `transport_factory`) receives the correct ID.
  - Updated `Engine.__str__` to display the custom `hgi_id` if set, otherwise falling back to the default `HGI_DEV_ADDR.id`.

### Testing Performed:
- **New Unit Tests (`tests/tests/test_hgi_id.py`):**
  - `test_hgi_id_injection`: Verifies that when a custom ID is passed to `Gateway()`, it is correctly stored, reflected in the string representation, and passed to the `transport_factory`.
  - `test_hgi_id_default_behavior`: Verifies that omitting the `hgi_id` argument preserves the original behavior (defaulting to the Sentinel ID `18:000730`).
- **Regression Testing:** Ran the full pytest suite (`pytest`), resulting in **619 passed tests**, confirming that these changes did not break existing functionality.

### Risks of NOT Implementing:

Leaving the code as-is forces developers to maintain complex and fragile workarounds (packet patching) in downstream integrations. This increases technical debt and leaves the protocol vulnerable to timing-based errors that are difficult to debug.

### Risks of Implementing:
- **Configuration Errors:** If a user provides an incorrect or malformed `hgi_id`, the transport layer may fail to communicate with the device.
- **Transport Compatibility:** While the `Engine` passes the ID, specific custom transport implementations must be written to respect `SZ_ACTIVE_HGI` in their `extra_info` or configuration (though this is standard practice in `ramses_tx`).

### Mitigation Steps:
- **Backward Compatibility:** The `hgi_id` argument is strictly optional (`None` by default). The logic explicitly falls back to `HGI_DEV_ADDR.id` if no custom ID is provided, ensuring zero impact on existing users or standard serial setups.
- **Strict Typing:** All changes are fully typed and passed `mypy` strict checks.
- **Test Coverage:** Added specific tests to cover both the "custom ID" and "default ID" paths to prevent regression.