### PR TITLE
Fix: Handle list payloads in System heat logic to prevent crash (Fixes issue #416)

### DIFF
--- a/src/ramses_rf/system/heat.py
+++ b/src/ramses_rf/system/heat.py
@@ -137,7 +137,7 @@ class SystemBase(Parent, Entity):  # 3B00 (multi-relay)
         self._child_id = FF  # NOTE: domain_id
 
         self._app_cntrl: BdrSwitch | OtbGateway | None = None
-        self._heat_demand = None
+        self._heat_demand: dict[str, Any] | None = None
 
     def __repr__(self) -> str:
         return f"{self.ctl.id} ({self._SLUG})"
@@ -217,17 +217,33 @@ class SystemBase(Parent, Entity):  # 3B00 (multi-relay)
         super()._handle_msg(msg)
 
         if msg.code == Code._000C:
-            if msg.payload[SZ_ZONE_TYPE] == DEV_ROLE_MAP.APP and msg.payload.get(
-                SZ_DEVICES
-            ):
-                self._gwy.get_device(
-                    msg.payload[SZ_DEVICES][0], parent=self, child_id=FC
-                )  # sets self._app_cntrl
+            if isinstance(msg.payload, dict):
+                if msg.payload[SZ_ZONE_TYPE] == DEV_ROLE_MAP.APP and msg.payload.get(
+                    SZ_DEVICES
+                ):
+                    self._gwy.get_device(
+                        msg.payload[SZ_DEVICES][0], parent=self, child_id=FC
+                    )  # sets self._app_cntrl
+            else:
+                _LOGGER.warning(
+                    f"{msg!r} < Unexpected payload type for {msg.code}: {type(msg.payload)} (expected dict)"
+                )
             return
 
-        if msg.code == Code._3150:
-            if msg.payload.get(SZ_DOMAIN_ID) == FC and msg.verb in (I_, RP):
-                self._heat_demand = msg.payload
+        if msg.code == Code._3150 and msg.verb in (I_, RP):
+            # 3150 payload can be a dict (old) or list (new, multi-zone)
+            if isinstance(msg.payload, list):
+                if payload := next(
+                    (d for d in msg.payload if d.get(SZ_DOMAIN_ID) == FC), None
+                ):
+                    self._heat_demand = payload
+            elif isinstance(msg.payload, dict):
+                if msg.payload.get(SZ_DOMAIN_ID) == FC:
+                    self._heat_demand = msg.payload
+            else:
+                _LOGGER.warning(
+                    f"{msg!r} < Unexpected payload type for {msg.code}: {type(msg.payload)} (expected list/dict)"
+                )
 
         if self._gwy.config.enable_eavesdrop and not self.appliance_control:
             eavesdrop_appliance_control(msg)
@@ -588,7 +604,12 @@ class ScheduleSync(SystemBase):  # 0006 (+/- 0404?)
         super()._handle_msg(msg)
 
         if msg.code == Code._0006:
-            self._msg_0006 = msg
+            if isinstance(msg.payload, dict):
+                self._msg_0006 = msg
+            else:
+                _LOGGER.warning(
+                    f"{msg!r} < Unexpected payload type for {msg.code}: {type(msg.payload)} (expected dict)"
+                )
 
     async def _schedule_version(self, *, force_io: bool = False) -> tuple[int, bool]:
         """Return the global schedule version number, and an indication if I/O was done.
@@ -706,7 +727,12 @@ class Logbook(SystemBase):  # 0418
         super()._handle_msg(msg)
 
         if msg.code == Code._0418:  # and msg.verb in (I_, RP):
-            self._faultlog.handle_msg(msg)
+            if isinstance(msg.payload, dict):
+                self._faultlog.handle_msg(msg)
+            else:
+                _LOGGER.warning(
+                    f"{msg!r} < Unexpected payload type for {msg.code}: {type(msg.payload)} (expected dict)"
+                )
 
     async def get_faultlog(
         self,

--- a/tests/tests_rf/test_system_heat.py
+++ b/tests/tests_rf/test_system_heat.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Test the System heat logic, specifically packet processing."""
+
+import asyncio
+from datetime import datetime as dt
+from typing import Any, Final
+from unittest.mock import MagicMock
+
+import pytest
+
+from ramses_rf import Gateway
+from ramses_rf.const import FC, I_, SZ_DOMAIN_ID, Code
+from ramses_rf.system.heat import SystemBase
+from ramses_tx import Message, Packet
+from ramses_tx.address import HGI_DEVICE_ID
+
+# A standard 3150 I-packet (Heat Demand) from a Controller
+# 3150 002 FCC8 -> domain_id=FC (System), demand=C8 (100%)
+# NOTE: Must use double space after RSSI (064) for ' I' verb parsing by Packet.from_port
+PKT_3150: Final = f"064  I --- 01:145038 --:------ 01:145038 {Code._3150} 002 FCC8"
+
+
+# --- Fixtures required for fake_evofw3 ---
+
+
+@pytest.fixture()
+def gwy_config() -> dict:
+    """Return a valid configuration for the gateway."""
+    return {}
+
+
+@pytest.fixture()
+def gwy_dev_id() -> str:
+    """Return a valid device ID for the gateway."""
+    return HGI_DEVICE_ID
+
+
+# --- Helper to create a valid Mock Message ---
+
+
+def create_mock_message(tcs: SystemBase, payload: Any) -> MagicMock:
+    """Create a mock message that looks like it came from the TCS controller.
+
+    Includes internal structures (_pkt, _ctx) required for logging/caching.
+    """
+    mock_msg = MagicMock(spec=Message)
+    mock_msg.code = Code._3150
+    mock_msg.verb = I_
+    mock_msg.src = MagicMock()
+    mock_msg.src.id = tcs.id  # Match TCS ID so it is accepted
+    mock_msg.payload = payload
+
+    # Mock the internal packet structure required by Entity._handle_msg logging
+    mock_msg._pkt = MagicMock()
+    # Unique context key for caching: (timestamp, addr, ...)
+    # Just needs to be hashable
+    mock_msg._pkt._ctx = f"{dt.now().isoformat()}_{tcs.id}"
+
+    return mock_msg
+
+
+# --- Tests ---
+
+
+@pytest.mark.asyncio
+async def test_system_handle_msg_3150_real_packet(fake_evofw3: Gateway) -> None:
+    """Check that a real 3150 packet is handled correctly.
+
+    If this passes, it means the current parser produces a payload (likely a dict)
+    that the current code can handle.
+    """
+    gwy = fake_evofw3
+    pkt = Packet.from_port(dt.now(), PKT_3150)
+    gwy._protocol.pkt_received(pkt)
+    await asyncio.sleep(0.001)
+
+    tcs = gwy.tcs
+    assert tcs is not None
+    assert tcs.heat_demand is not None
+
+
+@pytest.mark.asyncio
+async def test_system_handle_msg_3150_force_list(fake_evofw3: Gateway) -> None:
+    """Simulate a parser returning a LIST payload.
+
+    THIS TEST IS EXPECTED TO FAIL (CRASH) on the current Master branch.
+    It confirms that IF the parser returns a list, the system breaks.
+    """
+    gwy = fake_evofw3
+
+    # Bootstrap TCS
+    pkt = Packet.from_port(dt.now(), PKT_3150)
+    gwy._protocol.pkt_received(pkt)
+    await asyncio.sleep(0.001)
+    tcs = gwy.tcs
+    assert tcs is not None  # Ensure TCS exists for Mypy
+
+    # Construct a List-based payload (New/Hybrid Style)
+    # The parser might return [ {domain: FC, demand: 0.5}, ... ]
+    payload = [{SZ_DOMAIN_ID: FC, "heat_demand": 0.5}]
+
+    if not isinstance(tcs, SystemBase):
+        pytest.fail("TCS is not an instance of SystemBase")
+
+    msg = create_mock_message(tcs, payload)
+
+    # This should raise AttributeError: 'list' object has no attribute 'get'
+    tcs._handle_msg(msg)
+
+    # If we get here, the code handled the list (or ignored it)
+    # We verify if it actually extracted the value
+    assert tcs._heat_demand == payload[0]
+
+
+@pytest.mark.asyncio
+async def test_system_handle_msg_3150_force_dict(fake_evofw3: Gateway) -> None:
+    """Simulate a parser returning a DICT payload.
+
+    This ensures backward compatibility for Dict payloads.
+    """
+    gwy = fake_evofw3
+
+    # Bootstrap TCS
+    pkt = Packet.from_port(dt.now(), PKT_3150)
+    gwy._protocol.pkt_received(pkt)
+    await asyncio.sleep(0.001)
+    tcs = gwy.tcs
+    assert tcs is not None  # Ensure TCS exists for Mypy
+
+    # Construct a Dict-based payload (Legacy Style)
+    payload = {SZ_DOMAIN_ID: FC, "heat_demand": 0.5}
+
+    if not isinstance(tcs, SystemBase):
+        pytest.fail("TCS is not an instance of SystemBase")
+
+    msg = create_mock_message(tcs, payload)
+
+    tcs._handle_msg(msg)
+
+    assert tcs._heat_demand == payload


### PR DESCRIPTION
### The Problem:

A regression was introduced in versions 0.52.3/0.52.4 where certain packets (specifically `3150` Heat Demand) began parsing as a `list` of dictionaries rather than a single `dict`. The existing logic in `src/ramses_rf/system/heat.py` assumed a `dict` payload and attempted to call `.get()` on the list, resulting in an `AttributeError`.

### Consequences:

For users affected by this parser change, the `SystemBase` entity crashes whenever a `3150` packet is received. This causes the Climate controller to stop updating entirely, effectively breaking the integration's core functionality for those users.

### The Fix:

I have updated `src/ramses_rf/system/heat.py` to implement "defensive programming." The handler now explicitly checks the type of `msg.payload`. It supports both the legacy `dict` format and the new `list` format. If an unexpected type is encountered, it now logs a warning instead of crashing.

### Technical Implementation:

Modified `SystemBase._handle_msg` and other classes in `heat.py` to:
1. Check `isinstance(msg.payload, list)`: If true, iterate through the list to find the item corresponding to the System Domain (`FC`).
2. Check `isinstance(msg.payload, dict)`: If true, process as legacy/standard behavior.
3. **Fallback**: If the payload is neither (or a list for a packet type that shouldn't be a list), log a warning to `_LOGGER` with the packet details.
4. Applied this logic to codes: `3150` (Heat Demand), `000C` (Appliance Control), `0006` (Schedule Sync), and `0418` (Logbook).
5. Added correct Type Hinting for `self._heat_demand`.

### Testing Performed:

I developed a specific regression test suite in `tests/tests_rf/test_system_heat.py` to prove the hypothesis and verify the fix:
1. **Baseline Test**: Validated that the current parser still produces `dict` payloads for standard simple packets (test passed).
2. **Reproduction Test**: Created a test injecting a mocked `3150` message with a **List** payload. This successfully reproduced the crash (`AttributeError`) on the original code.
3. **Verification Test**: Ran the same "List Payload" test against the fixed code. The test passed, correctly extracting the heat demand from the list.
4. **Legacy Test**: Verified that mocked `dict` payloads still process correctly to ensure backward compatibility.
5. **Full Suite**: Ran the complete `pytest` suite (661 tests) to ensure no regressions. All passed.

### Risks of NOT Implementing:

The integration remains broken for any user whose system/parser produces list-based payloads for system messages. This is a critical blocking bug for 0.52.3+.

### Risks of Implementing:

Low. The primary risk is that the logic for extracting the specific domain item from the list is incorrect, which would lead to a "silent failure" (state not updating) rather than a crash.

### Mitigation Steps:
1. The logic specifically looks for `SZ_DOMAIN_ID == FC` (System) within the list, ensuring we grab the correct data.
2. Added a "catch-all" else block that logs warnings. If a packet arrives in a format we still don't handle, the user will see a warning in the logs rather than experiencing a total integration crash.