### PR TITLE
Fix: Zigbee Transport Stabilization, Memory Leak Fixes & Strict Typing

### DIFF
--- a/src/ramses_rf/device/__init__.py
+++ b/src/ramses_rf/device/__init__.py
@@ -4,11 +4,11 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from ramses_rf.const import DEV_TYPE_MAP
+from ramses_rf.models import DeviceTraits
 from ramses_tx.const import DevType
-from ramses_tx.schemas import SZ_CLASS, SZ_FAKED
 
 from .base import (  # noqa: F401, isort: skip, pylint: disable=unused-import
     BASE_CLASS_BY_SLUG as _BASE_CLASS_BY_SLUG,
@@ -100,7 +100,7 @@ def best_dev_role(
     *,
     msg: Message | None = None,
     eavesdrop: bool = False,
-    **schema: Any,
+    traits: DeviceTraits | None = None,
 ) -> type[Device]:
     """Return the best device role (object class) for a given device id/msg/schema.
 
@@ -112,15 +112,17 @@ def best_dev_role(
     """
 
     cls: type[Device]
-    slug: str
+    slug: str | None
+
+    traits = traits or DeviceTraits()
 
     try:  # convert (say) 'dhw_sensor' to DHW
-        slug = DEV_TYPE_MAP.slug(schema.get(SZ_CLASS))  # type: ignore[arg-type]
+        slug = DEV_TYPE_MAP.slug(traits.device_class)  # type: ignore[arg-type]
     except KeyError:
-        slug = schema.get(SZ_CLASS)
+        slug = traits.device_class
 
     # a specified device class always takes precedence (even if it is wrong)...
-    if slug in _CLASS_BY_SLUG:
+    if slug and slug in _CLASS_BY_SLUG:
         cls = _CLASS_BY_SLUG[slug]
         _LOGGER.debug(
             f"Using an explicitly-defined class for: {dev_addr!r} ({cls._SLUG})"
@@ -157,27 +159,33 @@ def best_dev_role(
 
 
 def device_factory(
-    gwy: Gateway, dev_addr: Address, *, msg: Message | None = None, **traits: Any
+    gwy: Gateway,
+    dev_addr: Address,
+    *,
+    msg: Message | None = None,
+    traits: DeviceTraits | None = None,
 ) -> Device:
     """Return the initial device class for a given device id/msg/traits.
 
     Devices of certain classes are promotable to a compatible sub class.
     """
 
+    traits = traits or DeviceTraits()
+
     cls: type[Device] = best_dev_role(
         dev_addr,
         msg=msg,
         eavesdrop=gwy.config.enable_eavesdrop,
-        **traits,
+        traits=traits,
     )
 
     if (
         isinstance(cls, DeviceHvac)
-        and traits.get(SZ_CLASS) in (DEV_TYPE_MAP.HVC, None)
-        and traits.get(SZ_FAKED)
+        and traits.device_class in (DEV_TYPE_MAP.HVC, None)
+        and traits.faked
     ):
         raise TypeError(
-            "Faked devices from the HVAC domain must have an explicit class: {dev_addr}"
+            f"Faked devices from the HVAC domain must have an explicit class: {dev_addr}"
         )
 
-    return cls.create_from_schema(gwy, dev_addr, **traits)
+    return cls.create_from_schema(gwy, dev_addr, **traits.to_dict())

--- a/src/ramses_rf/device/__init__.py
+++ b/src/ramses_rf/device/__init__.py
@@ -180,12 +180,12 @@ def device_factory(
     )
 
     if (
-        isinstance(cls, DeviceHvac)
-        and traits.device_class in (DEV_TYPE_MAP.HVC, None)
+        issubclass(cls, DeviceHvac)
+        and traits.device_class in (DevType.HVC, None)
         and traits.faked
     ):
         raise TypeError(
             f"Faked devices from the HVAC domain must have an explicit class: {dev_addr}"
         )
 
-    return cls.create_from_schema(gwy, dev_addr, **traits.to_dict())
+    return cls.create_from_schema(gwy, dev_addr, traits=traits)

--- a/src/ramses_rf/device/base.py
+++ b/src/ramses_rf/device/base.py
@@ -13,15 +13,7 @@ from typing import TYPE_CHECKING, Any, cast
 from ramses_rf.binding_fsm import BindContext, Vendor
 from ramses_rf.const import DEV_TYPE_MAP, SZ_OEM_CODE, DevType
 from ramses_rf.entity_base import Child, Entity, class_by_attr
-from ramses_rf.helpers import shrink
-from ramses_rf.schemas import (
-    SCH_TRAITS,
-    SZ_ALIAS,
-    SZ_CLASS,
-    SZ_FAKED,
-    SZ_KNOWN_LIST,
-    SZ_SCHEME,
-)
+from ramses_rf.schemas import SZ_ALIAS, SZ_CLASS, SZ_FAKED, SZ_KNOWN_LIST
 from ramses_tx import Command, Packet, Priority, QosParams
 from ramses_tx.ramses import CODES_BY_DEV_SLUG, CODES_ONLY_FROM_CTL
 from ramses_tx.typing import PayloadT
@@ -38,6 +30,7 @@ if TYPE_CHECKING:
     from typing import Any
 
     from ramses_rf import Gateway
+    from ramses_rf.models import DeviceTraits
     from ramses_rf.system import Zone
     from ramses_tx import Address, DeviceIdT, IndexT, Message
 
@@ -58,8 +51,15 @@ class DeviceBase(Entity):
 
     _bind_context: BindContext | None = None
 
-    def __init__(self, gwy: Gateway, dev_addr: Address, **kwargs: Any) -> None:
-        super().__init__(gwy)
+    def __init__(
+        self,
+        gwy: Gateway,
+        dev_addr: Address,
+        *,
+        traits: DeviceTraits | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(gwy, **kwargs)
 
         # FIXME: gwy.msg_db entities must know their parent device ID and their own idx
         self._z_id = dev_addr.id  # the responsible device is itself
@@ -74,7 +74,7 @@ class DeviceBase(Entity):
         self.addr = dev_addr
         self.type = dev_addr.type  # DEX  # TODO: remove this attr? use SLUG?
 
-        self._scheme: Vendor = None
+        self._scheme: Vendor | None = traits.scheme if traits else None
 
     def __str__(self) -> str:
         if self._STATE_ATTR and hasattr(self, self._STATE_ATTR):
@@ -87,25 +87,23 @@ class DeviceBase(Entity):
             return NotImplemented
         return self.id < other.id  # type: ignore[no-any-return]
 
-    def _update_traits(self, **traits: Any) -> None:
+    def _update_traits(self, traits: DeviceTraits) -> None:
         """Update a device with new schema attributes.
 
         :param traits: The traits to apply (e.g., alias, class, faked)
         :raises TypeError: If the device is not fakeable but 'faked' is set.
         """
 
-        traits = shrink(SCH_TRAITS(traits))
-
-        if traits.get(SZ_FAKED):  # class & alias are done elsewhere
+        if traits.faked:  # class & alias are done elsewhere
             if not isinstance(self, Fakeable):
                 raise TypeError(f"Device is not fakeable: {self} (traits={traits})")
             self._make_fake()
 
-        self._scheme = traits.get(SZ_SCHEME)
+        self._scheme = traits.scheme
 
     @classmethod
     def create_from_schema(
-        cls, gwy: Gateway, dev_addr: Address, **schema: Any
+        cls, gwy: Gateway, dev_addr: Address, *, traits: DeviceTraits | None = None
     ) -> DeviceBase:
         """Create a device (for a GWY) and set its schema attrs (aka traits).
 
@@ -115,8 +113,9 @@ class DeviceBase(Entity):
         Schema attrs include: class (SLUG), alias & faked.
         """
 
-        dev = cls(gwy, dev_addr)
-        dev._update_traits(**schema)  # TODO: split traits/schema
+        dev = cls(gwy, dev_addr, traits=traits)
+        if traits:
+            dev._update_traits(traits)
         return dev
 
     def _setup_discovery_cmds(self) -> None:
@@ -293,8 +292,14 @@ class Fakeable(DeviceBase):
     such packets via RF.
     """
 
-    def __init__(self, gwy: Gateway, *args: Any, **kwargs: Any) -> None:
-        super().__init__(gwy, *args, **kwargs)
+    def __init__(
+        self,
+        gwy: Gateway,
+        *args: Any,
+        traits: DeviceTraits | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(gwy, *args, traits=traits, **kwargs)
 
         self._bind_context: BindContext | None = None
 
@@ -302,7 +307,7 @@ class Fakeable(DeviceBase):
         if self.id in gwy._include and gwy._include[self.id].get(SZ_FAKED):
             self._make_fake()
 
-        if kwargs.get(SZ_FAKED):
+        if traits and traits.faked:
             self._make_fake()
 
     def _make_fake(self) -> None:
@@ -413,9 +418,16 @@ class Fakeable(DeviceBase):
 class Device(Child, DeviceBase):
     """The base class for all devices."""
 
-    def __init__(self, gwy: Gateway, dev_addr: Address, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        gwy: Gateway,
+        dev_addr: Address,
+        *,
+        traits: DeviceTraits | None = None,
+        **kwargs: Any,
+    ) -> None:
         _LOGGER.debug("Creating a Device: %s (%s)", dev_addr.id, self.__class__)
-        super().__init__(gwy, dev_addr)
+        super().__init__(gwy, dev_addr, traits=traits, **kwargs)
 
         gwy._add_device(self)
 
@@ -425,8 +437,10 @@ class HgiGateway(Device):  # HGI (18:)
 
     _SLUG: str = DevType.HGI
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self, *args: Any, traits: DeviceTraits | None = None, **kwargs: Any
+    ) -> None:
+        super().__init__(*args, traits=traits, **kwargs)
 
         self.ctl = None  # FIXME: a mess
         self._child_id = "gw"  # TODO
@@ -445,8 +459,15 @@ class DeviceHeat(Device):  # Heat domain: Honeywell CH/DHW or compatible
 
     _SLUG: str = DevType.HEA  # shouldn't be any of these instantiated
 
-    def __init__(self, gwy: Gateway, dev_addr: Address, **kwargs: Any) -> None:
-        super().__init__(gwy, dev_addr, **kwargs)
+    def __init__(
+        self,
+        gwy: Gateway,
+        dev_addr: Address,
+        *,
+        traits: DeviceTraits | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(gwy, dev_addr, traits=traits, **kwargs)
 
         self.ctl = None
         self.tcs = None
@@ -505,8 +526,15 @@ class DeviceHvac(Device):  # HVAC domain: ventilation, PIV, MV/HR
 
     _SLUG: str = DevType.HVC  # these may be instantiated, and promoted later on
 
-    def __init__(self, gwy: Gateway, dev_addr: Address, **kwargs: Any) -> None:
-        super().__init__(gwy, dev_addr, **kwargs)
+    def __init__(
+        self,
+        gwy: Gateway,
+        dev_addr: Address,
+        *,
+        traits: DeviceTraits | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(gwy, dev_addr, traits=traits, **kwargs)
 
         self._child_id = "hv"  # TODO: domain_id/deprecate
 

--- a/src/ramses_rf/device/heat.py
+++ b/src/ramses_rf/device/heat.py
@@ -101,6 +101,7 @@ from ramses_tx.const import (
 )
 
 if TYPE_CHECKING:
+    from ramses_rf.models import DeviceTraits
     from ramses_rf.system import Evohome, Zone
     from ramses_tx import Address, Message, Packet
     from ramses_tx.opentherm import OtDataId
@@ -323,8 +324,10 @@ class Controller(DeviceHeat):  # CTL (01):
     _SLUG = DevType.CTL
     _STATE_ATTR = HEAT_DEMAND
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self, *args: Any, traits: DeviceTraits | None = None, **kwargs: Any
+    ) -> None:
+        super().__init__(*args, traits=traits, **kwargs)
 
         # self.ctl = None
         self.tcs = None  # TODO: = self?
@@ -393,8 +396,10 @@ class UfhController(Parent, DeviceHeat):  # UFC (02):
     # 12:27:24.824 059  I --- 01:191718 --:------ 01:191718 3150 002 FC5C
     # 12:27:24.857 067  I --- 02:000921 --:------ 02:000921 3150 006 0060-015A-025C
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self, *args: Any, traits: DeviceTraits | None = None, **kwargs: Any
+    ) -> None:
+        super().__init__(*args, traits=traits, **kwargs)
 
         self.circuit_by_id = {f"{i:02X}": {} for i in range(8)}
 
@@ -608,8 +613,10 @@ class DhwSensor(DhwTemperature, BatteryState, Fakeable):  # DHW (07): 10A0, 1260
     _SLUG: str = DevType.DHW
     _STATE_ATTR = DhwTemperature.TEMPERATURE
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self, *args: Any, traits: DeviceTraits | None = None, **kwargs: Any
+    ) -> None:
+        super().__init__(*args, traits=traits, **kwargs)
 
         self._child_id = FA  # NOTE: domain_id
 
@@ -685,8 +692,10 @@ class OtbGateway(Actuator, HeatDemand):  # OTB (10): 3220 (22D9, others)
         v: k for k, v in OT_TO_RAMSES.items() if v != Code._3EF0
     }  # also 10A0?
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self, *args: Any, traits: DeviceTraits | None = None, **kwargs: Any
+    ) -> None:
+        super().__init__(*args, traits=traits, **kwargs)
 
         self._child_id = FC  # NOTE: domain_id
 
@@ -1356,8 +1365,8 @@ class BdrSwitch(Actuator, RelayDemand):  # BDR (13):
     _SLUG = DevType.BDR
     _STATE_ATTR = "active"
 
-    # def __init__(self, *args: Any, **kwargs: Any) -> None:
-    #     super().__init__(*args, **kwargs)
+    # def __init__(self, *args: Any, traits: DeviceTraits | None = None, **kwargs: Any) -> None:
+    #     super().__init__(*args, traits=traits, **kwargs)
 
     #     if kwargs.get(SZ_DOMAIN_ID) == FC:  # TODO: F9/FA/FC, zone_idx
     #         self.ctl._set_app_cntrl(self)

--- a/src/ramses_rf/device/hvac.py
+++ b/src/ramses_rf/device/hvac.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from ramses_rf import exceptions as exc
 from ramses_rf.const import (
@@ -55,6 +55,9 @@ from ramses_rf.const import (  # noqa: F401, isort: skip, pylint: disable=unused
     W_,
     Code,
 )
+
+if TYPE_CHECKING:
+    from ramses_rf.models import DeviceTraits
 
 # TODO: Switch this module to utilise the (run-time) decorator design pattern...
 # - https://refactoring.guru/design-patterns/decorator/python/example
@@ -260,13 +263,16 @@ class RfsGateway(DeviceHvac):  # RFS: (spIDer gateway)
 
     _SLUG: str = DevType.RFS
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self, *args: Any, traits: DeviceTraits | None = None, **kwargs: Any
+    ) -> None:
         """Initialize the RFS gateway.
 
         :param args: Positional arguments passed to the parent class
+        :param traits: Strictly typed traits object for device creation
         :param kwargs: Keyword arguments passed to the parent class
         """
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, traits=traits, **kwargs)
 
         self.ctl = None
         self._child_id = "hv"  # NOTE: domain_id
@@ -441,13 +447,16 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
 
     _SLUG: str = DevType.FAN
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self, *args: Any, traits: DeviceTraits | None = None, **kwargs: Any
+    ) -> None:
         """Initialize the HvacVentilator.
 
         :param args: Positional arguments passed to the parent class
+        :param traits: Strictly typed traits object for device creation
         :param kwargs: Keyword arguments passed to the parent class
         """
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, traits=traits, **kwargs)
         self._supports_2411 = False  # Flag for 2411 parameter support
         self._params_2411: dict[str, float] = {}  # Store 2411 parameters here
         self._initialized_callback = None  # Called when device is fully initialized

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -69,6 +69,7 @@ from .database import MessageIndex
 from .device import DeviceHeat, DeviceHvac, Fakeable, HgiGateway, device_factory
 from .dispatcher import detect_array_fragment, process_msg
 from .interfaces import GatewayInterface, MessageIndexInterface
+from .models import DeviceTraits
 from .schemas import load_schema
 from .system import Evohome
 
@@ -94,6 +95,7 @@ class GatewayConfig:
     use_aliases: dict[str, str] = field(default_factory=dict)
     enforce_strict_handling: bool = False
     use_native_ot: Literal["always", "prefer", "avoid", "never"] | None = None
+    app_context: Any | None = None
 
 
 class Gateway(Engine, GatewayInterface):
@@ -173,7 +175,6 @@ class Gateway(Engine, GatewayInterface):
         if debug_mode:
             _LOGGER.setLevel(logging.DEBUG)
 
-        hidden_kwargs = {k: v for k, v in kwargs.items() if k.startswith("_")}
         self._gwy_config = config or GatewayConfig()
 
         super().__init__(
@@ -191,12 +192,8 @@ class Gateway(Engine, GatewayInterface):
             enforce_known_list=enforce_known_list,
             evofw_flag=evofw_flag,
             use_regex=self._gwy_config.use_regex,
+            app_context=self._gwy_config.app_context,
         )
-
-        if hidden_kwargs:
-            self._extra.update(
-                hidden_kwargs
-            )  # injected into transport_factory() via Engine.start()
 
         if self._disable_sending:
             self._gwy_config.disable_discovery = True
@@ -540,7 +537,7 @@ class Gateway(Engine, GatewayInterface):
         parent: Parent | None = None,
         child_id: str | None = None,
         is_sensor: bool | None = None,
-    ) -> Device:  # TODO: **schema/traits) -> Device:  # may: LookupError
+    ) -> Device:
         """Return a device, creating it if it does not already exist.
 
         This method uses provided traits to create or update a device and optionally
@@ -595,14 +592,15 @@ class Gateway(Engine, GatewayInterface):
 
         if not dev:
             # voluptuous bug workaround: https://github.com/alecthomas/voluptuous/pull/524
-            _traits: dict[str, Any] = self._include.get(device_id, {})  # type: ignore[assignment]
-            _traits.pop("commands", None)
+            _traits_raw: dict[str, Any] = self._include.get(device_id, {})  # type: ignore[assignment]
+            _traits_raw.pop("commands", None)
 
-            traits: dict[str, Any] = SCH_TRAITS(self._include.get(device_id, {}))
+            traits_dict: dict[str, Any] = SCH_TRAITS(self._include.get(device_id, {}))
+            traits = DeviceTraits.from_dict(traits_dict)
 
-            dev = device_factory(self, Address(device_id), msg=msg, **_traits)
+            dev = device_factory(self, Address(device_id), msg=msg, traits=traits)
 
-            if traits.get(SZ_FAKED):
+            if traits.faked:
                 if isinstance(dev, Fakeable):
                     dev._make_fake()
                 else:

--- a/src/ramses_rf/models.py
+++ b/src/ramses_rf/models.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""RAMSES RF - Data models and configuration objects."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class DeviceTraits:
+    """Strictly typed traits for device instantiation."""
+
+    device_class: str | None = None
+    alias: str | None = None
+    faked: bool | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DeviceTraits:
+        """Construct DeviceTraits safely from a dynamically parsed dictionary."""
+        return cls(
+            device_class=data.get("class"),
+            alias=data.get("alias"),
+            faked=data.get("faked"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize back to a dictionary.
+
+        Useful for bridging the boundary into legacy methods expecting **kwargs.
+        """
+        result: dict[str, Any] = {}
+        if self.device_class is not None:
+            result["class"] = self.device_class
+        if self.alias is not None:
+            result["alias"] = self.alias
+        if self.faked is not None:
+            result["faked"] = self.faked
+        return result

--- a/src/ramses_rf/models.py
+++ b/src/ramses_rf/models.py
@@ -14,6 +14,7 @@ class DeviceTraits:
     device_class: str | None = None
     alias: str | None = None
     faked: bool | None = None
+    scheme: str | None = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> DeviceTraits:
@@ -22,6 +23,7 @@ class DeviceTraits:
             device_class=data.get("class"),
             alias=data.get("alias"),
             faked=data.get("faked"),
+            scheme=data.get("scheme"),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -36,4 +38,6 @@ class DeviceTraits:
             result["alias"] = self.alias
         if self.faked is not None:
             result["faked"] = self.faked
+        if self.scheme is not None:
+            result["scheme"] = self.scheme
         return result

--- a/src/ramses_tx/exceptions.py
+++ b/src/ramses_tx/exceptions.py
@@ -61,6 +61,10 @@ class TransportSourceInvalid(TransportError):
     """The source of packets (frames) is not valid type/configuration."""
 
 
+class TransportZigbeeError(TransportError):
+    """A failure occurred specifically within the Zigbee ZHA transport layer."""
+
+
 ########################################################################################
 # Errors at/below the protocol/transport layer, incl. packet processing
 

--- a/src/ramses_tx/gateway.py
+++ b/src/ramses_tx/gateway.py
@@ -80,6 +80,7 @@ class Engine:
         evofw_flag: str | None = None,
         use_regex: dict[str, dict[str, str]] | None = None,
         transport_constructor: Callable[..., Awaitable[RamsesTransportT]] | None = None,
+        app_context: Any | None = None,
     ) -> None:
         if port_name and input_file:
             _LOGGER.warning(
@@ -121,6 +122,7 @@ class Engine:
         )
 
         self._transport_constructor = transport_constructor
+        self._app_context = app_context
 
         self._hgi_id = hgi_id
 
@@ -136,8 +138,6 @@ class Engine:
         self._this_msg: Message | None = None
 
         self._tasks: list[asyncio.Task] = []  # type: ignore[type-arg]
-
-        self._extra: dict[str, Any] = {}  # extra info injected into transport factory
 
         self._set_msg_handler(self._msg_handler)  # sets self._protocol
 
@@ -204,13 +204,12 @@ class Engine:
             log_all=bool(self._log_all_mqtt),
             evofw_flag=self._evofw_flag,
             use_regex=self._use_regex,
+            app_context=self._app_context,
         )
 
         extra_info: dict[str, Any] = {}
         if self._hgi_id:
             extra_info[SZ_ACTIVE_HGI] = self._hgi_id
-        if self._extra:
-            extra_info.update(self._extra)
 
         # incl. await protocol.wait_for_connection_made(timeout=5)
         self._transport = await transport_factory(

--- a/src/ramses_tx/transport/base.py
+++ b/src/ramses_tx/transport/base.py
@@ -41,6 +41,7 @@ class TransportConfig:
     evofw_flag: str | None = None
     use_regex: dict[str, dict[str, str]] = field(default_factory=dict)
     timeout: float | None = None
+    app_context: Any | None = None
 
 
 class _BaseTransport:

--- a/src/ramses_tx/transport/factory.py
+++ b/src/ramses_tx/transport/factory.py
@@ -160,7 +160,6 @@ async def transport_factory(
             port_name,
             protocol,
             config=config,
-            extra=extra,
             loop=loop,
         )
         try:

--- a/src/ramses_tx/transport/zigbee.py
+++ b/src/ramses_tx/transport/zigbee.py
@@ -9,12 +9,13 @@ import logging
 import math
 import re
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, cast
 from urllib.parse import parse_qs, urlparse
 
 from .. import exceptions as exc
 from ..const import SZ_ACTIVE_HGI, SZ_IS_EVOFW3
 from ..helpers import dt_now
+from ..typing import DeviceIdT
 from .base import TransportConfig, _FullTransport
 from .helpers import _normalise
 
@@ -45,28 +46,30 @@ class _ZigbeeTransportAbstractor:
         self._zigbee_url = urlparse(zigbee_url)
         self._protocol = protocol
         self._loop = loop or asyncio.get_event_loop()
-        self._hass = None
-        self._cluster = None
-        self._write_cluster = None
+        self._hass: Any | None = None
+        self._cluster: Any | None = None
+        self._write_cluster: Any | None = None
 
 
 class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
     """Send/receive packets to/from ESP32 Zigbee device.
 
-    Zigbee URL format: zigbee://ieee/cluster/attr/endpoint/write_cluster/write_attr/write_endpoint
+    Zigbee URL format:
+    zigbee://ieee/cluster/attr/endpoint/write_cluster/write_attr/write_endpoint
     """
 
     _GATEWAY_POLL_INTERVAL: Final[float] = 1.0
     _GATEWAY_POLL_ATTEMPTS: Final[int] = 30
     _DEVICE_READY_TIMEOUT: Final[float] = 60.0
     _MAX_CHAR_STRING_LEN: Final[int] = 63
-    _CHUNK_BODY_LEN: Final[int] = (
-        32  # Reduced to prevent APS fragmentation & buffer exhaustion
-    )
+
+    # Reduced to prevent APS fragmentation & buffer exhaustion
+    _CHUNK_BODY_LEN: Final[int] = 32
     _MAX_CHAR_STRING_LEN_CMD: Final[int] = 63
-    _CHUNK_BODY_LEN_CMD: Final[int] = (
-        32  # Reduced to prevent APS fragmentation & buffer exhaustion
-    )
+
+    # Reduced to prevent APS fragmentation & buffer exhaustion
+    _CHUNK_BODY_LEN_CMD: Final[int] = 32
+    _CHUNK_TIMEOUT: Final[float] = 5.0
 
     def __init__(
         self,
@@ -76,8 +79,20 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
         config: TransportConfig,
         loop: asyncio.AbstractEventLoop | None = None,
     ) -> None:
+        """Initialize the Zigbee transport.
+
+        :param zigbee_url: The connection URL.
+        :type zigbee_url: str
+        :param protocol: The active protocol instance.
+        :type protocol: RamsesProtocolT
+        :param config: Transport configuration object.
+        :type config: TransportConfig
+        :param loop: The asyncio event loop.
+        :type loop: asyncio.AbstractEventLoop | None, optional
+        :raises TransportSourceInvalid: If URL is malformed.
+        """
         # _FullTransport and _ReadTransport break the cooperative MRO chain by
-        # calling their parent classes directly rather than via super().  We
+        # calling their parent classes directly rather than via super(). We
         # therefore initialise both halves of the diamond explicitly.
         _ZigbeeTransportAbstractor.__init__(self, zigbee_url, protocol, loop=loop)
         _FullTransport.__init__(self, config=config, loop=loop)
@@ -87,7 +102,8 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
 
         if not self._ieee or len(path_parts) < 6:
             raise exc.TransportSourceInvalid(
-                "Invalid Zigbee URL format. Expected zigbee://ieee/cluster/attr/endpoint/write_cluster/write_attr/write_endpoint"
+                "Invalid Zigbee URL format. Expected "
+                "zigbee://ieee/cluster/attr/endpoint/write_cluster/write_attr/write_endpoint"
             )
 
         self._cluster_id = int(
@@ -105,12 +121,14 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
 
         query = parse_qs(self._zigbee_url.query)
         cmd = query.get("cmd", ["0x00"])[0] or "0x00"
+
         # For this deployment we use custom ZCL commands for all payloads
         # (ESP <-> HA uses commands only). Force command mode regardless of
         # URL query; this removes the attribute-path fallback and keeps
         # handling simple and consistent.
         self._use_command_mode = True
         self._cmd_id = int(cmd, 16 if cmd.startswith("0x") else 10)
+
         # For custom commands, we listen on client-side cluster where Zigbee stack
         # delivers incoming commands from the ESP's client cluster
         self._read_direction = "out" if self._use_command_mode else "in"
@@ -126,20 +144,38 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
         self._hass = config.app_context
         self._device: Any | None = None
         self._zha_gateway: Any | None = None
-        self._cluster: Any | None = None
-        self._write_cluster: Any | None = None
         self._device_ready_unsub: Callable[[], None] | None = None
 
-        self._loop.create_task(self._async_init(), name="ZigbeeTransport._async_init()")
-        # buffers for assembling incoming chunked messages per device
+        self._tasks: set[asyncio.Task[Any]] = set()
+
+        # Buffers for assembling incoming chunked messages per device
         self._chunk_buffers: dict[str, dict[str, Any]] = {}
 
+        self._track_task(
+            self._loop.create_task(
+                self._async_init(), name="ZigbeeTransport._async_init()"
+            )
+        )
+
+    def _track_task(self, task: asyncio.Task[Any]) -> None:
+        """Add a task to the registry to prevent garbage collection.
+
+        :param task: The asyncio task to track.
+        :type task: asyncio.Task[Any]
+        """
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
     async def _async_init(self) -> None:
+        """Initialize ZHA dependencies and wait for the gateway to connect.
+
+        :raises TransportZigbeeError: If the device or Home Assistant context is missing.
+        """
         try:
             from zigpy.types import EUI64
 
             if not self._hass:
-                raise exc.TransportError("Home Assistant instance not available")
+                raise exc.TransportZigbeeError("Home Assistant instance not available")
 
             gateway = await self._wait_for_gateway()
             ieee = EUI64.convert(self._ieee)
@@ -152,7 +188,7 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                 device = gateway.application_controller.devices.get(ieee)
 
             if not device:
-                raise exc.TransportError(f"Zigbee device {self._ieee} not found")
+                raise exc.TransportZigbeeError(f"Zigbee device {self._ieee} not found")
 
             self._zha_gateway = gateway
             self._device = device
@@ -162,18 +198,27 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
             await self._bind_and_configure()
 
             self._extra[SZ_ACTIVE_HGI] = self._ieee
-            self._make_connection(gwy_id=self._ieee)
+            self._make_connection(gwy_id=cast(DeviceIdT, self._ieee))
             _LOGGER.info(
                 "Zigbee transport ready: ieee=%s cluster=0x%04x attr=0x%04x",
                 self._ieee,
                 self._cluster_id,
                 self._attr_id,
             )
+        except asyncio.CancelledError:
+            raise
         except Exception as err:
             _LOGGER.exception("Failed to initialize Zigbee transport: %s", err)
-            self._close(exc.TransportError(str(err)))
+            self._close(exc.TransportZigbeeError(str(err)))
 
     def attribute_updated(self, attrid: int, value: Any) -> None:
+        """Callback invoked when a bound cluster attribute updates.
+
+        :param attrid: The ID of the updated attribute.
+        :type attrid: int
+        :param value: The new value of the attribute.
+        :type value: Any
+        """
         self._ensure_read_cluster_bound()
         if attrid != self._attr_id or not isinstance(value, str):
             return
@@ -181,6 +226,7 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
         payload = value.strip()
         if not payload:
             return
+
         # Fast-path: ignore application ACKs here so they are not treated
         # as normal RAMSES frames by the parser.
         if payload.startswith("ACK "):
@@ -190,9 +236,13 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
         try:
             if self._maybe_handle_incoming_chunk(payload):
                 return
-        except Exception:
-            _LOGGER.exception("Error handling incoming chunk")
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            _LOGGER.exception("Error handling incoming chunk: %s", err)
+
         self._frame_read(dt_now().isoformat(), _normalise(payload))
+
         # If this payload looks like a chunk header, schedule an application ACK
         try:
             m = re.match(r"^(\d{1,3})/(\d{1,3})\|", payload)
@@ -200,21 +250,36 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                 seq = int(m.group(1))
                 total = int(m.group(2))
                 ack = f"ACK {seq}/{total}"
-                # fire-and-forget ACK send on the cluster that delivered this payload
+
+                # Fire-and-forget ACK send on the cluster that delivered this payload
                 _LOGGER.debug("Scheduling application ACK: %s", ack)
                 try:
                     target_cluster = self._cluster
                 except Exception:
                     target_cluster = None
-                self._loop.create_task(
-                    self._send_unacked(ack, target_cluster=target_cluster)
+
+                self._track_task(
+                    self._loop.create_task(
+                        self._send_unacked(ack, target_cluster=target_cluster)
+                    )
                 )
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            _LOGGER.debug("Failed to schedule application ACK: %s", err)
 
     def cluster_command(
         self, tsn: int, command_id: int, args: Any, *_args: Any, **_kwargs: Any
     ) -> None:
+        """Callback invoked when a ZCL command is received on the bound cluster.
+
+        :param tsn: The transaction sequence number.
+        :type tsn: int
+        :param command_id: The ZCL command ID.
+        :type command_id: int
+        :param args: The command arguments/payload.
+        :type args: Any
+        """
         # Attempt to decode command payload as a ZCL char-string. Previously
         # we ignored incoming commands unless in explicit command mode; this
         # prevented handling ESP custom-command chunked payloads when the
@@ -228,13 +293,18 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
         # into the RAMSES frame parser (they are control-plane only).
         if isinstance(payload, str) and payload.startswith("ACK "):
             return
+
         # If chunked, assemble and only call frame_read when complete
         try:
             if self._maybe_handle_incoming_chunk(payload):
                 return
-        except Exception:
-            _LOGGER.exception("Error handling incoming chunk")
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            _LOGGER.exception("Error handling incoming chunk: %s", err)
+
         self._frame_read(dt_now().isoformat(), _normalise(payload))
+
         # If payload looks like a chunk header, schedule an ACK
         try:
             m = re.match(r"^(\d{1,3})/(\d{1,3})\|", payload)
@@ -242,20 +312,32 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                 seq = int(m.group(1))
                 total = int(m.group(2))
                 ack = f"ACK {seq}/{total}"
+
                 _LOGGER.debug("Scheduling application ACK (cmd): %s", ack)
                 try:
                     target_cluster = self._cluster
                 except Exception:
                     target_cluster = None
-                self._loop.create_task(
-                    self._send_unacked(ack, target_cluster=target_cluster)
+
+                self._track_task(
+                    self._loop.create_task(
+                        self._send_unacked(ack, target_cluster=target_cluster)
+                    )
                 )
-        except Exception:
-            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            _LOGGER.debug("Failed to schedule application ACK (cmd): %s", err)
 
     async def _write_frame(self, frame: str) -> None:
+        """Write a frame to the Zigbee device.
+
+        :param frame: The frame content to write.
+        :type frame: str
+        :raises TransportZigbeeError: If the transport is closing.
+        """
         if self._closing:
-            raise exc.TransportError("Zigbee transport is closing")
+            raise exc.TransportZigbeeError("Zigbee transport is closing")
 
         _LOGGER.debug("Zigbee write requested frame: %s", frame)
 
@@ -273,6 +355,8 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                     # Delay between chunks to prevent ZBOSS buffer pool exhaustion
                     if seq < total:
                         await asyncio.sleep(0.025)
+                except asyncio.CancelledError:
+                    raise
                 except Exception as err:
                     _LOGGER.warning(
                         "Zigbee chunk %s/%s failed: %s - continuing", seq, total, err
@@ -287,15 +371,23 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                 # Delay between chunks to prevent ZBOSS buffer pool exhaustion
                 if seq < total:
                     await asyncio.sleep(0.025)
+            except asyncio.CancelledError:
+                raise
             except Exception as err:
                 _LOGGER.warning(
                     "Zigbee chunk %s/%s failed: %s - continuing", seq, total, err
                 )
 
     def close(self) -> None:
+        """Close the transport cleanly, unbinding clusters and cancelling tasks."""
         if self._closing:
             return
         self._closing = True
+
+        for task in self._tasks:
+            if not task.done():
+                task.cancel()
+
         if self._cluster:
             with contextlib.suppress(Exception):
                 self._cluster.remove_listener(self)
@@ -306,6 +398,12 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
         super().close()
 
     async def _wait_for_gateway(self) -> Any:
+        """Poll the Home Assistant environment for the ZHA gateway.
+
+        :raises TransportZigbeeError: If the ZHA gateway proxy is not found in time.
+        :return: The gateway instance.
+        :rtype: Any
+        """
         for _attempt in range(self._GATEWAY_POLL_ATTEMPTS):
             zha_data = self._hass.data.get("zha") if self._hass else None
             gateway_proxy = (
@@ -315,9 +413,17 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
             if gateway:
                 return gateway
             await asyncio.sleep(self._GATEWAY_POLL_INTERVAL)
-        raise exc.TransportError("ZHA gateway proxy not found")
+        raise exc.TransportZigbeeError("ZHA gateway proxy not found")
 
     async def _wait_for_device_ready(self, device: Any, ieee: Any) -> None:
+        """Wait for the target Zigbee device to be fully initialized.
+
+        :param device: The ZHA device object.
+        :type device: Any
+        :param ieee: The IEEE address of the device.
+        :type ieee: Any
+        :raises TransportZigbeeError: If initialization times out.
+        """
         if getattr(device, "is_initialized", True):
             return
 
@@ -338,8 +444,8 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
             await asyncio.wait_for(
                 ready_event.wait(), timeout=self._DEVICE_READY_TIMEOUT
             )
-        except TimeoutError as err:  # pragma: no cover - defensive
-            raise exc.TransportError(
+        except TimeoutError as err:
+            raise exc.TransportZigbeeError(
                 f"Zigbee device {ieee} did not finish initializing"
             ) from err
         finally:
@@ -347,8 +453,26 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                 self._device_ready_unsub()
                 self._device_ready_unsub = None
 
+    def _cleanup_chunk_buffers(self) -> None:
+        """Remove chunk buffers that have exceeded the TTL to prevent leaks."""
+        now = dt_now()
+        stale_keys = [
+            key
+            for key, buf in self._chunk_buffers.items()
+            if (now - buf["timestamp"]).total_seconds() > self._CHUNK_TIMEOUT
+        ]
+        for key in stale_keys:
+            _LOGGER.warning("Dropping stale incomplete chunk buffer for %s", key)
+            del self._chunk_buffers[key]
+
     def _parse_chunk(self, payload: str) -> tuple[int, int, str] | None:
-        """Parse a chunk header of the form 'seq/total|body'. Returns (seq,total,body) or None."""
+        """Parse a chunk header of the form 'seq/total|body'.
+
+        :param payload: The raw payload.
+        :type payload: str
+        :return: Tuple containing (seq, total, body) or None if malformed.
+        :rtype: tuple[int, int, str] | None
+        """
         try:
             m = re.match(r"^(\d{1,3})/(\d{1,3})\|(.*)$", payload, re.DOTALL)
             if not m:
@@ -359,23 +483,43 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
             if seq < 1 or total < 1 or seq > total:
                 return None
             return (seq, total, body)
+        except asyncio.CancelledError:
+            raise
         except Exception:
             return None
 
     def _maybe_handle_incoming_chunk(self, payload: str) -> bool:
-        """Handle incoming chunked payloads. If payload is chunked, buffer and
-        assemble; call _frame_read when complete. Returns True if chunk handled
-        (and original should NOT be passed to _frame_read)."""
+        """Handle incoming chunked payloads.
+
+        If payload is chunked, buffer and assemble; call _frame_read when
+        complete. Cleans up stale buffers first.
+
+        :param payload: The raw payload string.
+        :type payload: str
+        :return: True if the chunk was handled, False otherwise.
+        :rtype: bool
+        """
+        self._cleanup_chunk_buffers()
+
         parsed = self._parse_chunk(payload)
         if not parsed:
             return False
+
         seq, total, body = parsed
         key = str(self._ieee)
         buf = self._chunk_buffers.get(key)
+
         if not buf or buf.get("total") != total:
-            # start new assembly
-            buf = {"total": total, "parts": [None] * total, "received": 0}
+            # Start new assembly
+            buf = {
+                "total": total,
+                "parts": [None] * total,
+                "received": 0,
+                "timestamp": dt_now(),
+            }
             self._chunk_buffers[key] = buf
+        else:
+            buf["timestamp"] = dt_now()
 
         parts = buf["parts"]
         if parts[seq - 1] is None:
@@ -388,12 +532,17 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                     target_cluster = self._cluster
                 except Exception:
                     target_cluster = None
-                # fire-and-forget ACK send on the cluster that delivered this payload
-                self._loop.create_task(
-                    self._send_unacked(ack, target_cluster=target_cluster)
+
+                # Fire-and-forget ACK send on the cluster that delivered this payload
+                self._track_task(
+                    self._loop.create_task(
+                        self._send_unacked(ack, target_cluster=target_cluster)
+                    )
                 )
-            except Exception:
-                _LOGGER.exception("Failed to schedule application ACK")
+            except asyncio.CancelledError:
+                raise
+            except Exception as err:
+                _LOGGER.exception("Failed to schedule application ACK: %s", err)
 
         if buf["received"] < total:
             # Not complete yet
@@ -402,74 +551,105 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
         # All parts received; assemble and clear buffer
         assembled = "".join(p if p is not None else "" for p in parts)
         try:
-            # deliver assembled payload to frame reader
+            # Deliver assembled payload to frame reader
             self._frame_read(dt_now().isoformat(), _normalise(assembled))
+        except asyncio.CancelledError:
+            raise
         except Exception as err:
             _LOGGER.exception("Error delivering assembled chunk: %s", err)
-        # cleanup
-        with contextlib.suppress(Exception):
+
+        # Cleanup
+        with contextlib.suppress(KeyError):
             del self._chunk_buffers[key]
+
         return True
 
     def _get_cluster(
         self, device: Any, endpoint_id: int, cluster_id: int, direction: str = "in"
     ) -> Any:
+        """Retrieve a cluster object from a ZHA device endpoint.
+
+        :param device: The ZHA device.
+        :type device: Any
+        :param endpoint_id: The ID of the endpoint.
+        :type endpoint_id: int
+        :param cluster_id: The ID of the cluster.
+        :type cluster_id: int
+        :param direction: The direction ('in' or 'out'), defaults to "in".
+        :type direction: str, optional
+        :raises TransportZigbeeError: If cluster resolution fails.
+        :return: The resolved cluster object.
+        :rtype: Any
+        """
         getter = getattr(device, "async_get_cluster", None)
         if callable(getter):
             try:
                 cluster = getter(endpoint_id, cluster_id, direction)
+            except asyncio.CancelledError:
+                raise
             except Exception as err:
                 # Some ZHA implementations raise KeyError (or other exceptions)
-                # when the cluster is not present; normalize to TransportError
-                raise exc.TransportError(
-                    f"Cluster lookup failed for 0x{cluster_id:04x} on endpoint {endpoint_id}: {err}"
+                # when the cluster is not present; normalize to TransportZigbeeError
+                raise exc.TransportZigbeeError(
+                    f"Cluster lookup failed for 0x{cluster_id:04x} on "
+                    f"endpoint {endpoint_id}: {err}"
                 ) from err
             if cluster is None:
-                raise exc.TransportError(
+                raise exc.TransportZigbeeError(
                     f"Cluster 0x{cluster_id:04x} not found on endpoint {endpoint_id}"
                 )
             return cluster
 
         if not hasattr(device, "endpoints"):
-            raise exc.TransportError("Zigbee device has no endpoints map")
+            raise exc.TransportZigbeeError("Zigbee device has no endpoints map")
 
         endpoint = device.endpoints.get(endpoint_id)
         if endpoint is None:
-            raise exc.TransportError(
+            raise exc.TransportZigbeeError(
                 f"Endpoint {endpoint_id} not found on Zigbee device {self._ieee}"
             )
 
         clusters_attr = "in_clusters" if direction == "in" else "out_clusters"
         clusters = getattr(endpoint, clusters_attr, None)
         if clusters is None:
-            raise exc.TransportError(
+            raise exc.TransportZigbeeError(
                 f"Endpoint {endpoint_id} has no {direction} clusters map"
             )
+
         cluster = clusters.get(cluster_id)
         if cluster is None:
-            raise exc.TransportError(
+            raise exc.TransportZigbeeError(
                 f"Cluster 0x{cluster_id:04x} not found on endpoint {endpoint_id}"
             )
+
         return cluster
 
     def _attach_clusters(self, device: Any) -> None:
+        """Attempt to locate and attach read/write clusters for the device.
+
+        :param device: The ZHA device object.
+        :type device: Any
+        :raises TransportZigbeeError: If clusters cannot be matched.
+        """
         try:
             read_cluster = self._get_cluster(
                 device, self._endpoint_id, self._cluster_id, self._read_direction
             )
-        except exc.TransportError:
+        except exc.TransportZigbeeError:
             # Fallback: search all endpoints and both cluster directions
             # for the requested cluster id, and bind to the first matching
             # endpoint/direction. This helps when the user supplied an
             # endpoint that doesn't expose the custom cluster in the
             # expected direction (in vs out).
             _LOGGER.debug(
-                "Read cluster 0x%04x not found on endpoint %s; searching other endpoints/directions",
+                "Read cluster 0x%04x not found on endpoint %s; "
+                "searching other endpoints/directions",
                 self._cluster_id,
                 self._endpoint_id,
             )
-            # Dump device endpoints and their clusters to help diagnose role/direction mismatches
             try:
+                # Dump device endpoints and their clusters to help diagnose
+                # role/direction mismatches
                 ep_map = {}
                 for ep_id, ep_obj in getattr(device, "endpoints", {}).items():
                     try:
@@ -491,7 +671,8 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                     ep_map[int(ep_id)] = {"in": in_clusters, "out": out_clusters}
                 _LOGGER.debug("ZHA device endpoints map: %s", ep_map)
             except Exception:
-                _LOGGER.exception("Failed to dump device endpoints for debugging")
+                _LOGGER.debug("Failed to dump device endpoints for debugging")
+
             found = False
             for ep_id, _ep in getattr(device, "endpoints", {}).items():
                 for dir_try in ("in", "out"):
@@ -500,7 +681,8 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                             device, int(ep_id), self._cluster_id, dir_try
                         )
                         _LOGGER.info(
-                            "Auto-selected endpoint %s (direction=%s) for read cluster 0x%04x",
+                            "Auto-selected endpoint %s (direction=%s) for read "
+                            "cluster 0x%04x",
                             ep_id,
                             dir_try,
                             self._cluster_id,
@@ -525,12 +707,13 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
             write_cluster = read_cluster
         else:
             _LOGGER.debug(
-                "Write cluster 0x%04x not found on endpoint %s; searching other endpoints/directions",
+                "Write cluster 0x%04x not found on endpoint %s; "
+                "searching other endpoints/directions",
                 self._write_cluster_id,
                 self._write_endpoint_id,
             )
-            # Dump device endpoints and clusters for debugging
             try:
+                # Dump device endpoints and clusters for debugging
                 ep_map = {}
                 for ep_id, ep_obj in getattr(device, "endpoints", {}).items():
                     try:
@@ -552,7 +735,8 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                     ep_map[int(ep_id)] = {"in": in_clusters, "out": out_clusters}
                 _LOGGER.debug("ZHA device endpoints map: %s", ep_map)
             except Exception:
-                _LOGGER.exception("Failed to dump device endpoints for debugging")
+                _LOGGER.debug("Failed to dump device endpoints for debugging")
+
             found = False
             for ep_id, _ep in getattr(device, "endpoints", {}).items():
                 for dir_try in ("in", "out"):
@@ -561,7 +745,8 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                             device, int(ep_id), self._write_cluster_id, dir_try
                         )
                         _LOGGER.info(
-                            "Auto-selected endpoint %s (direction=%s) for write cluster 0x%04x",
+                            "Auto-selected endpoint %s (direction=%s) for write "
+                            "cluster 0x%04x",
                             ep_id,
                             dir_try,
                             self._write_cluster_id,
@@ -576,8 +761,9 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                 if found:
                     break
             if not found:
-                raise exc.TransportError(
-                    f"Write cluster 0x{self._write_cluster_id:04x} not found on device {self._ieee}"
+                raise exc.TransportZigbeeError(
+                    f"Write cluster 0x{self._write_cluster_id:04x} not found "
+                    f"on device {self._ieee}"
                 )
 
         if self._cluster and hasattr(self._cluster, "remove_listener"):
@@ -591,8 +777,12 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
             self._cluster.add_listener(self)
 
     async def _bind_and_configure(self) -> None:
+        """Bind read clusters and configure attribute reporting if supported.
+
+        :raises TransportZigbeeError: If read cluster is missing.
+        """
         if not self._cluster:
-            raise exc.TransportError("Read cluster handle not available")
+            raise exc.TransportZigbeeError("Read cluster handle not available")
 
         if self._use_command_mode:
             return
@@ -608,6 +798,11 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
             await configure(self._attr_id, 0, 0xFFFE, None)
 
     def _refresh_write_cluster(self) -> Any | None:
+        """Re-acquire the write cluster reference.
+
+        :return: The resolved write cluster.
+        :rtype: Any | None
+        """
         if not self._device:
             return self._write_cluster
 
@@ -618,18 +813,26 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                 self._write_cluster_id,
                 self._write_direction,
             )
-        except exc.TransportError:
+        except exc.TransportZigbeeError:
             return None
 
         self._write_cluster = cluster
         return cluster
 
     def _get_active_write_cluster(self, force_refresh: bool = False) -> Any | None:
+        """Return the write cluster, refreshing if explicitly requested or missing.
+
+        :param force_refresh: Whether to enforce refreshing the object.
+        :type force_refresh: bool, optional
+        :return: The write cluster.
+        :rtype: Any | None
+        """
         if force_refresh or self._write_cluster is None:
             return self._refresh_write_cluster()
         return self._write_cluster
 
     def _ensure_read_cluster_bound(self) -> None:
+        """Re-bind the read listener if cluster references have become stale."""
         if not self._device:
             return
 
@@ -637,7 +840,7 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
             cluster = self._get_cluster(
                 self._device, self._endpoint_id, self._cluster_id, self._read_direction
             )
-        except exc.TransportError:
+        except exc.TransportZigbeeError:
             return
 
         if cluster is self._cluster:
@@ -652,27 +855,42 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
             self._cluster.add_listener(self)
 
     def _chunk_payload(self, payload: str) -> list[tuple[int, int, str]]:
+        """Split a string payload into sequence-numbered chunks.
+
+        :param payload: The full string to chunk.
+        :type payload: str
+        :raises TransportZigbeeError: If the chunk header exceeds size limits.
+        :return: A list of tuples containing (seq, total, chunk_string).
+        :rtype: list[tuple[int, int, str]]
+        """
         if len(payload) <= self._max_char_len:
             return [(1, 1, payload)]
 
         total = math.ceil(len(payload) / self._chunk_body_len)
         chunks: list[tuple[int, int, str]] = []
+
         for idx in range(total):
             start = idx * self._chunk_body_len
             body = payload[start : start + self._chunk_body_len]
             header = f"{idx + 1}/{total}|"
             allowed = self._max_char_len - len(header)
             if allowed <= 0:
-                raise exc.TransportError(
+                raise exc.TransportZigbeeError(
                     "Chunk header exceeds Zigbee char-string limit"
                 )
             body = body[:allowed]
-            chunk = header + body
-            chunks.append((idx + 1, total, chunk))
+            chunks.append((idx + 1, total, header + body))
 
         return chunks
 
     def _decode_command_payload(self, args: Any) -> str | None:
+        """Safely decode incoming ZCL command arguments into a string payload.
+
+        :param args: The arbitrary payload argument block.
+        :type args: Any
+        :return: The decoded string or None if unparseable.
+        :rtype: str | None
+        """
         if isinstance(args, str):
             return args
 
@@ -690,11 +908,11 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
 
         # Check if this is a valid ZCL char-string (length prefix + data)
         # where the first byte indicates the string length
-        if len(raw) >= 2 and raw[0] > 0 and raw[0] <= len(raw) - 1:
+        if len(raw) >= 2 and 0 < raw[0] <= len(raw) - 1:
             string_data = raw[1 : 1 + raw[0]]
-
-            # Check if the string data looks like a chunk header (e.g., "1/2|..." or "2/2|...")
             try:
+                # Check if the string data looks like a chunk header
+                # (e.g., "1/2|..." or "2/2|...")
                 data_str = string_data.decode("ascii", errors="strict")
                 if len(data_str) >= 4 and data_str[0].isdigit():
                     slash_pos = data_str.find("/")
@@ -712,19 +930,32 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
     async def _send_command(
         self, chunk: str, seq: int, total: int, cmd_override: int | None = None
     ) -> None:
+        """Send a string payload as a ZCL command to the write cluster.
+
+        :param chunk: The payload to send.
+        :type chunk: str
+        :param seq: Chunk sequence number.
+        :type seq: int
+        :param total: Total chunks.
+        :type total: int
+        :param cmd_override: Command ID to override default.
+        :type cmd_override: int | None, optional
+        :raises TransportZigbeeError: If the send attempt fails after retries.
+        """
         cluster = self._get_active_write_cluster()
         if not cluster:
-            raise exc.TransportError("Zigbee write cluster not ready")
+            raise exc.TransportZigbeeError("Zigbee write cluster not ready")
 
         _LOGGER.debug("Zigbee TX %s/%s: %s", seq, total, chunk)
-
         last_err: Exception | None = None
+
         # If a command override is requested (e.g., ACK=0x01) and we have
         # an active read cluster (self._cluster), try sending the command on
         # that cluster first. This helps hit the server/client direction
         # mapping that the device expects for ACK responses.
         tried_clusters: list[Any] = []
         candidate_clusters: list[Any] = []
+
         if cmd_override is not None and getattr(self, "_cluster", None) is not None:
             candidate_clusters.append(self._cluster)
         candidate_clusters.append(cluster)
@@ -736,6 +967,7 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                 tried_clusters.append(candidate)
                 try:
                     use_cmd = cmd_override if cmd_override is not None else self._cmd_id
+
                     # Prefer explicit client_command API when available (client->server)
                     if hasattr(candidate, "client_command"):
                         try:
@@ -744,17 +976,21 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                             )
                             return
                         except KeyError as ke:
-                            # Missing client command mapping for this id — try server-side command
+                            # Missing client command mapping for this id — try server
                             _LOGGER.debug(
-                                "client_command KeyError (cmd=0x%02x) on cluster 0x%04x, will try server_command: %s",
+                                "client_command KeyError (cmd=0x%02x) on "
+                                "cluster 0x%04x, will try server_command: %s",
                                 use_cmd,
                                 getattr(candidate, "cluster_id", 0),
                                 ke,
                             )
-                        except Exception as err:  # pragma: no cover - defensive
+                        except asyncio.CancelledError:
+                            raise
+                        except Exception as err:
                             last_err = err
                             _LOGGER.warning(
-                                "Zigbee write cmd %s/%s attempt %s failed (endpoint=%s cluster=0x%04x cmd=0x%02x): %s (%s)",
+                                "Zigbee write cmd %s/%s attempt %s failed "
+                                "(endpoint=%s cluster=0x%04x cmd=0x%02x): %s (%s)",
                                 seq,
                                 total,
                                 attempt,
@@ -765,17 +1001,21 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                                 type(err).__name__,
                             )
 
-                    # If client_command not available or failed with KeyError, try server_command (server->client)
+                    # If client_command not available or failed with KeyError,
+                    # try server_command (server->client)
                     if hasattr(candidate, "server_command"):
                         try:
                             await candidate.server_command(
                                 use_cmd, chunk, expect_reply=False
                             )
                             return
-                        except Exception as err:  # pragma: no cover - defensive
+                        except asyncio.CancelledError:
+                            raise
+                        except Exception as err:
                             last_err = err
                             _LOGGER.warning(
-                                "Zigbee write server cmd %s/%s attempt %s failed (endpoint=%s cluster=0x%04x cmd=0x%02x): %s (%s)",
+                                "Zigbee write server cmd %s/%s attempt %s failed "
+                                "(endpoint=%s cluster=0x%04x cmd=0x%02x): %s (%s)",
                                 seq,
                                 total,
                                 attempt,
@@ -791,10 +1031,13 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                         try:
                             await candidate.command(use_cmd, chunk, expect_reply=False)
                             return
-                        except Exception as err:  # pragma: no cover - defensive
+                        except asyncio.CancelledError:
+                            raise
+                        except Exception as err:
                             last_err = err
                             _LOGGER.warning(
-                                "Zigbee write generic cmd %s/%s attempt %s failed (endpoint=%s cluster=0x%04x cmd=0x%02x): %s (%s)",
+                                "Zigbee write generic cmd %s/%s attempt %s failed "
+                                "(endpoint=%s cluster=0x%04x cmd=0x%02x): %s (%s)",
                                 seq,
                                 total,
                                 attempt,
@@ -805,7 +1048,8 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                                 type(err).__name__,
                             )
 
-                    # If we reach here, nothing succeeded — dump available mappings for debugging
+                    # If we reach here, nothing succeeded — dump available mappings
+                    # for debugging
                     try:
                         client_map = getattr(
                             candidate, "client_commands", None
@@ -821,21 +1065,23 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                         )
                     except Exception:
                         pass
-                    # fall through to outer retry/refresh logic
-                except Exception as err:  # pragma: no cover - defensive
+                except asyncio.CancelledError:
+                    raise
+                except Exception as err:
                     last_err = err
                     _LOGGER.warning(
-                        "Zigbee write cmd %s/%s attempt %s unexpected failure (endpoint=%s cluster=0x%04x cmd=0x%02x): %s (%s)",
+                        "Zigbee write cmd %s/%s attempt %s unexpected failure "
+                        "(endpoint=%s cluster=0x%04x): %s (%s)",
                         seq,
                         total,
                         attempt,
                         self._write_endpoint_id,
                         self._write_cluster_id,
-                        cmd_override if cmd_override is not None else self._cmd_id,
                         err,
                         type(err).__name__,
                     )
-            # refresh and retry once
+
+            # Refresh and retry once
             if attempt == 1:
                 refreshed = self._get_active_write_cluster(force_refresh=True)
                 if refreshed and refreshed is not cluster:
@@ -848,14 +1094,23 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
             break
 
         if last_err is None:
-            raise exc.TransportError("Failed to send Zigbee command")
-
-        raise exc.TransportError("Failed to send Zigbee command") from last_err
+            raise exc.TransportZigbeeError("Failed to send Zigbee command")
+        raise exc.TransportZigbeeError("Failed to send Zigbee command") from last_err
 
     async def _send_chunk(self, chunk: str, seq: int, total: int) -> None:
+        """Write a string chunk to a Zigbee attribute.
+
+        :param chunk: The string payload.
+        :type chunk: str
+        :param seq: Chunk sequence number.
+        :type seq: int
+        :param total: Total chunks.
+        :type total: int
+        :raises TransportZigbeeError: If the send attempt fails after retries.
+        """
         cluster = self._get_active_write_cluster()
         if not cluster:
-            raise exc.TransportError("Zigbee write cluster not ready")
+            raise exc.TransportZigbeeError("Zigbee write cluster not ready")
 
         _LOGGER.debug(
             "Zigbee write chunk %s/%s (len=%s endpoint=%s cluster=0x%04x): %s",
@@ -877,10 +1132,13 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                     {self._write_attr_id: value}, manufacturer=None
                 )
                 return
-            except Exception as err:  # pragma: no cover - defensive
+            except asyncio.CancelledError:
+                raise
+            except Exception as err:
                 last_err = err
                 _LOGGER.warning(
-                    "Zigbee write chunk %s/%s attempt %s failed (endpoint=%s cluster=0x%04x): %s",
+                    "Zigbee write chunk %s/%s attempt %s failed "
+                    "(endpoint=%s cluster=0x%04x): %s",
                     seq,
                     total,
                     attempt,
@@ -896,18 +1154,23 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                 break
 
         if last_err is None:
-            raise exc.TransportError("Failed to send Zigbee chunk")
-
-        raise exc.TransportError("Failed to send Zigbee chunk") from last_err
+            raise exc.TransportZigbeeError("Failed to send Zigbee chunk")
+        raise exc.TransportZigbeeError("Failed to send Zigbee chunk") from last_err
 
     async def _send_unacked(self, text: str, target_cluster: Any | None = None) -> None:
-        """Send a small ZCL payload back to the device without expecting an app-level ACK.
+        """Send a ZCL payload back without expecting an app-level ACK.
 
         When `target_cluster` is provided, the send will use that cluster object and
         the command path implied by that cluster (server_command for server->client
         sends, client_command for client->server sends). This avoids probing multiple
         clusters dynamically and enforces deterministic behavior according to the
         quirk definitions.
+
+        :param text: The text payload to transmit.
+        :type text: str
+        :param target_cluster: An explicit cluster target to map the ACK onto.
+        :type target_cluster: Any | None, optional
+        :raises TransportZigbeeError: If generic command triggers raise an exception.
         """
         try:
             chunks = list(self._chunk_payload(text))
@@ -919,18 +1182,25 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
                         if isinstance(chunk, str) and chunk.startswith("ACK ")
                         else self._cmd_id
                     )
+
                     # Use the generic cluster.command API which ZHA cluster objects provide
                     # This respects the cluster role (server/client) under the hood and
                     # avoids relying on presence of `server_command`/`client_command`
                     try:
                         await target_cluster.command(use_cmd, chunk, expect_reply=False)
-                    except Exception as err:  # pragma: no cover - defensive
-                        raise exc.TransportError(
-                            f"Target cluster command failed (cluster=0x{getattr(target_cluster, 'cluster_id', 0):04x} cmd=0x{use_cmd:02x}): {err}"
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as err:
+                        raise exc.TransportZigbeeError(
+                            f"Target cluster command failed "
+                            f"(cluster=0x{getattr(target_cluster, 'cluster_id', 0):04x} "
+                            f"cmd=0x{use_cmd:02x}): {err}"
                         ) from err
                 else:
                     # No explicit cluster provided: fall back to the configured write cluster
                     await self._send_command(chunk, seq, total)
                 await asyncio.sleep(0.01)
-        except Exception as err:  # pragma: no cover - defensive
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
             _LOGGER.warning("Zigbee unacked send failed: %s", err)

--- a/src/ramses_tx/transport/zigbee.py
+++ b/src/ramses_tx/transport/zigbee.py
@@ -74,14 +74,13 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
         protocol: RamsesProtocolT,
         *,
         config: TransportConfig,
-        extra: dict[str, Any] | None = None,
         loop: asyncio.AbstractEventLoop | None = None,
     ) -> None:
         # _FullTransport and _ReadTransport break the cooperative MRO chain by
         # calling their parent classes directly rather than via super().  We
         # therefore initialise both halves of the diamond explicitly.
         _ZigbeeTransportAbstractor.__init__(self, zigbee_url, protocol, loop=loop)
-        _FullTransport.__init__(self, config=config, extra=extra, loop=loop)
+        _FullTransport.__init__(self, config=config, loop=loop)
 
         self._ieee = self._zigbee_url.netloc
         path_parts = [p for p in self._zigbee_url.path.strip("/").split("/") if p]
@@ -124,7 +123,7 @@ class ZigbeeTransport(_FullTransport, _ZigbeeTransportAbstractor):
         self._chunk_body_len = self._CHUNK_BODY_LEN_CMD
 
         self._extra[SZ_IS_EVOFW3] = True
-        self._hass = self._extra.get("_hass")
+        self._hass = config.app_context
         self._device: Any | None = None
         self._zha_gateway: Any | None = None
         self._cluster: Any | None = None

--- a/tests/tests_tx/test_transport_zigbee.py
+++ b/tests/tests_tx/test_transport_zigbee.py
@@ -42,7 +42,7 @@ def _mock_create_task() -> MagicMock:
 
 def _make_transport(
     url: str = _VALID_URL,
-    extra: dict[str, Any] | None = None,
+    app_context: Any = "DEFAULT_MOCK",
 ) -> ZigbeeTransport:
     """Create a ZigbeeTransport with *_async_init* suppressed.
 
@@ -51,7 +51,9 @@ def _make_transport(
     "coroutine was never awaited" warning.
     """
     mock_protocol = MagicMock()
-    _extra: dict[str, Any] = extra if extra is not None else {"_hass": MagicMock()}
+
+    if isinstance(app_context, str) and app_context == "DEFAULT_MOCK":
+        app_context = MagicMock()
 
     mock_loop = MagicMock(spec=asyncio.AbstractEventLoop)
 
@@ -68,8 +70,7 @@ def _make_transport(
     transport = ZigbeeTransport(
         url,
         mock_protocol,
-        config=TransportConfig(),
-        extra=_extra,
+        config=TransportConfig(app_context=app_context),
         loop=mock_loop,
     )
     # Re-install the coro-closing mock so that any subsequent create_task calls
@@ -122,13 +123,13 @@ class TestZigbeeTransportUrlParsing(unittest.TestCase):
         with self.assertRaises(exc.TransportSourceInvalid):
             _make_transport("zigbee:///0xFC00/0x0000/1/0xFC00/0x0001/1")
 
-    def test_hass_extracted_from_extra(self) -> None:
+    def test_hass_extracted_from_config(self) -> None:
         mock_hass = MagicMock()
-        t = _make_transport(extra={"_hass": mock_hass})
+        t = _make_transport(app_context=mock_hass)
         self.assertIs(t._hass, mock_hass)
 
-    def test_hass_none_when_missing_from_extra(self) -> None:
-        t = _make_transport(extra={})
+    def test_hass_none_when_missing_from_config(self) -> None:
+        t = _make_transport(app_context=None)
         self.assertIsNone(t._hass)
 
     def test_is_evofw3_set_true(self) -> None:
@@ -1001,7 +1002,7 @@ class TestAsyncInit(unittest.IsolatedAsyncioTestCase):
     async def test_no_hass_calls_close(self) -> None:
         from unittest.mock import patch
 
-        t = _make_transport(extra={})  # no _hass key
+        t = _make_transport(app_context=None)  # no hass
         t._close = MagicMock()
 
         with patch.dict(

--- a/tests/tests_tx/test_transport_zigbee.py
+++ b/tests/tests_tx/test_transport_zigbee.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import unittest
+from datetime import timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -489,13 +490,13 @@ class TestGetCluster(unittest.TestCase):
     def test_async_get_cluster_returns_none_raises(self) -> None:
         device = MagicMock()
         device.async_get_cluster.return_value = None
-        with self.assertRaises(exc.TransportError):
+        with self.assertRaises(exc.TransportZigbeeError):
             self.t._get_cluster(device, 1, 0xFC00, "out")
 
     def test_async_get_cluster_key_error_raises_transport_error(self) -> None:
         device = MagicMock()
         device.async_get_cluster.side_effect = KeyError("not found")
-        with self.assertRaises(exc.TransportError):
+        with self.assertRaises(exc.TransportZigbeeError):
             self.t._get_cluster(device, 1, 0xFC00, "out")
 
     # --- via endpoints map ---
@@ -529,7 +530,7 @@ class TestGetCluster(unittest.TestCase):
     def test_missing_endpoint_raises(self) -> None:
         device = MagicMock(spec=["endpoints"])
         device.endpoints = {}
-        with self.assertRaises(exc.TransportError):
+        with self.assertRaises(exc.TransportZigbeeError):
             self.t._get_cluster(device, 1, 0xFC00, "in")
 
     def test_missing_cluster_raises(self) -> None:
@@ -537,12 +538,12 @@ class TestGetCluster(unittest.TestCase):
         endpoint.in_clusters = {}
         device = MagicMock(spec=["endpoints"])
         device.endpoints = {1: endpoint}
-        with self.assertRaises(exc.TransportError):
+        with self.assertRaises(exc.TransportZigbeeError):
             self.t._get_cluster(device, 1, 0xFC00, "in")
 
     def test_device_without_endpoints_attr_raises(self) -> None:
         device = MagicMock(spec=[])  # no endpoints, no async_get_cluster
-        with self.assertRaises(exc.TransportError):
+        with self.assertRaises(exc.TransportZigbeeError):
             self.t._get_cluster(device, 1, 0xFC00, "in")
 
 
@@ -666,7 +667,7 @@ class TestWriteFrame(unittest.IsolatedAsyncioTestCase):
     async def test_closing_transport_raises(self) -> None:
         t = await self._make()
         t._closing = True
-        with self.assertRaises(exc.TransportError):
+        with self.assertRaises(exc.TransportZigbeeError):
             await t._write_frame("some frame")
 
     async def test_short_frame_sends_exactly_one_command(self) -> None:
@@ -721,7 +722,7 @@ class TestWaitForGateway(unittest.IsolatedAsyncioTestCase):
         t._GATEWAY_POLL_ATTEMPTS = 1
         t._GATEWAY_POLL_INTERVAL = 0.001
 
-        with self.assertRaises(exc.TransportError):
+        with self.assertRaises(exc.TransportZigbeeError):
             await t._wait_for_gateway()
 
     async def test_no_hass_raises_transport_error(self) -> None:
@@ -730,7 +731,7 @@ class TestWaitForGateway(unittest.IsolatedAsyncioTestCase):
         t._GATEWAY_POLL_ATTEMPTS = 1
         t._GATEWAY_POLL_INTERVAL = 0.001
 
-        with self.assertRaises(exc.TransportError):
+        with self.assertRaises(exc.TransportZigbeeError):
             await t._wait_for_gateway()
 
 
@@ -758,7 +759,7 @@ class TestSendCommand(unittest.IsolatedAsyncioTestCase):
         t = _make_transport()
         t._write_cluster = None
         t._device = None
-        with self.assertRaises(exc.TransportError):
+        with self.assertRaises(exc.TransportZigbeeError):
             await t._send_command("test", 1, 1)
 
     async def test_key_error_falls_back_to_server_command(self) -> None:
@@ -776,7 +777,7 @@ class TestSendCommand(unittest.IsolatedAsyncioTestCase):
         if hasattr(cluster, "command"):
             cluster.command = AsyncMock(side_effect=RuntimeError("fail"))
         # Should raise TransportError after retries exhausted
-        with self.assertRaises(exc.TransportError):
+        with self.assertRaises(exc.TransportZigbeeError):
             await t._send_command("test", 1, 1)
 
 
@@ -863,7 +864,7 @@ class TestClusterBinding(unittest.TestCase):
 
     def test_refresh_write_cluster_get_cluster_failure_returns_none(self) -> None:
         self.t._device = MagicMock()
-        self.t._get_cluster = MagicMock(side_effect=exc.TransportError("missing"))
+        self.t._get_cluster = MagicMock(side_effect=exc.TransportZigbeeError("missing"))
         result = self.t._refresh_write_cluster()
         self.assertIsNone(result)
 
@@ -892,7 +893,7 @@ class TestBindAndConfigure(unittest.IsolatedAsyncioTestCase):
     async def test_no_cluster_raises(self) -> None:
         t = _make_transport()
         t._cluster = None
-        with self.assertRaises(exc.TransportError):
+        with self.assertRaises(exc.TransportZigbeeError):
             await t._bind_and_configure()
 
     async def test_command_mode_skips_bind_and_configure(self) -> None:
@@ -1107,7 +1108,7 @@ class TestAttachClustersFallback(unittest.TestCase):
         ep.out_clusters = {}
         device = MagicMock(spec=["endpoints"])
         device.endpoints = {1: ep}
-        with self.assertRaises(exc.TransportError):
+        with self.assertRaises(exc.TransportZigbeeError):
             t._attach_clusters(device)
 
     def test_write_cluster_fallback_finds_on_different_endpoint(self) -> None:
@@ -1144,7 +1145,7 @@ class TestAttachClustersFallback(unittest.TestCase):
         device = MagicMock(spec=["endpoints"])
         device.endpoints = {1: ep1}  # no ep2 → write cluster 0xFC01 not found
 
-        with self.assertRaises(exc.TransportError):
+        with self.assertRaises(exc.TransportZigbeeError):
             t._attach_clusters(device)
 
 
@@ -1211,7 +1212,7 @@ class TestSendChunk(unittest.IsolatedAsyncioTestCase):
 
         with (
             patch.dict("sys.modules", {"zigpy": MagicMock()}),
-            self.assertRaises(exc.TransportError),
+            self.assertRaises(exc.TransportZigbeeError),
         ):
             await t._send_chunk("payload", 1, 1)
 
@@ -1229,7 +1230,7 @@ class TestSendChunk(unittest.IsolatedAsyncioTestCase):
 
         with (
             patch.dict("sys.modules", {"zigpy": mock_zigpy}),
-            self.assertRaises(exc.TransportError),
+            self.assertRaises(exc.TransportZigbeeError),
         ):
             await t._send_chunk("payload", 1, 1)
 
@@ -1305,6 +1306,86 @@ class TestMaybeHandleChunkErrorDelivery(unittest.TestCase):
         # 1/1 triggers immediate delivery
         result = self.t._maybe_handle_incoming_chunk("1/1|hello")
         self.assertTrue(result)  # must still return True (chunk was handled)
+
+
+# ---------------------------------------------------------------------------
+# 24. Task Tracking & Cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestTaskTracking(unittest.TestCase):
+    """Tests for task registry and cleanup."""
+
+    def setUp(self) -> None:
+        self.t = _make_transport()
+        self.t._tasks.clear()
+
+    def test_track_task_adds_and_clears(self) -> None:
+        mock_task = MagicMock()
+        self.t._track_task(mock_task)
+
+        self.assertIn(mock_task, self.t._tasks)
+        mock_task.add_done_callback.assert_called_once()
+
+        # Simulate the callback firing
+        callback = mock_task.add_done_callback.call_args[0][0]
+        callback(mock_task)
+        self.assertNotIn(mock_task, self.t._tasks)
+
+    def test_close_cancels_pending_tasks(self) -> None:
+        mock_task = MagicMock()
+        mock_task.done.return_value = False
+        self.t._tasks.add(mock_task)
+        self.t.close()
+        mock_task.cancel.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 25. Chunk Buffer TTL Cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestChunkBufferTTL(unittest.TestCase):
+    """Tests for stale chunk buffer garbage collection."""
+
+    def setUp(self) -> None:
+        self.t = _make_transport()
+
+    def test_cleanup_removes_stale_buffers(self) -> None:
+        from ramses_tx.helpers import dt_now
+
+        old_time = dt_now() - timedelta(seconds=self.t._CHUNK_TIMEOUT + 1)
+        fresh_time = dt_now()
+
+        self.t._chunk_buffers["stale_device"] = {
+            "timestamp": old_time,
+            "total": 2,
+            "parts": [None, None],
+        }
+        self.t._chunk_buffers["fresh_device"] = {
+            "timestamp": fresh_time,
+            "total": 2,
+            "parts": [None, None],
+        }
+
+        self.t._cleanup_chunk_buffers()
+
+        self.assertNotIn("stale_device", self.t._chunk_buffers)
+        self.assertIn("fresh_device", self.t._chunk_buffers)
+
+    def test_maybe_handle_triggers_cleanup(self) -> None:
+        from ramses_tx.helpers import dt_now
+
+        old_time = dt_now() - timedelta(seconds=self.t._CHUNK_TIMEOUT + 1)
+        self.t._chunk_buffers["stale_device"] = {
+            "timestamp": old_time,
+            "total": 2,
+            "parts": [None, None],
+        }
+
+        # Calling handle on a normal chunk should trigger the cleanup pass
+        self.t._maybe_handle_incoming_chunk("1/1|data")
+        self.assertNotIn("stale_device", self.t._chunk_buffers)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The Problem:

The recently merged Zigbee transport (PR #502) introduced several architectural "code smells" and stability risks:
1. **Memory Leaks:** `asyncio` tasks created during ACK scheduling were not tracked, leading to potential garbage collection issues or zombie tasks during transport closure.
2. **Buffer Bloat:** Incomplete incoming chunked messages had no Time-To-Live (TTL), meaning partially received frames could reside in memory indefinitely.
3. **Generic Error Handling:** Failures were raised as generic `TransportError`, making it impossible for higher-level logic (like `ramses_rf`) to differentiate between serial failures and Zigbee/ZHA proxy failures.
4. **Typing Violations:** Several areas lacked strict `DeviceIdT` enforcement, causing Mypy failures in strict mode.

## Consequences:

If not implemented, long-running instances (especially those on resource-constrained hardware like the ESP32-C6) could suffer from memory exhaustion or unexpected task crashes during reconnection events. Debugging connection issues would remain difficult due to lack of specific exception types.

## The Fix:

This PR performs a comprehensive stabilization of the Zigbee transport layer. It introduces a task registry for graceful async cleanup, a TTL mechanism for the chunked-message assembly buffer, and a refined exception hierarchy.

## Technical Implementation:
- **Task Tracking:** Added `self._tasks` and `self._track_task()` to register all fire-and-forget tasks. These are now explicitly cancelled in `close()` to ensure a clean shutdown.
- **Chunk Buffer TTL:** Implemented `_cleanup_chunk_buffers()` using a `_CHUNK_TIMEOUT` (5s). Incomplete buffers are now purged automatically during the reception loop.
- **Exception Tightening:** Defined `TransportZigbeeError` in `exceptions.py` and mapped all non-source-invalid failures in `zigbee.py` to this new class.
- **Type Safety:** Corrected IEEE string handling by casting to `DeviceIdT` when calling `_make_connection`.
- **Standards:** All functions updated with **Sphinx-style docstrings** and Ruff-compliant import sorting (Constants > Classes > Variables).

## Testing Performed:

Updated `tests/tests_tx/test_transport_zigbee.py` (127 passes):
- Verified `TransportZigbeeError` is correctly raised and caught.
- Added `TestTaskTracking` to verify tasks are added to the registry and cancelled on close.
- Added `TestChunkBufferTTL` to ensure stale incomplete frames are purged from memory.

## Risks of NOT Implementing:
- Async memory leaks leading to system instability over time.
- Inability to reliably close and restart the transport without leaking tasks.

## Risks of Implementing:

Minor risk of breaking third-party integrations (e.g., `ramses_cc`) that strictly catch `TransportError` but might not yet handle the more specific `TransportZigbeeError`.

## Mitigation Steps:

`TransportZigbeeError` inherits from `TransportError`, ensuring that any existing logic catching the parent class will continue to function without modification.

## AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.