### PR TITLE
Fix: Restore legacy kwargs support in Gateway init to resolve ramses_cc TypeError

### DIFF
--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import warnings
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from logging.handlers import QueueListener
@@ -105,8 +106,7 @@ class Gateway(Engine, GatewayInterface):
 
     def __init__(
         self,
-        port_name: str | None,
-        /,
+        port_name: str | None = None,
         *,
         config: GatewayConfig | None = None,
         schema: dict[str, Any] | None = None,
@@ -123,6 +123,7 @@ class Gateway(Engine, GatewayInterface):
         disable_qos: bool | None = None,
         enforce_known_list: bool = False,
         evofw_flag: str | None = None,
+        **kwargs: Any,
     ) -> None:
         """Initialize the Gateway instance.
 
@@ -158,7 +159,17 @@ class Gateway(Engine, GatewayInterface):
         :type enforce_known_list: bool, optional
         :param evofw_flag: Specific flag for evofw3 usage.
         :type evofw_flag: str | None, optional
+        :param kwargs: Catch-all for legacy keyword arguments.
+        :type kwargs: Any
         """
+        if kwargs:
+            warnings.warn(
+                "Initializing Gateway with undocumented **kwargs is deprecated. "
+                "Please transition to using GatewayConfig.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         if debug_mode:
             _LOGGER.setLevel(logging.DEBUG)
 

--- a/tests/tests_rf/test_gateway.py
+++ b/tests/tests_rf/test_gateway.py
@@ -1,0 +1,60 @@
+"""Tests for the Gateway backward compatibility and deprecation shims."""
+
+import warnings
+
+import pytest
+
+from ramses_rf.gateway import Gateway
+
+
+@pytest.mark.asyncio
+async def test_gateway_positional_port_name() -> None:
+    """
+    Test that initializing Gateway with a positional port_name succeeds.
+
+    This ensures standard initialization does not trigger deprecation warnings.
+
+    :returns: None
+    """
+    with warnings.catch_warnings(record=True) as recorded_warnings:
+        warnings.simplefilter("always")
+        Gateway("/dev/null")
+
+    deprecation_warnings = [
+        w for w in recorded_warnings if issubclass(w.category, DeprecationWarning)
+    ]
+    assert len(deprecation_warnings) == 0
+
+
+@pytest.mark.asyncio
+async def test_gateway_keyword_port_name() -> None:
+    """
+    Test that port_name can be passed as a keyword argument.
+
+    This specifically tests the fix for Issue #501 where the positional-only
+    marker ('/') caused a TypeError for legacy integrations like ramses_cc.
+
+    :returns: None
+    """
+    with warnings.catch_warnings(record=True) as recorded_warnings:
+        warnings.simplefilter("always")
+        Gateway(port_name="/dev/null")
+
+    deprecation_warnings = [
+        w for w in recorded_warnings if issubclass(w.category, DeprecationWarning)
+    ]
+    assert len(deprecation_warnings) == 0
+
+
+@pytest.mark.asyncio
+async def test_gateway_legacy_kwargs_warning() -> None:
+    """
+    Test that passing undefined kwargs triggers a DeprecationWarning.
+
+    This ensures that older versions of ramses_cc passing arbitrary kwargs
+    do not crash (TypeError), but do notify the user to upgrade their config.
+
+    :returns: None
+    """
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        Gateway(port_name="/dev/null", legacy_unsupported_flag=True)


### PR DESCRIPTION
### The Problem:

Current `master` of `ramses_rf` rejects configuration keyword arguments from `ramses_cc` (e.g., version 0.54.3). The `Gateway.__init__` signature was recently updated to use positional-only arguments (`/`), which causes a `TypeError` when `ramses_cc` passes `port_name` as a keyword argument during `_create_client` unpacking. This specifically addresses Issue ramses-rf/ramses_cc#501.

### Consequences:

If this isn't fixed, `ramses_cc` fails to initialize the `Gateway` entirely, resulting in a hard crash during the Home Assistant integration setup phase. Users updating to the latest `ramses_rf` backend will experience a total silent failure of their RF network integration.

### The Fix:

Removed the positional-only restriction for core gateway parameters and reintroduced a catch-all for legacy keyword arguments. Legacy arguments now trigger a soft deprecation warning rather than a fatal exception.

### Technical Implementation:
- Removed the `/` positional-only marker from the `Gateway.__init__` signature in `src/ramses_rf/gateway.py`.
- Added `**kwargs: Any` to the initialization signature to safely absorb dynamically unpacked dictionaries from older consumers.
- Wrapped the presence of `kwargs` in a check that emits a `DeprecationWarning`, pointing integrators toward the upcoming `GatewayConfig` DTO pattern.

### Testing Performed:

Created `tests/tests_rf/test_gateway.py` with `pytest.mark.asyncio` markers to ensure the event loop behaves correctly during instantiation. The test suite covers:
1. `test_gateway_positional_port_name`: Verifies standard initialization succeeds without warnings.
2. `test_gateway_keyword_port_name`: Verifies `port_name="/dev/null"` succeeds as a keyword argument (directly testing the #501 fix).
3. `test_gateway_legacy_kwargs_warning`: Asserts that passing arbitrary legacy kwargs triggers the specific `DeprecationWarning` without throwing a `TypeError`.

### Risks of NOT Implementing:

Leaving the code as-is breaks backward compatibility permanently. Existing deployments of `ramses_cc` (up to 0.54.3) will be unable to use the current `ramses_rf` master branch, halting integration updates and causing widespread user frustration upon upgrading.

### Risks of Implementing:

Adding `**kwargs` back into the signature temporarily weakens the strict typing rules. Mypy cannot validate the contents of `**kwargs`, meaning typos in configuration keys passed by consumers might be silently absorbed rather than explicitly rejected.

### Mitigation Steps:

Added the `DeprecationWarning` stack trace directly tied to the `kwargs` catch-all. This ensures that while the integration won't crash, the logs will actively warn developers that this loose typing is a temporary bridge, mitigating long-term technical debt while the `GatewayConfig` API is fully adopted. Extensive Mypy strict-mode checking was enforced on the rest of the updated file to guarantee no other type regressions were introduced.