### PR TITLE
fix(ramses_tx): increase timeouts for MQTT & refactor HGI patching

### DIFF
--- a/src/ramses_tx/const.py
+++ b/src/ramses_tx/const.py
@@ -20,10 +20,12 @@ DEFAULT_DISABLE_QOS: Final[bool | None] = None
 DEFAULT_WAIT_FOR_REPLY: Final[bool | None] = None
 
 #: Waiting for echo pkt after cmd sent (seconds)
-DEFAULT_ECHO_TIMEOUT: Final[float] = 0.50
+# NOTE: Increased to 3.0s to support high-latency transports (e.g., MQTT)
+DEFAULT_ECHO_TIMEOUT: Final[float] = 3.00
 
 #: Waiting for reply pkt after echo pkt rcvd (seconds)
-DEFAULT_RPLY_TIMEOUT: Final[float] = 0.50
+# NOTE: Increased to 3.0s to support high-latency transports (e.g., MQTT)
+DEFAULT_RPLY_TIMEOUT: Final[float] = 3.00
 DEFAULT_BUFFER_SIZE: Final[int] = 32
 
 #: Total waiting for successful send (seconds)

--- a/tests/tests_rf/test_protocol_fsm.py
+++ b/tests/tests_rf/test_protocol_fsm.py
@@ -15,6 +15,7 @@ import serial  # type: ignore[import-untyped]
 
 from ramses_rf import Command, Message, Packet
 from ramses_tx import exceptions as exc
+from ramses_tx.const import DEFAULT_ECHO_TIMEOUT, DEFAULT_RPLY_TIMEOUT
 from ramses_tx.protocol import PortProtocol, ReadProtocol, protocol_factory
 from ramses_tx.protocol_fsm import (
     Inactive,
@@ -80,8 +81,8 @@ async def protocol(rf: VirtualRf) -> AsyncGenerator[PortProtocol, None]:
 
     protocol._disable_qos = False  # HACK: needed for tests to succeed (default: None?)
 
-    assert protocol._context.echo_timeout == 0.5
-    assert protocol._context.reply_timeout == 0.5
+    assert protocol._context.echo_timeout == DEFAULT_ECHO_TIMEOUT
+    assert protocol._context.reply_timeout == DEFAULT_RPLY_TIMEOUT
     assert protocol._context.SEND_TIMEOUT_LIMIT == 20.0
 
     await assert_protocol_state(protocol, Inactive, max_sleep=0)


### PR DESCRIPTION
### The Problem:

Currently, the `ramses_rf` stack uses strict 0.5-second timeouts (`DEFAULT_ECHO_TIMEOUT` and `DEFAULT_RPLY_TIMEOUT`). When running over high-latency transports (such as MQTT via `ramses_cc`), valid echoes and replies often arrive slightly after this window, causing the protocol to throw `ProtocolSendFailed` errors even when the hardware successfully executed the command. Additionally, the logic for patching legacy HGI addresses (`18:000730`) to the actual `evofw3` ID was embedded directly within the `send_cmd` flow, making the code brittle and difficult to debug.

### Consequences:

If this isn't fixed, users attempting to run Home Assistant integrations over networked serial ports or MQTT will experience frequent command failures, "device unavailable" states, and connection drops. The system becomes unreliable for any setup that isn't a direct, low-latency USB connection.

### The Fix:

I have increased the default protocol timeouts to accommodate network latency and refactored the HGI address patching logic into a clean, dedicated method.

### Technical Implementation:
1. **Timeout Adjustment (`src/ramses_tx/const.py`):**
  - Increased `DEFAULT_ECHO_TIMEOUT` from `0.5s` to `3.0s`.
  - Increased `DEFAULT_RPLY_TIMEOUT` from `0.5s` to `3.0s`.
  - This ensures the FSM waits long enough for a round-trip over MQTT before declaring a failure.
2. **Refactoring (`src/ramses_tx/protocol.py`):**
  - Extracted the legacy address swapping logic into a new private method: `_patch_cmd_if_needed(self, cmd: Command) -> Command`.
  - This method encapsulates the check for `_is_evofw3` and the legacy address `18:000730`, returning a new `Command` object with the correct source ID only when strict patching conditions are met.

### Testing Performed:
- Tested on a live system with MQTT as the transport mechanism for the packet data
- Ran pytest with 100% of tests passing

### Risks of NOT Implementing:

Leaving the code as is renders the library unusable for distributed Home Assistant setups (e.g., Remote Home Assistant or MQTT bridges), limiting `ramses_rf` strictly to local USB hardware.

### Risks of Implementing:

Increasing the timeout means that *genuine* failures (where a device is actually unplugged or dead) will now take 3.0 seconds to fail instead of 0.5 seconds. This could make the UI appear slightly slower to report errors during actual hardware faults.

### Mitigation Steps:

The 3.0-second duration was chosen as a safe upper bound that covers standard MQTT QoS 0/1 latency spikes while still being fast enough to not hang the Home Assistant event loop noticeably. Successful commands return immediately upon receipt of the packet, so normal operation speed is unaffected.