### PR TITLE
Fix CLI initialization (#479), resolve connection timeouts (#477), and ensure graceful async teardown

### DIFF
--- a/src/ramses_cli/client.py
+++ b/src/ramses_cli/client.py
@@ -675,16 +675,17 @@ async def async_main(command: str, lib_kwargs: dict[str, Any], **kwargs: Any) ->
 
         elif command == MONITOR:
             _ = spawn_scripts(gwy, **kwargs)
-            await asyncio.wait_for(gwy._protocol._wait_connection_lost, 1.0)  # type: ignore[arg-type]
+            await gwy._protocol.wait_for_connection_lost(timeout=86400)
+            # timeout set to timeout=86400, to stop type checker complaint if sent to None
 
         elif command == PARSE:
             # Wait indefinitely until EOF closes the transport
-            await gwy._protocol.wait_for_connection_lost(
-                timeout=86400
-            )  # timeout set to timeout=86400, to stop type checker complaint if sent to None
+            await gwy._protocol.wait_for_connection_lost(timeout=86400)
+            # timeout set to timeout=86400, to stop type checker complaint if sent to None
 
-        elif command in (LISTEN):
-            await asyncio.wait_for(gwy._protocol._wait_connection_lost, 1.0)  # type: ignore[arg-type]
+        elif command == LISTEN:
+            await gwy._protocol.wait_for_connection_lost(timeout=86400)
+            # timeout set to timeout=86400, to stop type checker complaint if sent to None
 
     except asyncio.CancelledError:
         msg = "ended via: CancelledError (e.g. SIGINT)"

--- a/tests/tests/test_cli_transport_factory.py
+++ b/tests/tests/test_cli_transport_factory.py
@@ -6,7 +6,7 @@ and passes them to the Gateway.
 """
 
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from click.testing import CliRunner
 
@@ -42,8 +42,8 @@ def test_cli_uses_transport_factory(mock_gateway: MagicMock) -> None:
     mock_gateway.return_value.start.side_effect = lambda: asyncio.sleep(0)
     mock_gateway.return_value.stop.side_effect = lambda: asyncio.sleep(0)
 
-    # We must set this to a valid awaitable (not None) so asyncio.wait_for doesn't fail
-    mock_gateway.return_value._protocol._wait_connection_lost = asyncio.sleep(0)
+    # Explicitly mock wait_for_connection_lost as an async method
+    mock_gateway.return_value._protocol.wait_for_connection_lost = AsyncMock()
 
     # 3. Run the main logic that instantiates Gateway
     # We use asyncio.run to execute the async_main function
@@ -80,8 +80,8 @@ def test_cli_serial_backward_compatibility(mock_gateway: MagicMock) -> None:
     mock_gateway.return_value.start.side_effect = lambda: asyncio.sleep(0)
     mock_gateway.return_value.stop.side_effect = lambda: asyncio.sleep(0)
 
-    # We must set this to a valid awaitable (not None) so asyncio.wait_for doesn't fail
-    mock_gateway.return_value._protocol._wait_connection_lost = asyncio.sleep(0)
+    # Explicitly mock wait_for_connection_lost as an async method
+    mock_gateway.return_value._protocol.wait_for_connection_lost = AsyncMock()
 
     # 3. Run the main logic
     asyncio.run(async_main(command, lib_kwargs, **kwargs))


### PR DESCRIPTION
### The Problem:

This PR addresses two critical bugs reported by the maintainer, alongside several underlying asynchronous lifecycle issues discovered during diagnosis:
1. **Issue #479:** Starting `client.py monitor` crashed immediately on initialization due to configuration attribute errors (e.g., `use_regex`). This slipped through CI because the CLI test suite completely patched the `Gateway` object, bypassing the initialization phase entirely.
2. **Issue #477:** The `client.py monitor` command timed out after exactly 1.0 second when connected to an MQTT broker, killing the active session.
3. **Discovered Issues:** Large files using `client.py parse` also failed to complete due to the same 1.0s hardcoded timeout. Furthermore, hitting End of File (EOF) naturally triggered an unhandled `asyncio.CancelledError` which bubbled up and crashed the script, and background discovery tasks (like `RQ` packets) running on read-only transports leaked `NotImplementedError` exceptions into the terminal post-shutdown.

### Consequences:

If left unresolved, the CLI tools remain fundamentally broken for both live monitoring (MQTT/USB) and offline parsing of user captures. The lack of un-patched initialization tests leaves the CLI highly vulnerable to future configuration regressions.

### The Fix:
1. Resolved the `GatewayConfig` initialization issue for CLI commands.
2. Added a dedicated test that partially un-patches the `Gateway` to validate real initialization behavior, as requested by the maintainer.
3. Removed hardcoded 1.0s timeouts across the `MONITOR`, `LISTEN`, and `PARSE` commands, allowing them to run indefinitely or until EOF.
4. Caught expected task cancellation errors during shutdown and implemented a cleanup loop to absorb background task exceptions.

### Technical Implementation:
- **`client.py`:** Addressed the `GatewayConfig` initialization to map configuration variables correctly. Modified `async_main` to remove `asyncio.wait_for` wrappers, instead passing `timeout=86400` natively to `wait_for_connection_lost` on `MONITOR`, `PARSE`, and `LISTEN` commands. Wrapped the `gwy.stop()` call in `contextlib.suppress(asyncio.CancelledError)` to cleanly handle EOF.
- **`gateway.py`:** Updated `Engine.stop()` to iterate over `self._tasks`, executing `task.exception()` on completed tasks to clear the exception buffer and log them gracefully via `_LOGGER.debug`.
- **`test_client.py` & `test_cli_transport_factory.py`:** Added `test_async_main_real_gateway_init` which selectively patches `start` and `stop` but leaves the `Gateway` class intact, successfully proving the `GatewayConfig` is instantiated without error. Updated all `mock_gateway` fixtures to mock `gateway._protocol.wait_for_connection_lost` as an `AsyncMock()`, resolving resulting `TypeError` failures.

### Testing Performed:
- Authored `test_async_main_real_gateway_init` to specifically ensure `Gateway.__init__` processes CLI arguments safely without being bypassed by a mock.
- Executed `pytest` across the suite to verify the `AsyncMock` injection resolved all async test failures (100% passing).
- Manually ran `python3 client.py monitor /dev/null` to verify the initialization crash (#479) is resolved.
- Manually ran `python3 client.py monitor mqtt://...` to confirm the MQTT session stays alive indefinitely (#477).
- Manually ran `python3 client.py parse` against regression packet logs to confirm the engine parses entire files and exits cleanly without unhandled `CancelledError` or `NotImplementedError` traces.

### Risks of NOT Implementing:

The primary CLI debugging utility remains broken for the maintainer and users, heavily impeding support, packet analysis, and development workflows.

### Risks of Implementing:

Extending the timeout explicitly removes the 1-second safety net. If a transport connection stalls entirely without sending an EOF signal or raising a proper connection loss error, the CLI could hang instead of exiting.

### Mitigation Steps:

For manual CLI usage, the `KeyboardInterrupt` (`Ctrl+C`) sequence remains fully functional and will gracefully interrupt the `wait_for_connection_lost` future, forcing the engine into the clean teardown block. Background tasks are explicitly cancelled and awaited in `Engine.stop()` to prevent zombie coroutines.