### PR TITLE
Refactor: Enforce strict type hints and prevent null reference in entity_base.py

### DIFF
--- a/src/ramses_rf/entity_base.py
+++ b/src/ramses_rf/entity_base.py
@@ -1156,7 +1156,7 @@ class _Discovery(_MessageDB):
                 task[_SZ_NEXT_DUE] = dt_now + backoff(hdr, task[_SZ_FAILURES])
 
     def _deprecate_code_ctx(
-        self, pkt: Packet, ctx: str = None, reset: bool = False
+        self, pkt: Packet, ctx: str | None = None, reset: bool = False
     ) -> None:
         """If a code|ctx is deprecated twice, stop polling for it."""
 
@@ -1217,7 +1217,7 @@ class Parent(Entity):  # A System, Zone, DhwZone or a UfhController
     _dhw_valve: Any
     _htg_valve: Any
 
-    def __init__(self, *args: Any, child_id: str = None, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, child_id: str | None = None, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
         self._child_id: str = child_id  # type: ignore[assignment]
@@ -1241,7 +1241,7 @@ class Parent(Entity):  # A System, Zone, DhwZone or a UfhController
         self._child_id = value
 
     def _add_child(
-        self, child: Any, *, child_id: str = None, is_sensor: bool = None
+        self, child: Any, *, child_id: str | None = None, is_sensor: bool | None = None
     ) -> None:
         """Add a child device to this Parent, after validating the association.
 
@@ -1329,7 +1329,7 @@ class Child(Entity):  # A Zone, Device or a UfhCircuit
     def __init__(
         self,
         *args: Any,
-        parent: Parent = None,
+        parent: Parent | None = None,
         is_sensor: bool | None = None,
         **kwargs: Any,
     ) -> None:
@@ -1369,9 +1369,15 @@ class Child(Entity):  # A Zone, Device or a UfhCircuit
             eavesdrop_parent_zone()
 
     def _get_parent(
-        self, parent: Parent, *, child_id: str = None, is_sensor: bool | None = None
+        self,
+        parent: Parent | None,
+        *,
+        child_id: str | None = None,
+        is_sensor: bool | None = None,
     ) -> tuple[Parent, str | None]:
         """Get the device's parent, after validating it."""
+        if parent is None:
+            raise TypeError(f"{self}: parent cannot be None")
 
         parent_class = parent.__class__.__name__
         self_class = self.__class__.__name__
@@ -1506,7 +1512,11 @@ class Child(Entity):  # A Zone, Device or a UfhCircuit
 
     # TODO: should be a private method
     def set_parent(
-        self, parent: Parent | None, *, child_id: str = None, is_sensor: bool = None
+        self,
+        parent: Parent | None,
+        *,
+        child_id: str | None = None,
+        is_sensor: bool | None = None,
     ) -> Parent:
         """Set the device's parent, after validating it.
 


### PR DESCRIPTION
## The Problem:

Several methods in `entity_base.py` utilized implicit optional typing (e.g., `child_id: str = None` instead of `child_id: str | None = None`), which violates strict Mypy standards. Additionally, the `_get_parent` method accepted `parent: Parent | None` but immediately accessed `parent.__class__.__name__` without a null check. Mypy flagged this because it violated the guaranteed `tuple[Parent, str | None]` return type.

## Consequences:

Leaving this unresolved prevents the project from passing strict Mypy checks in CI/CD pipelines. Furthermore, if an upstream bug ever passed `None` into `_get_parent()`, it would result in an immediate, unhandled `AttributeError` crash at runtime.

## The Fix:

Upgraded all implicit optional type hints in `entity_base.py` to modern explicit syntax. Added a strict runtime type guard to `_get_parent()` to validate the `parent` object before processing.

## Technical Implementation:
- Replaced instances of `arg: type = None` with explicit unions (`arg: type | None = None`).
- Inserted `if parent is None: raise TypeError(f"{self}: parent cannot be None")` at the beginning of `Child._get_parent()`. This safely guards the method, protects the runtime, and explicitly satisfies Mypy's strict static analysis.

## Testing Performed:
- Ran the full `pytest` suite locally to ensure no regressions in entity initialization, parent/child assignment, or the discovery routines. All tests pass.
- Ran `mypy` in strict mode against `src/ramses_rf/entity_base.py` to confirm zero static analysis errors.

## Risks of NOT Implementing:

Failing to implement this blocks the ongoing efforts to enforce strict typing across the application layer. It also leaves a hidden landmine where an invalid null parent reference will crash the event loop rather than failing cleanly.

## Risks of Implementing:

The risk is minimal. However, by adding the explicit `TypeError` raise in `_get_parent()`, if there is currently a hidden upstream bug that incorrectly passes `None`, it will now fail fast rather than propagating further down the stack.

## Mitigation Steps:

The extensive existing test suite was executed and passed, proving that standard execution paths do not trigger the new `TypeError`.

## AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.