### PR TITLE
Fix for code scanning alert: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -1,6 +1,6 @@
 name: Linting
 
-permissions:
+permissions:  ## security hint
   contents: read
 
 on:

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -1,5 +1,7 @@
 name: Linting
 
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -1,5 +1,7 @@
 name: Testing
 
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/check-type.yml
+++ b/.github/workflows/check-type.yml
@@ -1,5 +1,7 @@
 name: Typing
 
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ramses-rf/ramses_rf/security/code-scanning/3](https://github.com/ramses-rf/ramses_rf/security/code-scanning/3)

In general, the fix is to explicitly set the `permissions` for the `GITHUB_TOKEN` in this workflow to the least privilege necessary. For a pure CI test workflow that only checks out code and runs tests, `contents: read` is typically sufficient, and can be applied either at the workflow top level or per job.

For this specific file, the best minimal change without altering existing functionality is to add a `permissions` block at the root of the workflow (so it applies to all jobs). We will set `contents: read`, which aligns with the CodeQL suggestion and the actual needs of the job. Concretely, in `.github/workflows/check-test.yml`, we will insert:

```yaml
permissions:
  contents: read
```

just after the `name: Testing` line and before the `on:` block. No imports or additional methods are needed, since this is a YAML configuration file for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
