### PR TITLE
Refactor: Eliminate circular dependencies and enforce strict interface contracts in ramses_rf

### DIFF
--- a/src/ramses_rf/interfaces.py
+++ b/src/ramses_rf/interfaces.py
@@ -1,0 +1,133 @@
+"""RAMSES RF - Abstract Base Classes and Interfaces."""
+
+from typing import TYPE_CHECKING, Any, Protocol
+
+from ramses_tx import Code, Command, Message, Packet, Priority
+
+from .typing import DeviceIdT
+
+if TYPE_CHECKING:
+    from .entity_base import Parent
+
+
+class MessageIndexInterface(Protocol):
+    """Interface for the SQLite Message Index database."""
+
+    def add(self, msg: Message) -> Message | None:
+        """Add a message to the index."""
+        ...
+
+    def add_record(
+        self, src: str, code: str = "", verb: str = "", payload: str = "00"
+    ) -> None:
+        """Add a single record to the index."""
+        ...
+
+    def rem(
+        self, msg: Message | None = None, **kwargs: Any
+    ) -> tuple[Message, ...] | None:
+        """Remove a set of message(s) from the index."""
+        ...
+
+    def get(self, msg: Message | None = None, **kwargs: Any) -> tuple[Message, ...]:
+        """Get a set of message(s) from the index."""
+        ...
+
+    def contains(self, **kwargs: Any) -> bool:
+        """Check if the index contains at least 1 record matching the fields."""
+        ...
+
+    def qry(self, sql: str, parameters: tuple[str, ...]) -> tuple[Message, ...]:
+        """Execute a custom SQL query returning messages."""
+        ...
+
+    def qry_field(self, sql: str, parameters: tuple[str, ...]) -> list[tuple[Any, ...]]:
+        """Execute a custom SQL query returning raw fields."""
+        ...
+
+    def get_rp_codes(self, parameters: tuple[str, ...]) -> list[Code]:
+        """Get a list of Codes from the index."""
+        ...
+
+    def all(self, include_expired: bool = False) -> tuple[Message, ...]:
+        """Get all messages from the index."""
+        ...
+
+    def flush(self) -> None:
+        """Flush the storage worker queue."""
+        ...
+
+    def stop(self) -> None:
+        """Stop the database and close connections."""
+        ...
+
+
+class DeviceInterface(Protocol):
+    """Interface for a standard RF Device."""
+
+    @property
+    def id(self) -> DeviceIdT:
+        """Return the device ID.
+
+        :return: The Device ID.
+        """
+        ...
+
+    @property
+    def traits(self) -> dict[str, Any]:
+        """Return the device traits.
+
+        :return: A dictionary of device traits.
+        """
+        ...
+
+    def _handle_msg(self, msg: Message) -> None:
+        """Process an incoming message.
+
+        :param msg: The message to process.
+        """
+        ...
+
+
+class GatewayInterface(Protocol):
+    """Interface for the core Gateway orchestrator."""
+
+    @property
+    def msg_db(self) -> MessageIndexInterface | None:
+        """Return the message database if configured."""
+        ...
+
+    @msg_db.setter
+    def msg_db(self, value: MessageIndexInterface | None) -> None:
+        """Set the message database."""
+        ...
+
+    @property
+    def config(self) -> Any:
+        """Return the gateway configuration."""
+        ...
+
+    def get_device(
+        self,
+        device_id: DeviceIdT,
+        *,
+        msg: Message | None = None,
+        parent: "Parent | None" = None,
+        child_id: str | None = None,
+        is_sensor: bool | None = None,
+    ) -> DeviceInterface:
+        """Retrieve or create a device."""
+        ...
+
+    async def async_send_cmd(
+        self,
+        cmd: Command,
+        /,
+        *,
+        priority: Priority = Priority.DEFAULT,
+        wait_for_reply: bool | None = True,
+        max_retries: int = 3,
+        timeout: float = 3.0,
+    ) -> Packet:
+        """Send a command asynchronously and return the resulting packet."""
+        ...

--- a/src/ramses_rf/typing.py
+++ b/src/ramses_rf/typing.py
@@ -1,0 +1,11 @@
+"""RAMSES RF - Domain-specific type definitions."""
+
+from typing import Any, TypeAlias
+
+from ramses_tx.typing import DeviceIdT as TxDeviceIdT, DevIndexT as TxIndexT
+
+DeviceIdT: TypeAlias = TxDeviceIdT
+IndexT: TypeAlias = TxIndexT
+
+DeviceTraitsT: TypeAlias = dict[str, Any]
+DeviceListT: TypeAlias = dict[DeviceIdT, DeviceTraitsT]


### PR DESCRIPTION
### The Problem:

The application layer (`ramses_rf`) heavily relies on inline imports hidden inside method bodies to circumvent circular dependency crashes during module load (e.g., `entity_base.py` importing concrete devices directly inside `set_parent`). Additionally, the lack of explicit API contracts makes domain objects tightly coupled, blocking static type checkers from analyzing the full object graph.

### Consequences:

Static type checking (Mypy) cannot verify type safety across domain boundaries. The codebase is artificially locked together, making it impossible to decompose monolithic files or extract logic into separate modules without breaking the fragile dependency graph.

### The Fix:

Extracted shared domain types and protocol interfaces into dedicated files. Removed the hidden inline dependencies and migrated the parent/child hierarchy logic to rely on abstract interface compliance and duck typing.

### Technical Implementation:
- Added `src/ramses_rf/typing.py` to consolidate shared type aliases (e.g., `DeviceListT`, `DeviceIdT`).
- Added `src/ramses_rf/interfaces.py` defining strict `typing.Protocol` classes (`GatewayInterface`, `DeviceInterface`, `MessageIndexInterface`).
- Updated `src/ramses_rf/gateway.py` to implement `GatewayInterface`, converting dynamic attributes to explicit properties and setters to satisfy interface constraints.
- Purged all `from .device import ...` and `from .system import ...` inline imports from `src/ramses_rf/entity_base.py`.
- Replaced concrete `isinstance` logic in `_get_parent` and `set_parent` with structural duck-typing (`hasattr`), runtime class string mapping (`__class__.__name__`), and explicit `typing.cast()` for Mypy compliance.

### Testing Performed:
- Ran the full `pytest` suite, validating that the transition from `isinstance` checks to duck-typing did not break the parent-child node graph, packet processing, or SQLite message storage.
- Statically analyzed the entire codebase with `mypy` (strict mode), resolving all interface overrides, list-item mismatches, and abstract property errors.

### Risks of NOT Implementing:

The architectural debt will indefinitely block the future decomposition of monolithic God objects (like `entity_base.py` and `Gateway`). Attempting to add new device models or features will require injecting even more fragile inline imports.

### Risks of Implementing:

There is a slight risk of subtle regressions during device discovery or tree-hierarchy mapping if the new duck-typing conditions fail to match edge cases previously handled by the strict `isinstance` logic.

### Mitigation Steps:

Enforced 100% strict Mypy compliance in the modified files, replacing loose `**kwargs` and generic mappings with explicit structural typing. Relied on the comprehensive automated test suite which aggressively asserts the topology and schema configurations. Preserved all explicit exception handling (`TypeError`, `SystemSchemaInconsistent`) to ensure any invalid hierarchies fail fast and loudly.