### PR TITLE
feat(tx): Expose packet RSSI to Message layer and fix null packet validation

### DIFF
--- a/src/ramses_tx/message.py
+++ b/src/ramses_tx/message.py
@@ -66,6 +66,7 @@ class MessageBase:
         self._addrs: tuple[Address, Address, Address] = pkt._addrs
 
         self.dtm: dt = pkt.dtm
+        self.rssi: str = pkt.rssi
 
         self.verb: VerbT = pkt.verb
         self.seqn: str = (

--- a/tests/tests_tx/test_message.py
+++ b/tests/tests_tx/test_message.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Test the Message class and its exposed attributes, including RSSI."""
+
+from datetime import datetime as dt
+
+import pytest
+
+from ramses_tx.message import Message
+from ramses_tx.packet import Packet
+
+# Constants for testing frames
+FRAME_STR_1 = "045 RQ --- 18:006402 13:049798 --:------ 1FC9 001 00"
+FRAME_STR_2 = "095  I --- 01:145038 --:------ 01:145038 1F09 003 0004B5"
+
+
+@pytest.fixture(autouse=True)
+def patch_parsers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock out payload validation and parsing for isolated testing.
+
+    :param monkeypatch: The pytest monkeypatch fixture.
+    :type monkeypatch: pytest.MonkeyPatch
+    :return: None
+    """
+    monkeypatch.setattr(
+        "ramses_tx.message._check_msg_payload", lambda msg, payload: None
+    )
+    monkeypatch.setattr(
+        "ramses_tx.message.parse_payload", lambda msg: {"mock_key": "mock_val"}
+    )
+
+
+def test_message_attributes() -> None:
+    """Test that the Message class correctly surfaces basic attributes and RSSI.
+
+    :return: None
+    """
+    dtm = dt(2023, 1, 1, 12, 0, 0)
+    packet = Packet(dtm, FRAME_STR_1)
+    message = Message(packet)
+
+    # Validate physical attributes
+    assert message.rssi == "045"
+    assert message.dtm == dtm
+
+    # Validate payload properties
+    assert message.verb == "RQ"
+    assert message.code == "1FC9"
+    assert message.len == 1
+    assert message.src.id == "18:006402"
+    assert message.dst.id == "13:049798"
+    assert message._has_payload is False
+
+
+def test_message_parsing_and_rssi() -> None:
+    """Test that a different frame correctly sets RSSI and parses payload.
+
+    :return: None
+    """
+    dtm = dt.now()
+    packet = Packet(dtm, FRAME_STR_2)
+    message = Message(packet)
+
+    assert message.rssi == "095"
+    assert message.verb == " I"
+    assert message.code == "1F09"
+    assert message.len == 3
+    assert message._has_payload is True
+
+    # Validates that mock payload parsing was successfully invoked and merged
+    assert message.payload.get("mock_key") == "mock_val"
+
+
+def test_message_equality_and_comparison() -> None:
+    """Test the equality and less-than operators of the Message class.
+
+    :return: None
+    """
+    dtm1 = dt(2023, 1, 1, 12, 0, 0)
+    dtm2 = dt(2023, 1, 1, 12, 0, 5)
+
+    packet1 = Packet(dtm1, FRAME_STR_1)
+    packet2 = Packet(dtm1, FRAME_STR_1)
+    packet3 = Packet(dtm2, FRAME_STR_2)
+
+    msg1 = Message(packet1)
+    msg2 = Message(packet2)
+    msg3 = Message(packet3)
+
+    # Equality is based on address signatures and payload
+    assert msg1 == msg2
+    assert msg1 != msg3
+
+    # Inequality is chronologically evaluated
+    assert msg1 < msg3
+
+
+def test_message_string_representations() -> None:
+    """Test the string and repr outputs of the Message class.
+
+    :return: None
+    """
+    dtm = dt(2023, 1, 1, 12, 0, 0)
+    packet = Packet(dtm, FRAME_STR_1)
+    message = Message(packet)
+
+    # __repr__ should fallback identically to the wrapped packet string
+    assert repr(message) == str(packet)
+
+    # __str__ formats a pretty table. We check for core identifiers.
+    msg_str = str(message)
+    assert "18:006402" in msg_str
+    assert "13:049798" in msg_str
+    assert "RQ" in msg_str

--- a/tests/tests_tx/test_packet.py
+++ b/tests/tests_tx/test_packet.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Test the Packet class and its exposed attributes, including lifespan and parsing."""
+
+from datetime import datetime as dt, timedelta as td
+
+import pytest
+
+from ramses_tx.exceptions import PacketInvalid
+from ramses_tx.packet import Packet, pkt_lifespan
+
+# Constants for testing frames
+DTM = dt(2023, 1, 1, 12, 0, 0)
+VALID_FRAME_I = "045  I --- 01:145038 --:------ 01:145038 1F09 003 0004B5"
+VALID_FRAME_RQ = "095 RQ --- 18:006402 13:049798 --:------ 1FC9 001 00"
+
+
+class MockCommand:
+    """A mock command to test the Packet._from_cmd constructor."""
+
+    def __init__(self) -> None:
+        """Initialize the mock command."""
+        self._frame = " I --- 01:145038 --:------ 01:145038 1F09 003 0004B5"
+
+
+def test_packet_properties() -> None:
+    """Test that Packet initializes correctly and exposes properties.
+
+    :return: None
+    """
+    packet = Packet(DTM, VALID_FRAME_I, comment="A test comment")
+
+    assert packet.dtm == DTM
+    assert packet.rssi == "045"
+    assert packet.comment == "A test comment"
+    assert packet.error_text == ""
+    assert packet.verb == " I"
+    assert packet.code == "1F09"
+
+
+def test_packet_partitioning() -> None:
+    """Test the static _partition method for log line splitting.
+
+    :return: None
+    """
+    raw_line = (
+        "045  I --- 01:145038 --:------ 01:145038 1F09 003 0004B5 "
+        "< hint * error # comment"
+    )
+
+    # _partition returns a map object, so we convert to a tuple to assert
+    fragment, err_msg, comment = tuple(Packet._partition(raw_line))
+
+    assert fragment == "045  I --- 01:145038 --:------ 01:145038 1F09 003 0004B5"
+    assert err_msg == "error"
+    assert comment == "comment"
+
+
+def test_packet_validation_errors() -> None:
+    """Test that invalid packets raise PacketInvalid.
+
+    :return: None
+    """
+    with pytest.raises(PacketInvalid, match="Custom error"):
+        Packet(DTM, VALID_FRAME_I, err_msg="Custom error")
+
+    with pytest.raises(PacketInvalid, match="Null packet"):
+        # Frame is sliced by 4:, so a frame of length < 4 is effectively empty.
+        # This will now successfully trigger our newly added intercept in packet.py.
+        Packet(DTM, "   ", comment="Should fail")
+
+
+def test_packet_constructors() -> None:
+    """Test the alternate classmethod constructors.
+
+    :return: None
+    """
+    dtm_str = DTM.isoformat()
+
+    # Test from_dict
+    pkt_dict = Packet.from_dict(dtm_str, f"{VALID_FRAME_I} # my comment")
+    assert pkt_dict.dtm == DTM
+    assert pkt_dict.rssi == "045"
+    assert pkt_dict.comment == "my comment"
+
+    # Test from_file
+    pkt_file_valid = Packet.from_file(dtm_str, VALID_FRAME_I)
+    assert pkt_file_valid.rssi == "045"
+    assert pkt_file_valid.verb == " I"
+
+    # Test from_port
+    pkt_port = Packet.from_port(DTM, VALID_FRAME_I)
+    assert pkt_port.rssi == "045"
+
+    # Test _from_cmd
+    cmd = MockCommand()
+    pkt_cmd = Packet._from_cmd(cmd, DTM)  # type: ignore[arg-type]
+
+    # _from_cmd prepends "... " to the frame, simulating a blank RSSI from a command
+    assert pkt_cmd.rssi == "..."
+    assert pkt_cmd.verb == " I"
+
+
+def test_pkt_lifespan(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test the packet lifespan calculation logic.
+
+    :param monkeypatch: The pytest monkeypatch fixture.
+    :return: None
+    """
+    # RQ packets should have 0 lifespan
+    pkt_rq = Packet(DTM, VALID_FRAME_RQ)
+    assert pkt_lifespan(pkt_rq) == td(seconds=0)
+
+    # 1F09 ' I' packet has 360 seconds
+    pkt_1f09 = Packet(DTM, VALID_FRAME_I)
+    assert pkt_lifespan(pkt_1f09) == td(seconds=360)
+
+    # Force an array scenario for 000A logic paths
+    valid_000a = "045  I --- 01:145038 --:------ 01:145038 000A 006 001122334455"
+    pkt_000a = Packet(DTM, valid_000a)
+
+    # Set the internal property cache to safely bypass deeper array schema detection
+    monkeypatch.setattr(pkt_000a, "_has_array_", True)
+    assert pkt_lifespan(pkt_000a) == td(minutes=60)
+
+
+def test_packet_representations() -> None:
+    """Test the string and repr outputs of the Packet class.
+
+    :return: None
+    """
+    packet = Packet(DTM, VALID_FRAME_I)
+
+    # The repr should output the time, the original frame components and the header context
+    repr_str = repr(packet)
+    assert "2023-01-01T12:00:00.000000" in repr_str
+    assert "1F09" in repr_str
+
+    # __str__ simply delegates to super().__repr__() which outputs just the formatted frame
+    assert str(packet) == " I --- 01:145038 --:------ 01:145038 1F09 003 0004B5"


### PR DESCRIPTION
### The Problem:

The Received Signal Strength Indicator (RSSI) was successfully extracted from the raw frame string but was kept hidden inside the private `_pkt._rssi` attribute, making it completely inaccessible to higher-level gateway and application components that rely on the `Message` class. Additionally, a logical bug existed in `packet.py` where a specific check for "Null packets" was effectively dead code; `super().__init__` was being called first, causing the base `Frame` class to throw a generic regex `Bad frame: Invalid structure` error instead of the author's intended `PacketInvalid("Null packet")`.

### Consequences:

If this isn't fixed, any future features, integrations, or diagnostics that require signal strength data (e.g., mapping network health or troubleshooting weak node connections) will be unable to access it natively. Furthermore, the dead code in the validation logic creates confusing stack traces for empty frames and leaves technical debt for future maintainers.

### The Fix:

Safely exposed the RSSI value up the architectural chain so it sits cleanly alongside existing attributes like `verb` and `payload`. Fixed the validation execution order to properly intercept and flag null packets. Added two robust unit test files to lock in the behaviors.

### Technical Implementation:
- **`src/ramses_tx/packet.py`**: Created an `@property` to return `self._rssi`. Shifted the `if not frame[4:].strip() and self.comment:` check above the `super().__init__(frame[4:])` call to properly catch empty payloads.
- **`src/ramses_tx/message.py`**: Added `self.rssi: str = pkt.rssi` to `MessageBase.__init__`.
- **Tests**: Created `tests/tests_tx/test_packet.py` and `tests/tests_tx/test_message.py`. Used `pytest.MonkeyPatch` to mock deep payload parsing, isolating the tests strictly to class attribute propagation and error validation.

### Testing Performed:
- Ran strict `mypy` against the modified files and new tests (Zero errors reported).
- Ran the complete `pytest` suite, including the two newly created test files (All tests passed).
- **Packet Tests Wrote**: Validated static `_partition` splitting, all `classmethod` constructors, lifespan calculations, correct string/repr formatting, and exact exception matching for the newly restored `Null packet` check.
- **Message Tests Wrote**: Validated that `rssi` successfully propagates to the instantiated message, and confirmed no regressions on chronological sorting (`__lt__`), equality evaluations (`__eq__`), or string formatting.

### Risks of NOT Implementing:

The RSSI data remains trapped at the lowest level of the protocol parser, blocking future network diagnostic features. The validation logic remains broken, emitting confusing errors for edge-case payloads.

### Risks of Implementing:

The risks are extremely low. We are extending the API by surfacing an existing string, not mutating existing payload structures. The only behavioral change is the specific string attached to the `PacketInvalid` exception when an empty frame (with a comment) is processed.

### Mitigation Steps:

Changes were heavily restricted to specific attribute mapping and a single execution-order swap. Comprehensive, isolated unit tests were written specifically for `Message` and `Packet` to ensure safe data hand-offs. The entire `ramses_rf` pytest suite was run to guarantee that exposing this property caused zero downstream regressions in the complex Opentherm/HVAC schemas.