### PR TITLE
Fix: Resolve blocking I/O in transport check (Ruff ASYNC248) #436

### DIFF
--- a/src/ramses_tx/transport.py
+++ b/src/ramses_tx/transport.py
@@ -229,7 +229,8 @@ async def is_hgi80(serial_port: SerPortNameT) -> bool | None:
             ) from err
         return None
 
-    if not os.path.exists(serial_port):
+    loop = asyncio.get_running_loop()
+    if not await loop.run_in_executor(None, os.path.exists, serial_port):
         raise exc.TransportSerialError(f"Unable to find {serial_port}")
 
     # first, try the easy win...


### PR DESCRIPTION
### The Problem:

The CI linting process is failing due to a new rule introduced in Ruff 0.15.0 (`ASYNC248`). This rule flags the use of `os.path.exists` inside the asynchronous function `is_hgi80` within `src/ramses_tx/transport.py`. This is a blocking I/O operation running on the main event loop.

### Consequences:
1. **CI Failure:** The linting workflow fails, preventing merges and deployments.
2. **Performance Degradation:** Although this specific check happens during startup, allowing blocking calls in `async` functions sets a bad precedent and halts the event loop, potentially delaying other pending tasks.

### The Fix:

I have refactored the file existence check to run in a separate thread using the standard `asyncio` executor pattern, rather than using `trio` (which is incompatible with this project's architecture).

### Technical Implementation:
- In `src/ramses_tx/transport.py`: Replaced `if not os.path.exists(serial_port):` with `if not await loop.run_in_executor(None, os.path.exists, serial_port):`.
- This offloads the blocking file system call to the default `ThreadPoolExecutor`, ensuring the main `asyncio` event loop remains non-blocking.

### Testing Performed:
- **New Unit Test:** Added `test_is_hgi80_async_file_check` to `tests/tests_tx/test_transport.py`. This test mocks `os.path.exists` and verifies that the function correctly awaits the executor result without raising errors.
- **Regression Testing:** Ran the full test suite (`pytest`) to confirm no regressions, specifically checking that transport binding does not time out (a regression observed in previous attempts using `trio`).
- **Linting:** Verified local pass with `ruff check src/ramses_tx/transport.py`.

### Risks of NOT Implementing:
- The CI pipeline will remain broken due to the linting error.

- Attempts to bypass this by ignoring the rule would leave blocking I/O technical debt in the codebase.

### Risks of Implementing:
- **Thread Overhead:** Offloading a trivial check to a thread adds slight overhead, but this is negligible during the application startup phase.

### Mitigation Steps:
- **Standard Library Usage:** Used `loop.run_in_executor` (standard `asyncio`) instead of introducing third-party libraries like `trio` or `anyio`, ensuring zero dependency conflicts.
- **Timeout Verification:** Confirmed via the full test suite that this change does not introduce the binding timeouts seen in PR #435.