### PR TITLE
fix: Handle integer OpenTherm context values from SQLite backend

### DIFF
--- a/src/ramses_rf/entity_base.py
+++ b/src/ramses_rf/entity_base.py
@@ -913,7 +913,9 @@ class _Discovery(_MessageDB):
                 sql, (self.id[:_ID_SLICE], self.id[:_ID_SLICE])
             ):
                 _LOGGER.debug("Fetched OT ctx from index: %s", rec[0])
-                res.append(rec[0])
+                # SQLite can return int, expected str (hex)
+                val = f"{rec[0]:02X}" if isinstance(rec[0], int) else rec[0]
+                res.append(val)
         else:  # TODO(eb): remove next Q1 2026
             res_dict: dict[bool | str | None, Message] | list[Any] = self._msgz[
                 Code._3220


### PR DESCRIPTION
### The Problem:

When using the SQLite backend, the `supported_cmds_ot` property fails with a `TypeError: int() can't convert non-string with explicit base`. This occurs because the SQLite adapter returns the OpenTherm context (`ctx`) as an integer (e.g., `5`), whereas the legacy backend returned it as a hex string (e.g., `"05"`). The code attempts to call `int(msg_id, 16)`, which fails when `msg_id` is already an integer.
- **Issue ID:** #396

### Consequences:
- **System Failure:** The entity fails to initialize properly during startup or discovery.
- **User Impact:** Users with the SQLite option enabled cannot use OpenTherm sensors/features effectively, resulting in persistent error logs and broken entities (e.g., status sensors).

### The Fix:

I modified `supported_cmds_ot` in `src/ramses_rf/entity_base.py`. The code now checks if the retrieved `ctx` value is an integer. If it is, it formats it as a 2-character hex string (e.g., `5` -> `"05"`) before processing it further.

### Technical Implementation:

In `_Discovery.supported_cmds_ot`:
- Added a check on the records returned by `self._gwy.msg_db.qry_field`.
- If `rec[0]` is an `int`, it is converted using `f"{rec[0]:02X}"`.
- This ensures `_to_data_id` always receives a valid hex string, maintaining compatibility with the rest of the discovery logic.

### Testing Performed:

I added two new test cases in `tests/tests_rf/test_entity_base.py`:
1. `test_gh_396_sqlite_ot_context_type`: Mocks the SQLite database returning an integer (`0`) and asserts that no `TypeError` is raised and the key is correctly formatted as `"0x00"`.
2. `test_gh_396_legacy_ot_context`: Verify that the legacy path (where `msg_db` is `None` and `_msgz_` is used) still functions correctly with string inputs.

### Risks of NOT Implementing:

The integration remains broken for all users opting into the new SQLite storage backend, which is a key feature of the recent updates.

### Risks of Implementing:
- **Minimal:** The change is localized to the OpenTherm discovery property and only modifies data type handling for the context field.
- **Regression:** Unlikely, as the legacy path is preserved and tested.

### Mitigation Steps:
- Included comprehensive unit tests covering both the new SQLite behavior and the existing legacy behavior to prevent regressions.
- Used standard f-string formatting to ensure consistent hex representation.