### PR TITLE
Import `trio` for asyncio file IO in `transport.py`

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -14,3 +14,4 @@
   click >= 8.2.1                                 # NOTE: non-async version
   colorama >= 0.4.6                              # on Windows, colorlog uses the latest colorama
   debugpy >= 1.8.13                              # can invoke via CLI
+  trio >= 0.32.0                                 # for asyncio IO since 0.54.0

--- a/src/ramses_rf/version.py
+++ b/src/ramses_rf/version.py
@@ -1,4 +1,4 @@
 """RAMSES RF - a RAMSES-II protocol decoder & analyser (application layer)."""
 
-__version__ = "0.53.6"
+__version__ = "0.54.0"
 VERSION = __version__

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -230,7 +230,8 @@ async def is_hgi80(serial_port: SerPortNameT) -> bool | None:
             ) from err
         return None
 
-    if not await trio.Path.exists(serial_port):
+    path = trio.Path(serial_port)
+    if not await path.exists():
         raise exc.TransportSerialError(f"Unable to find {serial_port}")
 
     # first, try the easy win...

--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -59,6 +59,7 @@ from time import perf_counter
 from typing import TYPE_CHECKING, Any, Final, TypeAlias
 from urllib.parse import parse_qs, unquote, urlparse
 
+import trio
 from paho.mqtt import MQTTException, client as mqtt
 
 try:
@@ -229,7 +230,7 @@ async def is_hgi80(serial_port: SerPortNameT) -> bool | None:
             ) from err
         return None
 
-    if not os.path.exists(serial_port):
+    if not await trio.Path.exists(serial_port):
         raise exc.TransportSerialError(f"Unable to find {serial_port}")
 
     # first, try the easy win...

--- a/src/ramses_tx/version.py
+++ b/src/ramses_tx/version.py
@@ -1,4 +1,4 @@
 """RAMSES RF - a RAMSES-II protocol decoder & analyser (transport layer)."""
 
-__version__ = "0.53.6"
+__version__ = "0.54.0"
 VERSION = __version__


### PR DESCRIPTION
Not an immediate fix for the ruff linting error flagged in latest `ruff`:
> src/ramses_tx/transport.py:232:12: ASYNC240 Async functions should not use os.path methods, use trio.Path or anyio.path

New rule in Ruff [0.15.0 change log](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md)

This simple (advised by ruff) change passes ruff linting but throws several test failures `ramses_tx.exceptions.TransportError: Transport did not bind to Protocol within 0.5 secs`


in 0.53.3 we introduced:
> src/ramses_rf/transport.py: Refactored FileTransport to run its file reading loop inside loop.run_in_executor(), preventing log replay from stalling the main loop.

