### PR TITLE
fix: progressive logging for benign FSM packet anomalies

### DIFF
--- a/src/ramses_tx/protocol_fsm.py
+++ b/src/ramses_tx/protocol_fsm.py
@@ -597,8 +597,17 @@ class WantEcho(ProtocolStateBase):
                 )
             )
         ):
-            _LOGGER.warning(
-                "%s: Invalid state to receive a reply (expecting echo)", self._context
+            if self._context._cmd_tx_count < 3:
+                level = logging.DEBUG
+            elif self._context._cmd_tx_count == 3:
+                level = logging.INFO
+            else:
+                level = logging.WARNING
+
+            _LOGGER.log(
+                level,
+                "%s: Invalid state to receive a reply (expecting echo)",
+                self._context,
             )
 
             self._rply_pkt = pkt
@@ -663,8 +672,17 @@ class WantRply(ProtocolStateBase):
         # 2024-04-16 08:28:33.910 052 RQ --- 01:145038 10:048122 --:------ 3220 005 0000110000  # 3220|RQ|10:048122|11
 
         if pkt._hdr == self._sent_cmd.tx_header and pkt.src == self._echo_pkt.src:
-            _LOGGER.warning(
-                "%s: Invalid state to receive an echo (expecting reply)", self._context
+            if self._context._cmd_tx_count < 3:
+                level = logging.DEBUG
+            elif self._context._cmd_tx_count == 3:
+                level = logging.INFO
+            else:
+                level = logging.WARNING
+
+            _LOGGER.log(
+                level,
+                "%s: Invalid state to receive an echo (expecting reply)",
+                self._context,
             )
             return  # do not transition, wait until existing timer expires
 


### PR DESCRIPTION
### The Problem:

Currently, the `protocol_fsm` logs a full `WARNING` immediately when encountering certain common RF artifacts. specifically:
1. **Missing Echo:** Receiving a valid Reply while still in the `WantEcho` state (the Echo was lost or the device was faster than the FSM).
2. **Duplicate Echo:** Receiving a second Echo while already in the `WantRply` state (benign re-transmission).

While technically "invalid" state transitions, these are frequent and expected occurrences in an RF mesh environment. Logging them as warnings on the first occurrence creates significant "log noise," causing alert fatigue and leading users to believe their system is unstable.

### Consequences:
- **User Confusion:** Users report benign RF collisions as critical bugs.
- **Log Bloat:** High-volume logs are filled with "Invalid state" warnings during normal operation.
- **Alert Fatigue:** Genuine connectivity issues are harder to spot amidst the noise.

### The Fix:

This PR extends the "progressive logging" strategy introduced in **PR #426** to the packet reception logic. Instead of immediately logging a `WARNING`, the FSM will now log these events as `DEBUG` for the first few attempts, escalating to `INFO` and then `WARNING` only if the command requires multiple retries.

### Technical Implementation:

Modified `src/ramses_tx/protocol_fsm.py`:
- **`WantEcho.pkt_rcvd`:** Wrapped the "Invalid state (expecting echo)" log call with a check against `self._context._cmd_tx_count`.
  - `tx_count < 3`: Log level `DEBUG`
  - `tx_count == 3`: Log level `INFO`
  - `tx_count > 3`: Log level `WARNING`
- **`WantRply.pkt_rcvd`:** Applied the same logic to the "Invalid state (expecting reply)" log call triggered by duplicate Echos.

### Testing Performed:
- **Static Analysis:** Passed `mypy` (strict mode) with no errors.
- **Unit Tests:** Ran the full `pytest` suite for the project and verified all tests passed without regression.

### Risks of NOT Implementing:

Leaving the code as-is perpetuates the issue of log noise, making it difficult for developers and users to distinguish between transient RF noise and actual protocol failures.

### Risks of Implementing:
- **Reduced Visibility:** There is a minor risk that a genuine, persistent protocol error could be masked as a `DEBUG` log if it resolves itself within 1-2 retries (though this is arguably the desired behavior for self-healing mesh networks).

### Mitigation Steps:
- **Escalation Logic:** The logging is not suppressed entirely; it merely escalates. If the condition persists (reaching retry limit), a `WARNING` is still generated, ensuring persistent issues remain visible.