### PR TITLE
feat: Progressive logging for protocol FSM timeouts

### DIFF
--- a/src/ramses_tx/protocol_fsm.py
+++ b/src/ramses_tx/protocol_fsm.py
@@ -145,13 +145,20 @@ class ProtocolContext:
             # nope, was not successful, so multiplier should be incremented...
             self._multiplier = min(3, old_val + 1)
 
+            if self._cmd_tx_count < 3:
+                level = logging.DEBUG
+            elif self._cmd_tx_count == 3:
+                level = logging.INFO
+            else:
+                level = logging.WARNING
+
             if isinstance(self._state, WantEcho):
-                _LOGGER.warning(
-                    f"Timeout expired waiting for echo: {self} (delay={delay})"
+                _LOGGER.log(
+                    level, f"Timeout expired waiting for echo: {self} (delay={delay})"
                 )
             else:  # isinstance(self._state, WantRply):
-                _LOGGER.warning(
-                    f"Timeout expired waiting for reply: {self} (delay={delay})"
+                _LOGGER.log(
+                    level, f"Timeout expired waiting for reply: {self} (delay={delay})"
                 )
 
             assert isinstance(self.is_sending, bool), (


### PR DESCRIPTION
### The Problem:

Currently, the `protocol_fsm` logs a `WARNING` for every single timeout event, including the very first missed packet. In an RF environment (868MHz), transient packet collisions are expected and handled automatically by the retry logic. Logging every retry as a warning creates significant "log noise" and alert fatigue, leading users to believe their system is unstable when it is actually functioning normally.

### Consequences:
- **User Confusion:** Users frequently report benign "Timeout expired" warnings as bugs.
- **Alert Fatigue:** Real connectivity issues (where a device is actually unreachable) are buried amongst hundreds of transient retry warnings.
- **Log Bloat:** Unnecessary write operations to Home Assistant logs.

### The Fix:

I have refactored the `expire_state_on_timeout` logic within `ProtocolContext` to implement a "progressive" logging strategy. The log level now escalates as the retry count increases.

### Technical Implementation:

Modified the `expire_state_on_timeout` inner function in `src/ramses_tx/protocol_fsm.py`. Instead of a hardcoded `_LOGGER.warning`, the code now dynamically selects the log level based on `self._cmd_tx_count`:
- **Count < 3:** Uses `logging.DEBUG` (Hidden by default, useful for deep tracing).
- **Count == 3:** Uses `logging.INFO` (Visible in standard logs, but indicates "Note this").
- **Count >= 4:** Uses `logging.WARNING` (Indicates the retry limit is reached or imminent).

### Testing Performed:
- **Static Analysis:** Ensured the changes pass Mypy strict typing and Ruff linting standards.

### Risks of NOT Implementing:

Leaving the code as-is guarantees continued user reports of "errors" that are actually normal protocol behavior, wasting developer time on non-issues.

### Risks of Implementing:
- **Reduced Visibility:** If a user is diagnosing a specific "weak signal" issue without enabling debug logs, they might miss the fact that their system is constantly retrying 1-2 times per command.

### Mitigation Steps:
- **Escalation:** The logic guarantees that if the retries continue to fail (reaching count 4), a `WARNING` is still generated.
- **Debug Mode:** Full visibility is preserved simply by enabling `DEBUG` logging for `ramses_tx`.