### PR TITLE
Fix: Resolve strict Mypy errors

### DIFF
--- a/src/ramses_rf/device/base.py
+++ b/src/ramses_rf/device/base.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 from ramses_rf.binding_fsm import BindContext, Vendor
 from ramses_rf.const import DEV_TYPE_MAP, SZ_OEM_CODE, DevType
@@ -235,13 +235,13 @@ class BatteryState(DeviceBase):  # 1060
     def battery_low(self) -> None | bool:  # 1060
         if self.is_faked:
             return False
-        return self._msg_value(Code._1060, key=self.BATTERY_LOW)
+        return cast(bool | None, self._msg_value(Code._1060, key=self.BATTERY_LOW))
 
     @property
     def battery_state(self) -> dict[str, Any] | None:  # 1060
         if self.is_faked:
             return None
-        return self._msg_value(Code._1060)
+        return cast(dict[str, Any] | None, self._msg_value(Code._1060))
 
     @property
     def status(self) -> dict[str, Any]:
@@ -264,7 +264,7 @@ class DeviceInfo(DeviceBase):  # 10E0
 
     @property
     def device_info(self) -> dict | None:  # 10E0
-        return self._msg_value(Code._10E0)
+        return cast(dict | None, self._msg_value(Code._10E0))
 
     @property
     def traits(self) -> dict[str, Any]:
@@ -406,7 +406,7 @@ class Fakeable(DeviceBase):
         # raise NotImplementedError  # self.traits is a @property
         if not self.traits.get(SZ_OEM_CODE):
             self.traits[SZ_OEM_CODE] = self._msg_value(Code._10E0, key=SZ_OEM_CODE)
-        return self.traits.get(SZ_OEM_CODE)
+        return cast(str | None, self.traits.get(SZ_OEM_CODE))
 
 
 class Device(Child, DeviceBase):

--- a/src/ramses_rf/device/heat.py
+++ b/src/ramses_rf/device/heat.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, cast
 
 from ramses_rf import exceptions as exc
 from ramses_rf.const import (
@@ -153,11 +153,11 @@ class Actuator(DeviceHeat):  # 3EF0, 3EF1 (for 10:/13:)
 
     @property
     def actuator_cycle(self) -> dict | None:  # 3EF1
-        return self._msg_value(Code._3EF1)
+        return cast(dict | None, self._msg_value(Code._3EF1))
 
     @property
     def actuator_state(self) -> dict | None:  # 3EF0
-        return self._msg_value(Code._3EF0)
+        return cast(dict | None, self._msg_value(Code._3EF0))
 
     @property
     def status(self) -> dict[str, Any]:
@@ -173,7 +173,7 @@ class HeatDemand(DeviceHeat):  # 3150
 
     @property
     def heat_demand(self) -> float | None:  # 3150
-        return self._msg_value(Code._3150, key=self.HEAT_DEMAND)
+        return cast(float | None, self._msg_value(Code._3150, key=self.HEAT_DEMAND))
 
     @property
     def status(self) -> dict[str, Any]:
@@ -188,7 +188,7 @@ class Setpoint(DeviceHeat):  # 2309
 
     @property
     def setpoint(self) -> float | None:  # 2309
-        return self._msg_value(Code._2309, key=self.SETPOINT)
+        return cast(float | None, self._msg_value(Code._2309, key=self.SETPOINT))
 
     @property
     def status(self) -> dict[str, Any]:
@@ -203,7 +203,7 @@ class Weather(DeviceHeat):  # 0002
 
     @property
     def temperature(self) -> float | None:  # 0002
-        return self._msg_value(Code._0002, key=SZ_TEMPERATURE)
+        return cast(float | None, self._msg_value(Code._0002, key=SZ_TEMPERATURE))
 
     @temperature.setter
     def temperature(self, value: float | None) -> None:
@@ -247,7 +247,7 @@ class RelayDemand(DeviceHeat):  # 0008
 
     @property
     def relay_demand(self) -> float | None:  # 0008
-        return self._msg_value(Code._0008, key=self.RELAY_DEMAND)
+        return cast(float | None, self._msg_value(Code._0008, key=self.RELAY_DEMAND))
 
     @property
     def status(self) -> dict[str, Any]:
@@ -262,7 +262,7 @@ class DhwTemperature(DeviceHeat):  # 1260
 
     @property
     def temperature(self) -> float | None:  # 1260
-        return self._msg_value(Code._1260, key=SZ_TEMPERATURE)
+        return cast(float | None, self._msg_value(Code._1260, key=SZ_TEMPERATURE))
 
     @temperature.setter
     def temperature(self, value: float | None) -> None:
@@ -288,7 +288,7 @@ class Temperature(DeviceHeat):  # 30C9
     # .I --- 34:145039 01:054173 --:------ 1FC9 006 00-30C9-8A368F
     @property
     def temperature(self) -> float | None:  # 30C9
-        return self._msg_value(Code._30C9, key=SZ_TEMPERATURE)
+        return cast(float | None, self._msg_value(Code._30C9, key=SZ_TEMPERATURE))
 
     @temperature.setter
     def temperature(self, value: float | None) -> None:
@@ -526,20 +526,28 @@ class UfhController(Parent, DeviceHeat):  # UFC (02):
 
     @property
     def heat_demand(self) -> float | None:  # 3150|FC (there is also 3150|FA)
-        return self._msg_value_msg(self._heat_demand, key=self.HEAT_DEMAND)
+        return cast(
+            float | None, self._msg_value_msg(self._heat_demand, key=self.HEAT_DEMAND)
+        )
 
     @property
     def heat_demands(self) -> dict | None:  # 3150|ufh_idx array
         # return self._heat_demands.payload if self._heat_demands else None
-        return self._msg_value_msg(self._heat_demands)
+        return cast(dict | None, self._msg_value_msg(self._heat_demands))
 
     @property
     def relay_demand(self) -> dict | None:  # 0008|FC
-        return self._msg_value_msg(self._relay_demand, key=SZ_RELAY_DEMAND)
+        return cast(
+            dict | None,
+            self._msg_value_msg(self._relay_demand, key=SZ_RELAY_DEMAND),
+        )
 
     @property
     def relay_demand_fa(self) -> dict | None:  # 0008|FA
-        return self._msg_value_msg(self._relay_demand_fa, key=SZ_RELAY_DEMAND)
+        return cast(
+            dict | None,
+            self._msg_value_msg(self._relay_demand_fa, key=SZ_RELAY_DEMAND),
+        )
 
     @property
     def setpoints(self) -> dict | None:  # 22C9|ufh_idx array
@@ -607,7 +615,7 @@ class DhwSensor(DhwTemperature, BatteryState, Fakeable):  # DHW (07): 10A0, 1260
 
     @property
     def dhw_params(self) -> PayDictT._10A0 | None:
-        return self._msg_value(Code._10A0)
+        return cast(PayDictT._10A0 | None, self._msg_value(Code._10A0))
 
     @property
     def params(self) -> dict[str, Any]:
@@ -804,7 +812,7 @@ class OtbGateway(Actuator, HeatDemand):  # OTB (10): 3220 (22D9, others)
             self._deprecate_code_ctx(msg._pkt, reset=True)
 
     def _ot_msg_flag(self, msg_id: MsgId, flag_idx: int) -> bool | None:
-        flags: list = self._ot_msg_value(msg_id)
+        flags = cast(list, self._ot_msg_value(msg_id))
         return bool(flags[flag_idx]) if flags else None
 
     @staticmethod
@@ -906,11 +914,11 @@ class OtbGateway(Actuator, HeatDemand):  # OTB (10): 3220 (22D9, others)
 
     @property  # TODO
     def percent(self) -> float | None:  # 2401 - WIP (~3150|FC)
-        return self._msg_value(Code._2401, key=SZ_HEAT_DEMAND)
+        return cast(float | None, self._msg_value(Code._2401, key=SZ_HEAT_DEMAND))
 
     @property  # TODO
     def value(self) -> int | None:  # 2401 - WIP
-        return self._msg_value(Code._2401, key="_value_2")
+        return cast(int | None, self._msg_value(Code._2401, key="_value_2"))
 
     @property
     def boiler_output_temp(self) -> float | None:  # 3220|19, or 3200
@@ -921,131 +929,182 @@ class OtbGateway(Actuator, HeatDemand):  # OTB (10): 3220 (22D9, others)
         #     self._result_by_lookup(Code._3200, key=SZ_TEMPERATURE),
         # )
 
-        return self._result_by_lookup(Code._3200, key=SZ_TEMPERATURE)
+        return cast(
+            float | None, self._result_by_lookup(Code._3200, key=SZ_TEMPERATURE)
+        )
 
     @property
     def boiler_return_temp(self) -> float | None:  # 3220|1C, or 3210
-        return self._result_by_lookup(Code._3210, key=SZ_TEMPERATURE)
+        return cast(
+            float | None, self._result_by_lookup(Code._3210, key=SZ_TEMPERATURE)
+        )
 
     @property
     def boiler_setpoint(self) -> float | None:  # 3220|01, or 22D9
-        return self._result_by_lookup(Code._22D9, key=SZ_SETPOINT)
+        return cast(float | None, self._result_by_lookup(Code._22D9, key=SZ_SETPOINT))
 
     @property
     def ch_max_setpoint(self) -> float | None:  # 3220|39, or 1081
-        return self._result_by_lookup(Code._1081, key=SZ_SETPOINT)
+        return cast(float | None, self._result_by_lookup(Code._1081, key=SZ_SETPOINT))
 
     @property  # TODO: no OT equivalent
     def ch_setpoint(self) -> float | None:  # 3EF0 (byte 7, only R8820A?)
-        return self._result_by_value(
-            None, self._msg_value(Code._3EF0, key=SZ_CH_SETPOINT)
+        return cast(
+            float | None,
+            self._result_by_value(
+                None, self._msg_value(Code._3EF0, key=SZ_CH_SETPOINT)
+            ),
         )
 
     @property
     def ch_water_pressure(self) -> float | None:  # 3220|12, or 1300
-        return self._result_by_lookup(Code._1300, key=SZ_PRESSURE)
+        return cast(float | None, self._result_by_lookup(Code._1300, key=SZ_PRESSURE))
 
     @property
     def dhw_flow_rate(self) -> float | None:  # 3220|13, or 12F0
-        return self._result_by_lookup(Code._12F0, key=SZ_DHW_FLOW_RATE)
+        return cast(
+            float | None, self._result_by_lookup(Code._12F0, key=SZ_DHW_FLOW_RATE)
+        )
 
     @property
     def dhw_setpoint(self) -> float | None:  # 3220|38, or 10A0
-        return self._result_by_lookup(Code._10A0, key=SZ_SETPOINT)
+        return cast(float | None, self._result_by_lookup(Code._10A0, key=SZ_SETPOINT))
 
     @property
     def dhw_temp(self) -> float | None:  # 3220|1A, or 1260
-        return self._result_by_lookup(Code._1260, key=SZ_TEMPERATURE)
+        return cast(
+            float | None, self._result_by_lookup(Code._1260, key=SZ_TEMPERATURE)
+        )
 
     @property  # TODO: no reliable OT equivalent?
     def max_rel_modulation(self) -> float | None:  # 3220|0E, or 3EF0 (byte 8)
         if self._gwy.config.use_native_ot == "prefer":  # HACK: there'll always be 3EF0
-            return self._msg_value(Code._3EF0, key=SZ_MAX_REL_MODULATION)
-        return self._result_by_value(
-            self._ot_msg_value(MsgId._0E),  # NOTE: not reliable?
-            self._msg_value(Code._3EF0, key=SZ_MAX_REL_MODULATION),
+            return cast(
+                float | None, self._msg_value(Code._3EF0, key=SZ_MAX_REL_MODULATION)
+            )
+        return cast(
+            float | None,
+            self._result_by_value(
+                self._ot_msg_value(MsgId._0E),  # NOTE: not reliable?
+                self._msg_value(Code._3EF0, key=SZ_MAX_REL_MODULATION),
+            ),
         )
 
     @property
     def oem_code(self) -> float | None:  # 3220|73, no known RAMSES equivalent
-        return self._ot_msg_value(MsgId._73)
+        return cast(float | None, self._ot_msg_value(MsgId._73))
 
     @property
     def outside_temp(self) -> float | None:  # 3220|1B, 1290
-        return self._result_by_lookup(Code._1290, key=SZ_TEMPERATURE)
+        return cast(
+            float | None, self._result_by_lookup(Code._1290, key=SZ_TEMPERATURE)
+        )
 
     @property  # TODO: no reliable OT equivalent?
     def rel_modulation_level(self) -> float | None:  # 3220|11, or 3EF0/3EF1
         if self._gwy.config.use_native_ot == "prefer":  # HACK: there'll always be 3EF0
-            return self._msg_value((Code._3EF0, Code._3EF1), key=self.MODULATION_LEVEL)
-        return self._result_by_value(
-            self._ot_msg_value(MsgId._11),  # NOTE: not reliable?
-            self._msg_value((Code._3EF0, Code._3EF1), key=self.MODULATION_LEVEL),
+            return cast(
+                float | None,
+                self._msg_value((Code._3EF0, Code._3EF1), key=self.MODULATION_LEVEL),
+            )
+        return cast(
+            float | None,
+            self._result_by_value(
+                self._ot_msg_value(MsgId._11),  # NOTE: not reliable?
+                self._msg_value((Code._3EF0, Code._3EF1), key=self.MODULATION_LEVEL),
+            ),
         )
 
     @property  # TODO: no reliable OT equivalent?
     def ch_active(self) -> bool | None:  # 3220|00, or 3EF0 (byte 3)
         if self._gwy.config.use_native_ot == "prefer":  # HACK: there'll always be 3EF0
-            return self._msg_value(Code._3EF0, key=SZ_CH_ACTIVE)
-        return self._result_by_value(
-            self._ot_msg_flag(MsgId._00, 8 + 1),  # NOTE: not reliable?
-            self._msg_value(Code._3EF0, key=SZ_CH_ACTIVE),
+            return cast(bool | None, self._msg_value(Code._3EF0, key=SZ_CH_ACTIVE))
+        return cast(
+            bool | None,
+            self._result_by_value(
+                self._ot_msg_flag(MsgId._00, 8 + 1),  # NOTE: not reliable?
+                self._msg_value(Code._3EF0, key=SZ_CH_ACTIVE),
+            ),
         )
 
     @property  # TODO: no reliable OT equivalent?
     def ch_enabled(self) -> bool | None:  # 3220|00, or 3EF0 (byte 6)
         if self._gwy.config.use_native_ot == "prefer":  # HACK: there'll always be 3EF0
-            return self._msg_value(Code._3EF0, key=SZ_CH_ENABLED)
-        return self._result_by_value(
-            self._ot_msg_flag(MsgId._00, 0),  # NOTE: not reliable?
-            self._msg_value(Code._3EF0, key=SZ_CH_ENABLED),
+            return cast(bool | None, self._msg_value(Code._3EF0, key=SZ_CH_ENABLED))
+        return cast(
+            bool | None,
+            self._result_by_value(
+                self._ot_msg_flag(MsgId._00, 0),  # NOTE: not reliable?
+                self._msg_value(Code._3EF0, key=SZ_CH_ENABLED),
+            ),
         )
 
     @property
     def cooling_active(self) -> bool | None:  # 3220|00, TODO: no known RAMSES
-        return self._result_by_value(self._ot_msg_flag(MsgId._00, 8 + 4), None)
+        return cast(
+            bool | None,
+            self._result_by_value(self._ot_msg_flag(MsgId._00, 8 + 4), None),
+        )
 
     @property
     def cooling_enabled(self) -> bool | None:  # 3220|00, TODO: no known RAMSES
-        return self._result_by_value(self._ot_msg_flag(MsgId._00, 2), None)
+        return cast(
+            bool | None, self._result_by_value(self._ot_msg_flag(MsgId._00, 2), None)
+        )
 
     @property  # TODO: no reliable OT equivalent?
     def dhw_active(self) -> bool | None:  # 3220|00, or 3EF0 (byte 3)
         if self._gwy.config.use_native_ot == "prefer":  # HACK: there'll always be 3EF0
-            return self._msg_value(Code._3EF0, key=SZ_DHW_ACTIVE)
-        return self._result_by_value(
-            self._ot_msg_flag(MsgId._00, 8 + 2),  # NOTE: not reliable?
-            self._msg_value(Code._3EF0, key=SZ_DHW_ACTIVE),
+            return cast(bool | None, self._msg_value(Code._3EF0, key=SZ_DHW_ACTIVE))
+        return cast(
+            bool | None,
+            self._result_by_value(
+                self._ot_msg_flag(MsgId._00, 8 + 2),  # NOTE: not reliable?
+                self._msg_value(Code._3EF0, key=SZ_DHW_ACTIVE),
+            ),
         )
 
     @property
     def dhw_blocking(self) -> bool | None:  # 3220|00, TODO: no known RAMSES
-        return self._result_by_value(self._ot_msg_flag(MsgId._00, 6), None)
+        return cast(
+            bool | None, self._result_by_value(self._ot_msg_flag(MsgId._00, 6), None)
+        )
 
     @property
     def dhw_enabled(self) -> bool | None:  # 3220|00, TODO: no known RAMSES
-        return self._result_by_value(self._ot_msg_flag(MsgId._00, 1), None)
+        return cast(
+            bool | None, self._result_by_value(self._ot_msg_flag(MsgId._00, 1), None)
+        )
 
     @property
     def fault_present(self) -> bool | None:  # 3220|00, TODO: no known RAMSES
-        return self._result_by_value(self._ot_msg_flag(MsgId._00, 8), None)
+        return cast(
+            bool | None, self._result_by_value(self._ot_msg_flag(MsgId._00, 8), None)
+        )
 
     @property  # TODO: no reliable OT equivalent?
     def flame_active(self) -> bool | None:  # 3220|00, or 3EF0 (byte 3)
         if self._gwy.config.use_native_ot == "prefer":  # HACK: there'll always be 3EF0
-            return self._msg_value(Code._3EF0, key="flame_on")
-        return self._result_by_value(
-            self._ot_msg_flag(MsgId._00, 8 + 3),  # NOTE: not reliable?
-            self._msg_value(Code._3EF0, key="flame_on"),
+            return cast(bool | None, self._msg_value(Code._3EF0, key="flame_on"))
+        return cast(
+            bool | None,
+            self._result_by_value(
+                self._ot_msg_flag(MsgId._00, 8 + 3),  # NOTE: not reliable?
+                self._msg_value(Code._3EF0, key="flame_on"),
+            ),
         )
 
     @property
     def otc_active(self) -> bool | None:  # 3220|00, TODO: no known RAMSES
-        return self._result_by_value(self._ot_msg_flag(MsgId._00, 3), None)
+        return cast(
+            bool | None, self._result_by_value(self._ot_msg_flag(MsgId._00, 3), None)
+        )
 
     @property
     def summer_mode(self) -> bool | None:  # 3220|00, TODO: no known RAMSES
-        return self._result_by_value(self._ot_msg_flag(MsgId._00, 5), None)
+        return cast(
+            bool | None, self._result_by_value(self._ot_msg_flag(MsgId._00, 5), None)
+        )
 
     @property
     def opentherm_schema(self) -> dict[str, Any]:
@@ -1335,7 +1394,7 @@ class BdrSwitch(Actuator, RelayDemand):  # BDR (13):
 
     @property
     def tpi_params(self) -> PayDictT._10A0 | None:
-        return self._msg_value(Code._1100)
+        return cast(PayDictT._10A0 | None, self._msg_value(Code._1100))
 
     @property
     def schema(self) -> dict[str, Any]:
@@ -1376,7 +1435,7 @@ class TrvActuator(BatteryState, HeatDemand, Setpoint, Temperature):  # TRV (04):
 
     @property
     def window_open(self) -> bool | None:  # 12B0
-        return self._msg_value(Code._12B0, key=self.WINDOW_OPEN)
+        return cast(bool | None, self._msg_value(Code._12B0, key=self.WINDOW_OPEN))
 
     @property
     def status(self) -> dict[str, Any]:

--- a/src/ramses_rf/device/hvac.py
+++ b/src/ramses_rf/device/hvac.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from ramses_rf import exceptions as exc
 from ramses_rf.const import (
@@ -104,7 +104,7 @@ class CarbonDioxide(HvacSensorBase):  # 1298
         :return: The CO2 level in parts per million (ppm), or None if not available
         :rtype: int | None
         """
-        return self._msg_value(Code._1298, key=SZ_CO2_LEVEL)
+        return cast(int | None, self._msg_value(Code._1298, key=SZ_CO2_LEVEL))
 
     @co2_level.setter
     def co2_level(self, value: int | None) -> None:
@@ -144,7 +144,7 @@ class IndoorHumidity(HvacSensorBase):  # 12A0
         :return: The indoor relative humidity as a percentage (0-100), or None if not available
         :rtype: float | None
         """
-        return self._msg_value(Code._12A0, key=SZ_INDOOR_HUMIDITY)
+        return cast(float | None, self._msg_value(Code._12A0, key=SZ_INDOOR_HUMIDITY))
 
     @indoor_humidity.setter
     def indoor_humidity(self, value: float | None) -> None:
@@ -188,7 +188,7 @@ class PresenceDetect(HvacSensorBase):  # 2E10
         :return: True if presence is detected, False if not, None if status is unknown
         :rtype: bool | None
         """
-        return self._msg_value(Code._2E10, key=SZ_PRESENCE_DETECTED)
+        return cast(bool | None, self._msg_value(Code._2E10, key=SZ_PRESENCE_DETECTED))
 
     @presence_detected.setter
     def presence_detected(self, value: bool | None) -> None:
@@ -285,7 +285,7 @@ class HvacHumiditySensor(BatteryState, IndoorHumidity, Fakeable):  # HUM: I/12A0
         :return: The temperature in degrees Celsius, or None if not available
         :rtype: float | None
         """
-        return self._msg_value(Code._12A0, key=SZ_TEMPERATURE)
+        return cast(float | None, self._msg_value(Code._12A0, key=SZ_TEMPERATURE))
 
     @property
     def dewpoint_temp(self) -> float | None:
@@ -294,7 +294,7 @@ class HvacHumiditySensor(BatteryState, IndoorHumidity, Fakeable):  # HUM: I/12A0
         :return: The dewpoint temperature in degrees Celsius, or None if not available
         :rtype: float | None
         """
-        return self._msg_value(Code._12A0, key="dewpoint_temp")
+        return cast(float | None, self._msg_value(Code._12A0, key="dewpoint_temp"))
 
     @property
     def status(self) -> dict[str, Any]:
@@ -359,7 +359,7 @@ class HvacRemote(BatteryState, Fakeable, HvacRemoteBase):  # REM: I/22F[138]
         :rtype: str | None
         :note: This is a work in progress - rate can be either int or str
         """
-        return self._msg_value(Code._22F1, key="rate")
+        return cast(str | None, self._msg_value(Code._22F1, key="rate"))
 
     @fan_rate.setter
     def fan_rate(self, value: int) -> None:
@@ -387,7 +387,7 @@ class HvacRemote(BatteryState, Fakeable, HvacRemoteBase):  # REM: I/22F[138]
         :return: The fan mode as a string, or None if not available
         :rtype: str | None
         """
-        return self._msg_value(Code._22F1, key=SZ_FAN_MODE)
+        return cast(str | None, self._msg_value(Code._22F1, key=SZ_FAN_MODE))
 
     @property
     def boost_timer(self) -> int | None:
@@ -396,7 +396,7 @@ class HvacRemote(BatteryState, Fakeable, HvacRemoteBase):  # REM: I/22F[138]
         :return: The remaining boost time in minutes, or None if boost is not active
         :rtype: int | None
         """
-        return self._msg_value(Code._22F3, key=SZ_BOOST_TIMER)
+        return cast(int | None, self._msg_value(Code._22F3, key=SZ_BOOST_TIMER))
 
     @property
     def status(self) -> dict[str, Any]:
@@ -807,7 +807,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         :return: The air quality measurement as a float, or None if not available
         :rtype: float | None
         """
-        return self._msg_value(Code._31DA, key=SZ_AIR_QUALITY)
+        return cast(float | None, self._msg_value(Code._31DA, key=SZ_AIR_QUALITY))
 
     @property
     def air_quality_base(self) -> float | None:
@@ -819,14 +819,14 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         :return: The base air quality measurement, or None if not available
         :rtype: float | None
         """
-        return self._msg_value(Code._31DA, key=SZ_AIR_QUALITY_BASIS)
+        return cast(float | None, self._msg_value(Code._31DA, key=SZ_AIR_QUALITY_BASIS))
 
     @property
     def bypass_mode(self) -> str | None:
         """
         :return: bypass mode as on|off|auto
         """
-        return self._msg_value(Code._22F7, key=SZ_BYPASS_MODE)
+        return cast(str | None, self._msg_value(Code._22F7, key=SZ_BYPASS_MODE))
 
     @property
     def bypass_position(self) -> float | str | None:
@@ -835,7 +835,10 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         :return: bypass position as percentage: 0.0 (closed) or 1.0 (open), on error: "x_faulted"
         """
         # if both packets exist and both have the key, returns the most recent
-        return self._msg_value((Code._22F7, Code._31DA), key=SZ_BYPASS_POSITION)
+        return cast(
+            float | str | None,
+            self._msg_value((Code._22F7, Code._31DA), key=SZ_BYPASS_POSITION),
+        )
 
     @property
     def bypass_state(self) -> str | None:
@@ -843,7 +846,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         Orcon, others?
         :return: bypass position as on/off
         """
-        return self._msg_value(Code._22F7, key=SZ_BYPASS_STATE)
+        return cast(str | None, self._msg_value(Code._22F7, key=SZ_BYPASS_STATE))
 
     @property
     def co2_level(self) -> int | None:
@@ -852,7 +855,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         :return: The CO2 level in ppm, or None if not available
         :rtype: int | None
         """
-        return self._msg_value(Code._31DA, key=SZ_CO2_LEVEL)
+        return cast(int | None, self._msg_value(Code._31DA, key=SZ_CO2_LEVEL))
 
     @property
     def exhaust_fan_speed(
@@ -880,7 +883,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         :return: The exhaust air flow rate in m³/h, or None if not available
         :rtype: float | None
         """
-        return self._msg_value(Code._31DA, key=SZ_EXHAUST_FLOW)
+        return cast(float | None, self._msg_value(Code._31DA, key=SZ_EXHAUST_FLOW))
 
     @property
     def exhaust_temp(self) -> float | None:
@@ -889,7 +892,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         :return: The exhaust air temperature in degrees Celsius, or None if not available
         :rtype: float | None
         """
-        return self._msg_value(Code._31DA, key=SZ_EXHAUST_TEMP)
+        return cast(float | None, self._msg_value(Code._31DA, key=SZ_EXHAUST_TEMP))
 
     @property
     def fan_rate(self) -> str | None:
@@ -899,7 +902,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
 
         :return: int or str describing rate of fan
         """
-        return self._msg_value(Code._22F4, key=SZ_FAN_RATE)
+        return cast(str | None, self._msg_value(Code._22F4, key=SZ_FAN_RATE))
 
     @property
     def fan_mode(self) -> str | None:
@@ -909,7 +912,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
 
         :return: a string describing mode
         """
-        return self._msg_value(Code._22F4, key=SZ_FAN_MODE)
+        return cast(str | None, self._msg_value(Code._22F4, key=SZ_FAN_MODE))
 
     @property
     def fan_info(self) -> str | None:
@@ -970,7 +973,10 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
             if v := self._msgs[Code._12A0].payload[0].get(SZ_INDOOR_HUMIDITY):
                 assert isinstance(v, (float | type(None)))
                 return v
-        return self._msg_value((Code._12A0, Code._31DA), key=SZ_INDOOR_HUMIDITY)
+        return cast(
+            float | None,
+            self._msg_value((Code._12A0, Code._31DA), key=SZ_INDOOR_HUMIDITY),
+        )
 
     @property
     def indoor_temp(self) -> float | None:
@@ -979,7 +985,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         :return: The indoor temperature in degrees Celsius, or None if not available
         :rtype: float | None
         """
-        return self._msg_value(Code._31DA, key=SZ_INDOOR_TEMP)
+        return cast(float | None, self._msg_value(Code._31DA, key=SZ_INDOOR_TEMP))
 
     @property
     def outdoor_humidity(self) -> float | None:
@@ -996,7 +1002,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
             if v := self._msgs[Code._12A0].payload[1].get(SZ_OUTDOOR_HUMIDITY):
                 assert isinstance(v, (float | type(None)))
                 return v
-        return self._msg_value(Code._31DA, key=SZ_OUTDOOR_HUMIDITY)
+        return cast(float | None, self._msg_value(Code._31DA, key=SZ_OUTDOOR_HUMIDITY))
 
     @property
     def outdoor_temp(self) -> float | None:
@@ -1005,7 +1011,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         :return: The outdoor temperature in degrees Celsius, or None if not available
         :rtype: float | None
         """
-        return self._msg_value(Code._31DA, key=SZ_OUTDOOR_TEMP)
+        return cast(float | None, self._msg_value(Code._31DA, key=SZ_OUTDOOR_TEMP))
 
     @property
     def post_heat(self) -> int | None:
@@ -1014,7 +1020,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         :return: The post-heat status as an integer, or None if not available
         :rtype: int | None
         """
-        return self._msg_value(Code._31DA, key=SZ_POST_HEAT)
+        return cast(int | None, self._msg_value(Code._31DA, key=SZ_POST_HEAT))
 
     @property
     def pre_heat(self) -> int | None:
@@ -1023,7 +1029,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         :return: The pre-heat status as an integer, or None if not available
         :rtype: int | None
         """
-        return self._msg_value(Code._31DA, key=SZ_PRE_HEAT)
+        return cast(int | None, self._msg_value(Code._31DA, key=SZ_PRE_HEAT))
 
     @property
     def remaining_mins(self) -> int | None:
@@ -1032,7 +1038,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         :return: The remaining minutes as an integer, or None if not available
         :rtype: int | None
         """
-        return self._msg_value(Code._31DA, key=SZ_REMAINING_MINS)
+        return cast(int | None, self._msg_value(Code._31DA, key=SZ_REMAINING_MINS))
 
     @property
     def request_fan_speed(self) -> float | None:
@@ -1041,7 +1047,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         :return: The requested fan speed as a percentage, or None if not available
         :rtype: float | None
         """
-        return self._msg_value(Code._2210, key=SZ_REQ_SPEED)
+        return cast(float | None, self._msg_value(Code._2210, key=SZ_REQ_SPEED))
 
     @property
     def request_src(self) -> str | None:
@@ -1049,7 +1055,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         Orcon, others?
         :return: source sensor of auto speed request: IDL, CO2 or HUM
         """
-        return self._msg_value(Code._2210, key=SZ_REQ_REASON)
+        return cast(str | None, self._msg_value(Code._2210, key=SZ_REQ_REASON))
 
     @property
     def speed_cap(self) -> int | None:
@@ -1058,7 +1064,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         :return: The speed capabilities as an integer, or None if not available
         :rtype: int | None
         """
-        return self._msg_value(Code._31DA, key=SZ_SPEED_CAPABILITIES)
+        return cast(int | None, self._msg_value(Code._31DA, key=SZ_SPEED_CAPABILITIES))
 
     @property
     def supply_fan_speed(self) -> float | None:
@@ -1067,7 +1073,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         :return: The supply fan speed as a percentage, or None if not available
         :rtype: float | None
         """
-        return self._msg_value(Code._31DA, key=SZ_SUPPLY_FAN_SPEED)
+        return cast(float | None, self._msg_value(Code._31DA, key=SZ_SUPPLY_FAN_SPEED))
 
     @property
     def supply_flow(self) -> float | None:
@@ -1076,7 +1082,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         :return: The supply air flow rate in m³/h, or None if not available
         :rtype: float | None
         """
-        return self._msg_value(Code._31DA, key=SZ_SUPPLY_FLOW)
+        return cast(float | None, self._msg_value(Code._31DA, key=SZ_SUPPLY_FLOW))
 
     @property
     def supply_temp(self) -> float | None:
@@ -1094,7 +1100,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
             if v := self._msgs[Code._12A0].payload[1].get(SZ_TEMPERATURE):
                 assert isinstance(v, (float | type(None)))
                 return v
-        return self._msg_value(Code._31DA, key=SZ_SUPPLY_TEMP)
+        return cast(float | None, self._msg_value(Code._31DA, key=SZ_SUPPLY_TEMP))
 
     @property
     def status(self) -> dict[str, Any]:
@@ -1125,7 +1131,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
                 assert isinstance(v, (float | type(None)))
                 return v
         # ClimaRad minibox FAN sends (indoor) temp in 12A0
-        return self._msg_value(Code._12A0, key=SZ_TEMPERATURE)
+        return cast(float | None, self._msg_value(Code._12A0, key=SZ_TEMPERATURE))
 
 
 # class HvacFanHru(HvacVentilator):

--- a/src/ramses_rf/system/zones.py
+++ b/src/ramses_rf/system/zones.py
@@ -7,7 +7,7 @@ import asyncio
 import logging
 import math
 from datetime import datetime as dt, timedelta as td
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from ramses_rf import exceptions as exc
 from ramses_rf.const import (
@@ -351,15 +351,15 @@ class DhwZone(ZoneSchedule):  # CS92A
 
     @property
     def config(self) -> dict[str, Any] | None:  # 10A0
-        return self._msg_value(Code._10A0)  # type: ignore[return-value]
+        return cast(dict[str, Any] | None, self._msg_value(Code._10A0))
 
     @property
     def mode(self) -> dict[str, Any] | None:  # 1F41
-        return self._msg_value(Code._1F41)  # type: ignore[return-value]
+        return cast(dict[str, Any] | None, self._msg_value(Code._1F41))
 
     @property
     def setpoint(self) -> float | None:  # 10A0
-        return self._msg_value(Code._10A0, key=SZ_SETPOINT)  # type: ignore[return-value]
+        return cast(float | None, self._msg_value(Code._10A0, key=SZ_SETPOINT))
 
     @setpoint.setter  # TODO: can value be None?
     def setpoint(self, value: float) -> None:  # 10A0
@@ -367,19 +367,19 @@ class DhwZone(ZoneSchedule):  # CS92A
 
     @property
     def temperature(self) -> float | None:  # 1260
-        return self._msg_value(Code._1260, key=SZ_TEMPERATURE)  # type: ignore[return-value]
+        return cast(float | None, self._msg_value(Code._1260, key=SZ_TEMPERATURE))
 
     @property
     def heat_demand(self) -> float | None:  # 3150
-        return self._msg_value(Code._3150, key=SZ_HEAT_DEMAND)  # type: ignore[return-value]
+        return cast(float | None, self._msg_value(Code._3150, key=SZ_HEAT_DEMAND))
 
     @property
     def relay_demand(self) -> float | None:  # 0008
-        return self._msg_value(Code._0008, key=SZ_RELAY_DEMAND)  # type: ignore[return-value]
+        return cast(float | None, self._msg_value(Code._0008, key=SZ_RELAY_DEMAND))
 
     @property  # only seen with FC, but seems should pair with 0008?
     def relay_failsafe(self) -> float | None:  # 0009
-        return self._msg_value(Code._0009, key=SZ_RELAY_FAILSAFE)  # type: ignore[return-value]
+        return cast(float | None, self._msg_value(Code._0009, key=SZ_RELAY_FAILSAFE))
 
     def set_mode(
         self,
@@ -706,7 +706,7 @@ class Zone(ZoneSchedule):
             _LOGGER.debug(f"Pick Zone.name from: {msgs}[0])")  # DEBUG issue #317
             return msgs[0].payload.get(SZ_NAME) if msgs else None
 
-        return self._msg_value(Code._0004, key=SZ_NAME)  # type: ignore[no-any-return]
+        return cast(str | None, self._msg_value(Code._0004, key=SZ_NAME))
 
     @name.setter
     def name(self, value: str) -> None:
@@ -714,15 +714,18 @@ class Zone(ZoneSchedule):
 
     @property
     def config(self) -> dict[str, Any] | None:  # 000A
-        return self._msg_value(Code._000A)  # type: ignore[no-any-return]
+        return cast(dict[str, Any] | None, self._msg_value(Code._000A))
 
     @property
     def mode(self) -> dict[str, Any] | None:  # 2349
-        return self._msg_value(Code._2349)  # type: ignore[no-any-return]
+        return cast(dict[str, Any] | None, self._msg_value(Code._2349))
 
     @property
     def setpoint(self) -> float | None:  # 2309 (2349 is a superset of 2309)
-        return self._msg_value((Code._2309, Code._2349), key=SZ_SETPOINT)  # type: ignore[no-any-return]
+        return cast(
+            float | None,
+            self._msg_value((Code._2309, Code._2349), key=SZ_SETPOINT),
+        )
 
     @setpoint.setter  # TODO: can value be None?
     def setpoint(self, value: float) -> None:  # 000A/2309
@@ -756,7 +759,7 @@ class Zone(ZoneSchedule):
                 return msgs_sorted[0].payload.get(SZ_TEMPERATURE)  # type: ignore[no-any-return]
             return None
         # else: TODO Q1 2026 remove remainder
-        return self._msg_value(Code._30C9, key=SZ_TEMPERATURE)  # type: ignore[no-any-return]
+        return cast(float | None, self._msg_value(Code._30C9, key=SZ_TEMPERATURE))
 
     @property
     def heat_demand(self) -> float | None:  # 3150
@@ -771,7 +774,7 @@ class Zone(ZoneSchedule):
     @property
     def window_open(self) -> bool | None:  # 12B0
         """Return an estimate of the zone's current window_open state."""
-        return self._msg_value(Code._12B0, key=SZ_WINDOW_OPEN)  # type: ignore[no-any-return]
+        return cast(bool | None, self._msg_value(Code._12B0, key=SZ_WINDOW_OPEN))
 
     def _get_temp(self) -> asyncio.Task[Packet] | None:
         """Get the zone's latest temp from the Controller."""
@@ -886,7 +889,7 @@ class EleZone(Zone):  # BDR91A/T  # TODO: 0008/0009/3150
 
     @property
     def relay_demand(self) -> float | None:  # 0008 (NOTE: CTLs won't RP|0008)
-        return self._msg_value(Code._0008, key=SZ_RELAY_DEMAND)  # type: ignore[no-any-return]
+        return cast(float | None, self._msg_value(Code._0008, key=SZ_RELAY_DEMAND))
 
     @property
     def status(self) -> dict[str, Any]:
@@ -916,7 +919,7 @@ class MixZone(Zone):  # HM80  # TODO: 0008/0009/3150
 
     @property
     def mix_config(self) -> PayDictT._1030:
-        return self._msg_value(Code._1030)  # type: ignore[no-any-return]
+        return cast(PayDictT._1030, self._msg_value(Code._1030))
 
     @property
     def params(self) -> dict[str, Any]:


### PR DESCRIPTION
This PR adds follow-up fixes for strict type checking CI errors.
- **Typing Fixes:** Adds explicit `cast` to device properties to satisfy strict Mypy `no-any-return` errors.
These changes ensure the CI pipeline passes completely.

Developed for PR #437, after CI errors where found after PR submitted, but the PR was merged before these fixes could be added to the PR