### PR TITLE
Bump minimal python version to 3.12

### DIFF
--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@
     "Topic :: Home Automation",
     "Programming Language :: Python :: 3.13",
   ]
-  requires-python = ">=3.11"        # HA core >=3.13.2, TODO set to >=3.12 Feb. 2026 (issue #384)
+  requires-python = ">=3.12"        # HA core >=3.13.2
   dependencies = [
     "colorlog>=6.9.0",              # latest
     "paho-mqtt>=2.1.0",             # latest


### PR DESCRIPTION
No longer test on python 3.11, as announced in issue #384 