### PR TITLE
Bump version

### DIFF
--- a/src/ramses_rf/version.py
+++ b/src/ramses_rf/version.py
@@ -1,4 +1,4 @@
 """RAMSES RF - a RAMSES-II protocol decoder & analyser (application layer)."""
 
-__version__ = "0.53.6"
+__version__ = "0.54.0"
 VERSION = __version__

--- a/src/ramses_tx/version.py
+++ b/src/ramses_tx/version.py
@@ -1,4 +1,4 @@
 """RAMSES RF - a RAMSES-II protocol decoder & analyser (transport layer)."""
 
-__version__ = "0.53.6"
+__version__ = "0.54.0"
 VERSION = __version__


### PR DESCRIPTION
Release 0.54.0 should be available by tomorrow, to match HA 2026.2.0.

Single failing test is a fresh ruff requirement on transport.py that was not flagged earlier today. Tolerated to allow release. See PR #435