### PR TITLE
Refactor: Extract QoS management from Protocol FSM

### DIFF
--- a/src/ramses_tx/protocol/core.py
+++ b/src/ramses_tx/protocol/core.py
@@ -137,7 +137,7 @@ class PortProtocol(_DeviceIdFilterMixin):
         if not self._context:
             return super().__repr__()
         cls = self._context.state.__class__.__name__
-        return f"QosProtocol({cls}, len(queue)={self._context._que.qsize()})"
+        return f"QosProtocol({cls}, len(queue)={self._context.qsize})"
 
     def connection_made(  # type: ignore[override]
         self, transport: TransportInterface, /, *, ramses: bool = False

--- a/src/ramses_tx/protocol/qos.py
+++ b/src/ramses_tx/protocol/qos.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""RAMSES RF - RAMSES-II compatible packet protocol QoS management.
+
+This module provides the QosManager class, responsible for handling
+command queuing, priority, retry limits, and dynamic timeouts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime as dt
+from queue import Empty, Full, PriorityQueue
+from threading import Lock
+from typing import TypeAlias
+
+from ..command import Command
+from ..const import (
+    DEFAULT_BUFFER_SIZE,
+    DEFAULT_ECHO_TIMEOUT,
+    DEFAULT_RPLY_TIMEOUT,
+    MAX_RETRY_LIMIT,
+    MAX_SEND_TIMEOUT,
+    Priority,
+)
+from ..exceptions import ProtocolSendFailed
+from ..packet import Packet
+from ..typing import QosParams
+
+_LOGGER = logging.getLogger(__name__)
+
+_FutureT: TypeAlias = asyncio.Future[Packet]
+_QueueEntryT: TypeAlias = tuple[Priority, dt, Command, QosParams, _FutureT]
+
+
+class QosManager:
+    """Manages the Quality of Service (QoS) queue and retry limits."""
+
+    SEND_TIMEOUT_LIMIT = MAX_SEND_TIMEOUT
+
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        *,
+        echo_timeout: float = DEFAULT_ECHO_TIMEOUT,
+        reply_timeout: float = DEFAULT_RPLY_TIMEOUT,
+        max_retry_limit: int = MAX_RETRY_LIMIT,
+        max_buffer_size: int = DEFAULT_BUFFER_SIZE,
+    ) -> None:
+        """Initialize the QoS manager.
+
+        :param loop: The asyncio event loop.
+        :type loop: asyncio.AbstractEventLoop
+        :param echo_timeout: Timeout for an echo response.
+        :type echo_timeout: float
+        :param reply_timeout: Timeout for a full reply response.
+        :type reply_timeout: float
+        :param max_retry_limit: Maximum number of times to retry a send.
+        :type max_retry_limit: int
+        :param max_buffer_size: Maximum size of the command queue.
+        :type max_buffer_size: int
+        """
+        self._loop = loop
+        self.echo_timeout = echo_timeout
+        self.reply_timeout = reply_timeout
+        self.max_retry_limit = min(max_retry_limit, MAX_RETRY_LIMIT)
+        self.max_buffer_size = min(max_buffer_size, DEFAULT_BUFFER_SIZE)
+
+        self._lock = Lock()
+        self._que: PriorityQueue[_QueueEntryT] = PriorityQueue(
+            maxsize=self.max_buffer_size
+        )
+
+        self._multiplier: int = 0
+        self.cmd: Command | None = None
+        self.qos: QosParams | None = None
+        self.fut: _FutureT | None = None
+        self.tx_count: int = 0
+        self.tx_limit: int = 0
+
+    @property
+    def is_active(self) -> bool:
+        """Return True if a command is currently being processed."""
+        return self.cmd is not None
+
+    @property
+    def qsize(self) -> int:
+        """Return the number of commands currently in the queue."""
+        return self._que.qsize()
+
+    def enqueue(self, priority: Priority, cmd: Command, qos: QosParams) -> _FutureT:
+        """Add a command to the queue and return its future.
+
+        :param priority: The transmission priority.
+        :type priority: Priority
+        :param cmd: The command to transmit.
+        :type cmd: Command
+        :param qos: Quality of Service parameters.
+        :type qos: QosParams
+        :return: The future representing the expected response.
+        :rtype: _FutureT
+        :raises ProtocolSendFailed: If the send buffer is full.
+        """
+        fut: _FutureT = self._loop.create_future()
+        try:
+            self._que.put_nowait((priority, dt.now(), cmd, qos, fut))
+        except Full as err:
+            fut.cancel("Send buffer overflow")
+            raise ProtocolSendFailed("Send buffer overflow") from err
+        return fut
+
+    def get_next(self) -> bool:
+        """Retrieve the next command from the queue.
+
+        :return: True if a new command was successfully loaded.
+        :rtype: bool
+        """
+        self._lock.acquire()
+
+        if self.fut is not None and not self.fut.done():
+            self._lock.release()
+            return False
+
+        while True:
+            try:
+                *_, self.cmd, self.qos, self.fut = self._que.get_nowait()
+            except Empty:
+                self.reset_active()
+                self._lock.release()
+                return False
+
+            assert self.qos is not None
+            self.tx_count = 0
+            self.tx_limit = min(self.qos.max_retries, self.max_retry_limit) + 1
+
+            if self.fut is not None and self.fut.done():
+                self._que.task_done()
+                continue
+            break
+
+        self._lock.release()
+        return True
+
+    def task_done(self) -> None:
+        """Mark the active queued task as done."""
+        self._que.task_done()
+
+    def reset_active(self) -> None:
+        """Reset the currently active command state."""
+        self.cmd = self.qos = self.fut = None
+        self.tx_count = 0
+
+    def get_and_update_delay(self, is_echo: bool) -> tuple[float, int]:
+        """Calculate delay and update the multiplier.
+
+        :param is_echo: True if waiting for an echo, False for a reply.
+        :type is_echo: bool
+        :return: A tuple of the calculated delay and the old multiplier value.
+        :rtype: tuple[float, int]
+        """
+        if is_echo:
+            delay = self.echo_timeout * (2**self._multiplier)
+        else:
+            delay = self.reply_timeout * (2**self._multiplier)
+
+        old_val = self._multiplier
+        self._multiplier = max(0, self._multiplier - 1)
+        return delay, old_val
+
+    def restore_multiplier(self, old_val: int) -> None:
+        """Restore and increment the multiplier after a timeout sleep.
+
+        :param old_val: The previous multiplier value.
+        :type old_val: int
+        """
+        self._multiplier = min(3, old_val + 1)


### PR DESCRIPTION
### The Problem:

The `ProtocolContext` class inside the finite state machine (`fsm.py`) was violating the Single Responsibility Principle (SRP). It was simultaneously responsible for managing discrete state transitions (Idle -> WantEcho -> WantRply) *and* handling the Quality of Service (QoS) queue, buffer overflows, retry limits, and dynamic timeout multiplier logic.

### Consequences:

Coupling queue management with state machine transitions makes the FSM highly fragile and extremely difficult to test in isolation. It also makes extending the QoS logic (e.g., adding advanced backoff algorithms or priority re-sorting) highly risky, as it could unintentionally break the core protocol state transitions.

### The Fix:

Extracted all QoS, retry, and queue management logic into a dedicated, isolated `QosManager` class, and injected it into the `ProtocolContext`.

### Technical Implementation:
- **Created `qos.py`:** Built the `QosManager` class to encapsulate the `PriorityQueue`, track `tx_count` / `tx_limit`, manage buffer sizes, and calculate dynamic timeouts (the multiplier backoff).
- **Refactored `ProtocolContext`:** Stripped raw queue variables (`self._que`, `self._multiplier`) from the context. The FSM now delegates all queue-related queries (`enqueue`, `get_next`, `get_and_update_delay`) to `self._qos_mgr`.
- **Backward Compatibility:** Implemented `@property` decorators on `ProtocolContext` (e.g., `_cmd_tx_count`, `max_retry_limit`) to safely expose the underlying `QosManager` states, ensuring the existing rigorous test suite (`test_protocol_fsm.py`) passes without requiring a complete rewrite of the tests.

### Testing Performed:
- Ran the complete `pytest` suite (`test_protocol_fsm.py`, etc.). The FSM still correctly handles backoffs, queue overflows, and retries natively through the new manager. All tests pass.
- Ran `mypy` to verify strict typing compliance. No union-attribute or signature errors exist.

### Risks of NOT Implementing:

The FSM class would continue to bloat as more edge-cases for message delivery are added, eventually leading to unmaintainable spaghetti code where state logic and delivery logic are indistinguishable.

### Risks of Implementing:

Potential race conditions or queue locking issues if the FSM attempts to clear or access the queue asynchronously while the `QosManager` is mid-transition.

### Mitigation Steps:

Used thread-safe primitives (`PriorityQueue`, `Lock`) within the `QosManager` exactly as they were used in the original context. Preserved the precise logical flow of `_check_buffer_for_cmd` to ensure the asynchronous orchestration remains identical.