### PR TITLE
Fix: Export CallbackTransport from ramses_tx.transport to resolve ImportError

### DIFF
--- a/src/ramses_tx/transport/__init__.py
+++ b/src/ramses_tx/transport/__init__.py
@@ -8,12 +8,14 @@ Operates at the pkt layer of: app - msg - pkt - h/w
 from __future__ import annotations
 
 from .base import TransportConfig as TransportConfig
+from .callback import CallbackTransport as CallbackTransport
 from .factory import (
     RamsesTransportT as RamsesTransportT,
     transport_factory as transport_factory,
 )
 
 __all__ = [
+    "CallbackTransport",
     "RamsesTransportT",
     "TransportConfig",
     "transport_factory",


### PR DESCRIPTION
### The Problem:

The `CallbackTransport` class was missing from the `ramses_tx.transport` package's public API. When external packages like `ramses_cc` attempted to import it (`from ramses_tx.transport import CallbackTransport`), it resulted in an `ImportError` (Issue #473).

### Consequences:

The Home Assistant custom integration `ramses_cc` completely fails during setup, rendering the integration unusable for users after the recent updates.

### The Fix:

Exposed the `CallbackTransport` class through the `ramses_tx.transport` package's `__init__.py` file.

### Technical Implementation:

Added the statement `from .callback import CallbackTransport as CallbackTransport` to `src/ramses_tx/transport/__init__.py` and appended `"CallbackTransport"` to the `__all__` list. The redundant alias (`as CallbackTransport`) was deliberately used to ensure strict compliance with Mypy's explicit re-export rules while satisfying Ruff linting constraints.

### Testing Performed:

Verified the syntax and import structures against strict Mypy type-checking and Ruff linting rules to ensure no regressions in code quality standards.

### Risks of NOT Implementing:

If left unfixed, `ramses_cc` will remain broken for all Home Assistant users pulling the latest versions of `ramses_rf`/`ramses_tx`, leading to widespread integration failures.

### Risks of Implementing:

Extremely low. The change purely exposes an already defined class to the public API namespace without altering any underlying logic or execution flow.

### Mitigation Steps:

Adhered strictly to the existing type-safe import patterns (redundant aliases and `__all__` definitions) to prevent downstream static analysis tools from complaining about implicit exports.