### PR TITLE
Refactor: Implement centralized custom exception hierarchy

### DIFF
--- a/src/ramses_rf/binding_fsm.py
+++ b/src/ramses_rf/binding_fsm.py
@@ -487,7 +487,7 @@ class BindStateBase:
         )
 
         _LOGGER.warning(msg)
-        self._fut.set_exception(exc.BindingFlowFailed(msg))
+        self._fut.set_exception(exc.BindingTimeoutError(msg))
         self._set_context_state(DevHasFailedBinding)
 
     def _set_context_state(self, next_state: type[BindStateBase]) -> None:

--- a/src/ramses_rf/database.py
+++ b/src/ramses_rf/database.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING, Any, NewType
 
 from ramses_tx import CODES_SCHEMA, RQ, Code, Message, Packet
 
+from .exceptions import DatabaseQueryError
 from .storage import PacketLogEntry, StorageWorker
 
 if TYPE_CHECKING:
@@ -430,7 +431,9 @@ class MessageIndex:
         # bool(kwargs)
 
         if not bool(msg) ^ bool(kwargs):
-            raise ValueError("Either a Message or kwargs should be provided, not both")
+            raise DatabaseQueryError(
+                "Either a Message or kwargs should be provided, not both"
+            )
         if msg:
             kwargs["dtm"] = msg.dtm
 
@@ -439,8 +442,9 @@ class MessageIndex:
             # await self._lock.acquire()
             msgs = self._delete_from(**kwargs)
 
-        except sqlite3.Error:  # need to tighten?
+        except sqlite3.Error as err:  # need to tighten?
             self._cx.rollback()
+            raise DatabaseQueryError(f"Delete failed: {err}") from err
 
         else:
             for msg in msgs:
@@ -480,7 +484,9 @@ class MessageIndex:
         """
 
         if not (bool(msg) ^ bool(kwargs)):
-            raise ValueError("Either a Message or kwargs should be provided, not both")
+            raise DatabaseQueryError(
+                "Either a Message or kwargs should be provided, not both"
+            )
 
         if msg:
             kwargs["dtm"] = msg.dtm
@@ -535,7 +541,10 @@ class MessageIndex:
         sql = "SELECT dtm FROM messages WHERE "
         sql += " AND ".join(f"{k} = ?" for k in kw)
 
-        self._cu.execute(sql, tuple(kw.values()))
+        try:
+            self._cu.execute(sql, tuple(kw.values()))
+        except sqlite3.Error as err:
+            raise DatabaseQueryError(f"Query failed: {err}") from err
         return self._cu.fetchall()
 
     def qry(self, sql: str, parameters: tuple[str, ...]) -> tuple[Message, ...]:
@@ -548,9 +557,12 @@ class MessageIndex:
         """
 
         if "SELECT" not in sql:
-            raise ValueError(f"{self}: Only SELECT queries are allowed")
+            raise DatabaseQueryError(f"{self}: Only SELECT queries are allowed")
 
-        self._cu.execute(sql, parameters)
+        try:
+            self._cu.execute(sql, parameters)
+        except sqlite3.Error as err:
+            raise DatabaseQueryError(f"Database error during qry: {err}") from err
 
         lst: list[Message] = []
         # stamp = list(self._msgs)[0] if len(self._msgs) > 0 else "N/A"  # for debug
@@ -582,15 +594,21 @@ class MessageIndex:
             for Cd in CODES_SCHEMA:
                 if code == Cd:
                     return Cd
-            raise LookupError(f"Failed to find matching code for {code}")
+            raise DatabaseQueryError(f"Failed to find matching code for {code}")
 
         sql = """
                 SELECT code from messages WHERE verb is 'RP' AND (src = ? OR dst = ?)
             """
         if "SELECT" not in sql:
-            raise ValueError(f"{self}: Only SELECT queries are allowed")
+            raise DatabaseQueryError(f"{self}: Only SELECT queries are allowed")
 
-        self._cu.execute(sql, parameters)
+        try:
+            self._cu.execute(sql, parameters)
+        except sqlite3.Error as err:
+            raise DatabaseQueryError(
+                f"Database error during get_rp_codes: {err}"
+            ) from err
+
         res = self._cu.fetchall()
         return [get_code(res[0]) for res[0] in self._cu.fetchall()]
 
@@ -606,9 +624,13 @@ class MessageIndex:
         """
 
         if "SELECT" not in sql:
-            raise ValueError(f"{self}: Only SELECT queries are allowed")
+            raise DatabaseQueryError(f"{self}: Only SELECT queries are allowed")
 
-        self._cu.execute(sql, parameters)
+        try:
+            self._cu.execute(sql, parameters)
+        except sqlite3.Error as err:
+            raise DatabaseQueryError(f"Database error during qry_field: {err}") from err
+
         return self._cu.fetchall()
 
     def all(self, include_expired: bool = False) -> tuple[Message, ...]:

--- a/src/ramses_rf/device/__init__.py
+++ b/src/ramses_rf/device/__init__.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from ramses_rf import exceptions as exc
 from ramses_rf.const import DEV_TYPE_MAP
 from ramses_rf.models import DeviceTraits
 from ramses_tx.const import DevType
@@ -139,7 +140,7 @@ def best_dev_role(
                 f"Using the default Heat class for: {dev_addr!r} ({cls._SLUG})"
             )
             return cls
-    except TypeError:
+    except exc.DeviceNotRecognised:
         pass
 
     try:  # or, a HVAC class, eavesdropped from the message code/payload...
@@ -148,7 +149,7 @@ def best_dev_role(
                 f"Using eavesdropped HVAC class for: {dev_addr!r} ({cls._SLUG})"
             )
             return cls  # includes DeviceHvac
-    except TypeError:
+    except exc.DeviceNotRecognised:
         pass
 
     # otherwise, use the default device class...
@@ -184,7 +185,7 @@ def device_factory(
         and traits.device_class in (DevType.HVC, None)
         and traits.faked
     ):
-        raise TypeError(
+        raise exc.SchemaInconsistentError(
             f"Faked devices from the HVAC domain must have an explicit class: {dev_addr}"
         )
 

--- a/src/ramses_rf/device/base.py
+++ b/src/ramses_rf/device/base.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, cast
 from ramses_rf.binding_fsm import BindContext, Vendor
 from ramses_rf.const import DEV_TYPE_MAP, SZ_OEM_CODE, DevType
 from ramses_rf.entity_base import Child, Entity, class_by_attr
+from ramses_rf.exceptions import DeviceNotFaked, SchemaInconsistentError
 from ramses_rf.schemas import SZ_ALIAS, SZ_CLASS, SZ_FAKED, SZ_KNOWN_LIST
 from ramses_tx import Command, Packet, Priority, QosParams
 from ramses_tx.ramses import CODES_BY_DEV_SLUG, CODES_ONLY_FROM_CTL
@@ -91,12 +92,14 @@ class DeviceBase(Entity):
         """Update a device with new schema attributes.
 
         :param traits: The traits to apply (e.g., alias, class, faked)
-        :raises TypeError: If the device is not fakeable but 'faked' is set.
+        :raises DeviceNotFaked: If the device is not fakeable but 'faked' is set.
         """
 
         if traits.faked:  # class & alias are done elsewhere
             if not isinstance(self, Fakeable):
-                raise TypeError(f"Device is not fakeable: {self} (traits={traits})")
+                raise DeviceNotFaked(
+                    f"Device is not fakeable: {self} (traits={traits})"
+                )
             self._make_fake()
 
         self._scheme = traits.scheme
@@ -362,7 +365,7 @@ class Fakeable(DeviceBase):
         """
 
         if not self._bind_context:
-            raise TypeError(f"{self}: Faking not enabled")
+            raise DeviceNotFaked(f"{self}: Faking not enabled")
 
         msgs = await self._bind_context.wait_for_binding_request(
             accept_codes, idx=idx, require_ratify=require_ratify
@@ -391,7 +394,7 @@ class Fakeable(DeviceBase):
         # confirm_code can be FFFF.
 
         if not self._bind_context:
-            raise TypeError(f"{self}: Faking not enabled")
+            raise DeviceNotFaked(f"{self}: Faking not enabled")
 
         if isinstance(offer_codes, Iterable):
             codes: tuple[Code] = offer_codes
@@ -494,7 +497,9 @@ class DeviceHeat(Device):  # Heat domain: Honeywell CH/DHW or compatible
         """Attach a TCS (create/update as required) after passing it any msg."""
 
         if self.type not in DEV_TYPE_MAP.CONTROLLERS:  # potentially can be controllers
-            raise TypeError(f"Invalid device type to be a controller: {self}")
+            raise SchemaInconsistentError(
+                f"Invalid device type to be a controller: {self}"
+            )
 
         self._iz_controller = self._iz_controller or msg or True
 

--- a/src/ramses_rf/device/heat.py
+++ b/src/ramses_rf/device/heat.py
@@ -1322,11 +1322,13 @@ class Thermostat(BatteryState, Setpoint, Temperature, Fakeable):  # THM (..):
             if self._iz_controller is None:
                 # _LOGGER.info(f"{msg!r} # IS_CONTROLLER (10): is FALSE")
                 self._iz_controller = False
-            elif self._iz_controller:  # TODO: raise CorruptStateError
-                _LOGGER.error(f"{msg!r} # IS_CONTROLLER (11): was TRUE, now False")
+            elif self._iz_controller:
+                raise exc.SystemInconsistent(
+                    f"{msg!r} # IS_CONTROLLER (11): was TRUE, now False"
+                )
 
-            if msg.code in CODES_ONLY_FROM_CTL:  # TODO: raise CorruptPktError
-                _LOGGER.error(f"{msg!r} # IS_CONTROLLER (12); is CORRUPT PKT")
+            if msg.code in CODES_ONLY_FROM_CTL:
+                raise exc.PacketInvalid(f"{msg!r} # IS_CONTROLLER (12); is CORRUPT PKT")
 
         elif all(
             (
@@ -1339,8 +1341,10 @@ class Thermostat(BatteryState, Setpoint, Temperature, Fakeable):  # THM (..):
                 # _LOGGER.info(f"{msg!r} # IS_CONTROLLER (20): is TRUE")
                 self._iz_controller = msg
                 self._make_tcs_controller(msg=msg)
-            elif self._iz_controller is False:  # TODO: raise CorruptStateError
-                _LOGGER.error(f"{msg!r} # IS_CONTROLLER (21): was FALSE, now True")
+            elif self._iz_controller is False:
+                raise exc.SystemInconsistent(
+                    f"{msg!r} # IS_CONTROLLER (21): was FALSE, now True"
+                )
 
     async def initiate_binding_process(self) -> Packet:
         return await super()._initiate_binding_process(
@@ -1590,9 +1594,13 @@ def class_dev_heat(
         return HEAT_CLASS_BY_SLUG[slug]
 
     if not eavesdrop:
-        raise TypeError(f"No CH/DHW class for: {dev_addr} (no eavesdropping)")
+        raise exc.DeviceNotRecognised(
+            f"No CH/DHW class for: {dev_addr} (no eavesdropping)"
+        )
 
     if msg and msg.code in CODES_OF_HEAT_DOMAIN_ONLY:
         return DeviceHeat
 
-    raise TypeError(f"No CH/DHW class for: {dev_addr} (unknown type: {dev_addr.type})")
+    raise exc.DeviceNotRecognised(
+        f"No CH/DHW class for: {dev_addr} (unknown type: {dev_addr.type})"
+    )

--- a/src/ramses_rf/device/hvac.py
+++ b/src/ramses_rf/device/hvac.py
@@ -1175,10 +1175,12 @@ def class_dev_hvac(
     """
 
     if not eavesdrop:
-        raise TypeError(f"No HVAC class for: {dev_addr} (no eavesdropping)")
+        raise exc.DeviceNotRecognised(
+            f"No HVAC class for: {dev_addr} (no eavesdropping)"
+        )
 
     if msg is None:
-        raise TypeError(f"No HVAC class for: {dev_addr} (no msg)")
+        raise exc.DeviceNotRecognised(f"No HVAC class for: {dev_addr} (no msg)")
 
     if klass := HVAC_KLASS_BY_VC_PAIR.get((msg.verb, msg.code)):
         return HVAC_CLASS_BY_SLUG[klass]
@@ -1186,7 +1188,9 @@ def class_dev_hvac(
     if msg.code in CODES_OF_HVAC_DOMAIN_ONLY:
         return DeviceHvac
 
-    raise TypeError(f"No HVAC class for: {dev_addr} (insufficient meta-data)")
+    raise exc.DeviceNotRecognised(
+        f"No HVAC class for: {dev_addr} (insufficient meta-data)"
+    )
 
 
 _REMOTES = {

--- a/src/ramses_rf/dispatcher.py
+++ b/src/ramses_rf/dispatcher.py
@@ -85,7 +85,7 @@ def _create_devices_from_addrs(gwy: Gateway, this: Message) -> None:
     #  - eavesdrop: from packet fingerprint, incl. payloads
 
     if not isinstance(this.src, Device):  # type: ignore[unreachable]
-        # may: LookupError, but don't suppress
+        # may: DeviceNotFoundError, but don't suppress
         this.src = gwy.get_device(this.src.id)  # type: ignore[assignment]
         if this.dst.id == this.src.id:
             this.dst = this.src
@@ -95,7 +95,7 @@ def _create_devices_from_addrs(gwy: Gateway, this: Message) -> None:
         return
 
     if not isinstance(this.dst, Device) and this.src != gwy.hgi:  # type: ignore[unreachable]
-        with contextlib.suppress(LookupError):
+        with contextlib.suppress(exc.DeviceNotFoundError):
             this.dst = gwy.get_device(this.dst.id)  # type: ignore[assignment]
 
 
@@ -237,7 +237,7 @@ def process_msg(gwy: Gateway, msg: Message) -> None:
 
         try:
             _create_devices_from_addrs(gwy, msg)
-        except LookupError as err:
+        except exc.DeviceNotFoundError as err:
             (_LOGGER.error if _DBG_INCREASE_LOG_LEVELS else _LOGGER.warning)(
                 "%s < %s(%s)", msg._pkt, err.__class__.__name__, err
             )

--- a/src/ramses_rf/entity_base.py
+++ b/src/ramses_rf/entity_base.py
@@ -370,7 +370,9 @@ class _MessageDB(_Entity):
             # only 1 result expected since hdr is a unique key in _gwy.msg_db
             if msgs:
                 if msgs[0]._pkt._hdr != hdr:
-                    raise LookupError
+                    raise exc.DatabaseQueryError(
+                        f"Header mismatch: {msgs[0]._pkt._hdr} != {hdr}"
+                    )
                 return msgs[0]
         else:
             msg: Message
@@ -393,7 +395,9 @@ class _MessageDB(_Entity):
                 return None
 
             if msg._pkt._hdr != hdr:
-                raise LookupError
+                raise exc.DatabaseQueryError(
+                    f"Header mismatch: {msg._pkt._hdr} != {hdr}"
+                )
             return msg
         return None
 
@@ -968,9 +972,10 @@ class _Discovery(_MessageDB):
         Both `timeout` and `delay` are in seconds.
         """
 
-        if cmd.rx_header is None:  # TODO: raise TypeError
-            _LOGGER.warning(f"cmd({cmd}): invalid (null) header not added to discovery")
-            return
+        if cmd.rx_header is None:
+            raise exc.CommandInvalid(
+                f"cmd({cmd}): invalid (null) header not added to discovery"
+            )
 
         if cmd.rx_header in self.discovery_cmds:
             _LOGGER.info(f"cmd({cmd}): duplicate header not added to discovery")
@@ -1268,7 +1273,7 @@ class Parent(Entity):  # A System, Zone, DhwZone or a UfhController
             self._sensor = child
 
         elif is_sensor:
-            raise TypeError(
+            raise exc.SchemaInconsistentError(
                 f"not a valid combination for {self}: {child}|{child_id}|{is_sensor}"
             )
 
@@ -1306,7 +1311,7 @@ class Parent(Entity):  # A System, Zone, DhwZone or a UfhController
             pass
 
         else:
-            raise TypeError(
+            raise exc.SchemaInconsistentError(
                 f"not a valid combination for {self}: {child}|{child_id}|{is_sensor}"
             )
 
@@ -1377,7 +1382,7 @@ class Child(Entity):  # A Zone, Device or a UfhCircuit
     ) -> tuple[Parent, str | None]:
         """Get the device's parent, after validating it."""
         if parent is None:
-            raise TypeError(f"{self}: parent cannot be None")
+            raise exc.SchemaInconsistentError(f"{self}: parent cannot be None")
 
         parent_class = parent.__class__.__name__
         self_class = self.__class__.__name__
@@ -1416,7 +1421,7 @@ class Child(Entity):  # A Zone, Device or a UfhCircuit
             child_id = child_id or getattr(parent, "idx", None)
 
         elif parent_class == "UfhController" and not child_id:
-            raise TypeError(
+            raise exc.SchemaInconsistentError(
                 f"{self}: can't set child_id to: {child_id} "
                 f"(for Circuits, it must be a circuit_idx)"
             )
@@ -1466,44 +1471,44 @@ class Child(Entity):  # A Zone, Device or a UfhCircuit
 
         rules = PARENT_RULES.get(parent_class)
         if not rules:
-            raise TypeError(
+            raise exc.SchemaInconsistentError(
                 f"for Parent {parent}: not a valid parent "
                 f"(it must be {tuple(PARENT_RULES.keys())})"
             )
 
         if is_sensor and self_class not in rules[SZ_SENSOR]:
-            raise TypeError(
+            raise exc.SchemaInconsistentError(
                 f"for Parent {parent}: Sensor {self} must be {rules[SZ_SENSOR]}"
             )
         if not is_sensor and self_class not in rules[SZ_ACTUATORS]:
-            raise TypeError(
+            raise exc.SchemaInconsistentError(
                 f"for Parent {parent}: Actuator {self} must be {rules[SZ_ACTUATORS]}"
             )
 
         if "Zone" in parent_class and parent_class != "DhwZone":
             parent_idx = getattr(parent, "idx", None)  # noqa: B009
             if child_id != parent_idx:
-                raise TypeError(
+                raise exc.SchemaInconsistentError(
                     f"{self}: can't set child_id to: {child_id} "
                     f"(it must match its parent's zone idx, {parent_idx})"
                 )
 
         elif parent_class == "DhwZone":  # usu. FA (HW), could be F9
             if child_id not in (F9, FA):  # may not be known if eavesdrop'd
-                raise TypeError(
+                raise exc.SchemaInconsistentError(
                     f"{self}: can't set child_id to: {child_id} "
                     f"(for DHW, it must be F9 or FA)"
                 )
 
         elif parent_class in ("System", "Evohome"):  # usu. FC
             if child_id not in (FC, FF):  # was: not in (F9, FA, FC, "HW"):
-                raise TypeError(
+                raise exc.SchemaInconsistentError(
                     f"{self}: can't set child_id to: {child_id} "
                     f"(for TCS, it must be FC)"
                 )
 
         elif parent_class != "UfhController":  # is like CTL/TCS combined
-            raise TypeError(
+            raise exc.SchemaInconsistentError(
                 f"{self}: can't set Parent to: {parent} "
                 f"(it must be System, DHW, Zone, or UfhController)"
             )

--- a/src/ramses_rf/exceptions.py
+++ b/src/ramses_rf/exceptions.py
@@ -32,6 +32,10 @@ class BindingFlowFailed(BindingError):
     """The binding failed due to a timeout or retry limit being exceeded."""
 
 
+class BindingTimeoutError(BindingError):
+    """Raised when a binding operation exceeds the allotted time."""
+
+
 ########################################################################################
 # Errors above the protocol/transport layer, incl. message processing, state & schema
 
@@ -52,6 +56,14 @@ class ScheduleFlowError(ScheduleError):
 # Errors above the protocol/transport layer, incl. message processing, state & schema
 
 
+class DatabaseQueryError(_RamsesUpperError):
+    """Raised when a query to the message database fails or is invalid."""
+
+
+class DeviceNotFoundError(_RamsesUpperError):
+    """Raised when a specific device cannot be found in the gateway or system."""
+
+
 class ExpiredCallbackError(_RamsesUpperError):
     """Raised when the callback has expired."""
 
@@ -64,6 +76,12 @@ class SystemSchemaInconsistent(SystemInconsistent):
     """Raised when the system state (usu. schema) is inconsistent."""
 
     HINT = "try restarting the client library"
+
+
+class SchemaInconsistentError(SystemSchemaInconsistent):
+    """Raised when the loaded schema contradicts the known state or rules."""
+
+    HINT = "check the configuration schema for conflicting definitions"
 
 
 class DeviceNotFaked(SystemInconsistent):

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -68,6 +68,7 @@ from ramses_tx.typing import PktLogConfigT, PortConfigT
 from .database import MessageIndex
 from .device import DeviceHeat, DeviceHvac, Fakeable, HgiGateway, device_factory
 from .dispatcher import detect_array_fragment, process_msg
+from .exceptions import DeviceNotFaked, DeviceNotFoundError, SchemaInconsistentError
 from .interfaces import GatewayInterface, MessageIndexInterface
 from .models import DeviceTraits
 from .schemas import load_schema
@@ -520,11 +521,11 @@ class Gateway(Engine, GatewayInterface):
         :type dev: Device
         :returns: None
         :rtype: None
-        :raises LookupError: If the device already exists in the gateway.
+        :raises SchemaInconsistentError: If the device already exists in the gateway.
         """
 
         if dev.id in self.device_by_id:
-            raise LookupError(f"Device already exists: {dev.id}")
+            raise SchemaInconsistentError(f"Device already exists: {dev.id}")
 
         self.devices.append(dev)
         self.device_by_id[dev.id] = dev
@@ -556,34 +557,36 @@ class Gateway(Engine, GatewayInterface):
         :type is_sensor: bool | None, optional
         :returns: The existing or newly created device instance.
         :rtype: Device
-        :raises LookupError: If the device ID is blocked or not in the allowed known_list.
+        :raises DeviceNotFoundError: If the device ID is blocked or not in the allowed known_list.
         """
 
-        def check_filter_lists(dev_id: DeviceIdT) -> None:  # may: LookupError
-            """Raise a LookupError if a device_id is filtered out by a list."""
+        def check_filter_lists(dev_id: DeviceIdT) -> None:  # may: DeviceNotFoundError
+            """Raise a DeviceNotFoundError if a device_id is filtered out by a list."""
 
             if dev_id in self._unwanted:  # TODO: shouldn't invalidate a msg
-                raise LookupError(f"Can't create {dev_id}: it is unwanted or invalid")
+                raise DeviceNotFoundError(
+                    f"Can't create {dev_id}: it is unwanted or invalid"
+                )
 
             if self._enforce_known_list and (
                 dev_id not in self._include and dev_id != getattr(self.hgi, "id", None)
             ):
                 self._unwanted.append(dev_id)
-                raise LookupError(
+                raise DeviceNotFoundError(
                     f"Can't create {dev_id}: it is not an allowed device_id"
                     f" (if required, add it to the {SZ_KNOWN_LIST})"
                 )
 
             if dev_id in self._exclude:
                 self._unwanted.append(dev_id)
-                raise LookupError(
+                raise DeviceNotFoundError(
                     f"Can't create {dev_id}: it is a blocked device_id"
                     f" (if required, remove it from the {SZ_BLOCK_LIST})"
                 )
 
         try:
             check_filter_lists(device_id)
-        except LookupError:
+        except DeviceNotFoundError:
             # have to allow for GWY not being in known_list...
             if device_id != self._protocol.hgi_id:
                 raise  # TODO: make parochial
@@ -636,24 +639,27 @@ class Gateway(Engine, GatewayInterface):
         :type create_device: bool, optional
         :returns: The faked device instance.
         :rtype: Device | Fakeable
-        :raises TypeError: If the device ID is invalid or the device is not fakeable.
-        :raises LookupError: If the device does not exist and create_device is False,
+        :raises SchemaInconsistentError: If the device ID is invalid.
+        :raises DeviceNotFoundError: If the device does not exist and create_device is False,
                              or if create_device is True but the ID is not in known_list.
+        :raises DeviceNotFaked: If the device is not fakeable.
         """
 
         if not is_valid_dev_id(device_id):
-            raise TypeError(f"The device id is not valid: {device_id}")
+            raise SchemaInconsistentError(f"The device id is not valid: {device_id}")
 
         if not create_device and device_id not in self.device_by_id:
-            raise LookupError(f"The device id does not exist: {device_id}")
+            raise DeviceNotFoundError(f"The device id does not exist: {device_id}")
         elif create_device and device_id not in self.known_list:
-            raise LookupError(f"The device id is not in the known_list: {device_id}")
+            raise DeviceNotFoundError(
+                f"The device id is not in the known_list: {device_id}"
+            )
 
         if (dev := self.get_device(device_id)) and isinstance(dev, Fakeable):
             dev._make_fake()
             return dev
 
-        raise TypeError(f"The device is not fakeable: {device_id}")
+        raise DeviceNotFaked(f"The device is not fakeable: {device_id}")
 
     @property
     def tcs(self) -> Evohome | None:

--- a/src/ramses_rf/schemas.py
+++ b/src/ramses_rf/schemas.py
@@ -325,13 +325,13 @@ SCH_RESTORE_CACHE_DICT = {
 def _get_device(gwy: Gateway, dev_id: DeviceIdT, **kwargs: Any) -> Device:  # , **traits
     """Get a device from the gateway.
 
-    Raise a LookupError if a device_id is filtered out by the known or block list.
+    Raise a DeviceNotFoundError if a device_id is filtered out by the known or block list.
 
     The underlying method is wrapped only to provide a better error message.
     """
 
     def check_filter_lists(dev_id: DeviceIdT) -> None:
-        """Raise a LookupError if a device_id is filtered out by a list."""
+        """Raise a DeviceNotFoundError if a device_id is filtered out by a list."""
 
         err_msg = None
         if gwy._enforce_known_list and dev_id not in gwy._include:
@@ -342,7 +342,7 @@ def _get_device(gwy: Gateway, dev_id: DeviceIdT, **kwargs: Any) -> Device:  # , 
             err_msg = f"it is in the {SZ_SCHEMA}, but also in the {SZ_BLOCK_LIST}"
 
         if err_msg:
-            raise LookupError(
+            raise exc.DeviceNotFoundError(
                 f"Can't create {dev_id}: {err_msg} (check the lists and the {SZ_SCHEMA})"
             )
 
@@ -385,7 +385,7 @@ def load_schema(
         if traits.get(SZ_FAKED):
             dev = _get_device(gwy, device_id)  # , **traits)
             if not isinstance(dev, Fakeable):
-                raise exc.SystemSchemaInconsistent(f"Device is not fakeable: {dev}")
+                raise exc.DeviceNotFaked(f"Device is not fakeable: {dev}")
             if not dev.is_faked:
                 dev._make_fake()
 

--- a/src/ramses_rf/system/faultlog.py
+++ b/src/ramses_rf/system/faultlog.py
@@ -8,6 +8,7 @@ import logging
 from collections import OrderedDict
 from typing import TYPE_CHECKING, NewType, TypeAlias
 
+from ramses_rf import exceptions as exc
 from ramses_tx import Command, Message, Packet
 from ramses_tx.const import (
     SZ_LOG_ENTRY,
@@ -71,8 +72,8 @@ class FaultLogEntry:
     def _is_matching_pair(self, other: object) -> bool:
         """Return True if the other entry could be a matching pair (fault/restore)."""
 
-        if not isinstance(other, FaultLogEntry):  # TODO: make a parochial exception
-            raise TypeError(f"{other} is not not a FaultLogEntry")
+        if not isinstance(other, FaultLogEntry):
+            raise exc.SystemInconsistent(f"{other} is not a FaultLogEntry")
 
         if self.fault_state == FaultState.FAULT:
             return (
@@ -110,8 +111,8 @@ class FaultLogEntry:
         """Create a fault log entry from a packet's payload."""
 
         log_entry = parse_fault_log_entry(pkt.payload)
-        if log_entry is None:  # TODO: make a parochial exception
-            raise TypeError("Null fault log entry")
+        if log_entry is None:
+            raise exc.SystemInconsistent("Null fault log entry")
 
         return cls(**{k: v for k, v in log_entry.items() if k[:1] != "_"})  # type: ignore[arg-type]
 

--- a/src/ramses_rf/system/heat.py
+++ b/src/ramses_rf/system/heat.py
@@ -37,6 +37,7 @@ from ramses_rf.device import (
     UfhController,
 )
 from ramses_rf.entity_base import Entity, Parent, class_by_attr
+from ramses_rf.exceptions import ScheduleFlowError, SchemaInconsistentError
 from ramses_rf.helpers import shrink
 from ramses_rf.schemas import (
     DEFAULT_MAX_ZONES,
@@ -120,9 +121,9 @@ class SystemBase(Parent, Entity):  # 3B00 (multi-relay)
         _LOGGER.debug("Creating a TCS for CTL: %s (%s)", ctl.id, self.__class__)
 
         if ctl.id in ctl._gwy.system_by_id:
-            raise LookupError(f"Duplicate TCS for CTL: {ctl.id}")
+            raise SchemaInconsistentError(f"Duplicate TCS for CTL: {ctl.id}")
         if not isinstance(ctl, Controller):  # TODO
-            raise ValueError(f"Invalid CTL: {ctl} (is not a controller)")
+            raise SchemaInconsistentError(f"Invalid CTL: {ctl} (is not a controller)")
 
         super().__init__(ctl._gwy)
 
@@ -673,7 +674,7 @@ class ScheduleSync(SystemBase):  # 0006 (+/- 0404?)
             await asyncio.sleep(0.005)  # gives the other zone enough time
 
         else:
-            raise TimeoutError(
+            raise ScheduleFlowError(
                 f"Unable to obtain lock for {zone_idx} (used by {self.zone_lock_idx})"
             )
 

--- a/src/ramses_rf/system/schedule.py
+++ b/src/ramses_rf/system/schedule.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, Final, NotRequired, TypeAlias, TypedDict
 
 import voluptuous as vol  # type: ignore[import, unused-ignore]
 
+from ramses_rf import exceptions as exc
 from ramses_rf.const import (
     SZ_FRAG_NUMBER,
     SZ_FRAGMENT,
@@ -255,10 +256,10 @@ class Schedule:  # 0404
                 self._get_schedule(force_io=force_io), timeout=timeout
             )
         except TimeoutError as err:
-            raise TimeoutError(
+            raise exc.ScheduleFlowError(
                 f"Failed to obtain schedule within {timeout} secs"
             ) from err
-        # TODO: raise a more parochial exception
+
         return self.schedule
 
     async def _get_schedule(self, *, force_io: bool = False) -> None:
@@ -319,8 +320,8 @@ class Schedule:  # 0404
             schedule = fragz_to_full_sched(
                 payload[SZ_FRAGMENT] for payload in payload_set if payload
             )  # TODO: messy - what is set not full
-        except zlib.error:
-            return None  # TODO: raise a more parochial exception
+        except zlib.error as err:
+            raise exc.ScheduleError("Failed to decompress schedule fragments") from err
 
         if self.idx == "HW":
             schedule[SZ_ZONE_IDX] = "HW"
@@ -387,7 +388,7 @@ class Schedule:  # 0404
             try:
                 full_schedule = schedule_schema(full_schedule)
             except vol.MultipleInvalid as err:
-                raise TypeError(f"failed to set schedule: {err}") from err
+                raise exc.ScheduleError(f"failed to set schedule: {err}") from err
 
             if self.idx == "HW":  # HACK: to avoid confusing dhw with zone '00'
                 full_schedule[SZ_ZONE_IDX] = "00"
@@ -403,7 +404,7 @@ class Schedule:  # 0404
             for num, frag in enumerate(self._fragments, 1):
                 await put_fragment(num, len(self._fragments), frag)
         except TimeoutError as err:
-            raise TimeoutError(f"failed to set schedule: {err}") from err
+            raise exc.ScheduleFlowError(f"failed to set schedule: {err}") from err
         else:
             if not force_refresh:
                 self._global_ver, _ = await self.tcs._schedule_version(force_io=True)

--- a/src/ramses_rf/system/zones.py
+++ b/src/ramses_rf/system/zones.py
@@ -201,9 +201,11 @@ class DhwZone(ZoneSchedule):  # CS92A
         _LOGGER.debug("Creating a DHW for TCS: %s_HW (%s)", tcs.id, self.__class__)
 
         if tcs.dhw:
-            raise LookupError(f"Duplicate DHW for TCS: {tcs.id}")
+            raise exc.SchemaInconsistentError(f"Duplicate DHW for TCS: {tcs.id}")
         if zone_idx not in (None, "HW"):
-            raise ValueError(f"Invalid zone idx for DHW: {zone_idx} (not 'HW'/null)")
+            raise exc.SchemaInconsistentError(
+                f"Invalid zone idx for DHW: {zone_idx} (not 'HW'/null)"
+            )
 
         super().__init__(tcs, "HW")
 
@@ -473,9 +475,13 @@ class Zone(ZoneSchedule):
         _LOGGER.debug("Creating a Zone: %s_%s (%s)", tcs.id, zone_idx, self.__class__)
 
         if zone_idx in tcs.zone_by_idx:
-            raise LookupError(f"Duplicate ZON for TCS: {tcs.id}_{zone_idx}")
+            raise exc.SchemaInconsistentError(
+                f"Duplicate ZON for TCS: {tcs.id}_{zone_idx}"
+            )
         if int(zone_idx, 16) >= tcs._max_zones:
-            raise ValueError(f"Invalid zone_idx: {zone_idx} (exceeds max_zones)")
+            raise exc.SchemaInconsistentError(
+                f"Invalid zone_idx: {zone_idx} (exceeds max_zones)"
+            )
 
         super().__init__(tcs, zone_idx)
 
@@ -500,7 +506,7 @@ class Zone(ZoneSchedule):
             if zone_type in (ZON_ROLE_MAP.ACT, ZON_ROLE_MAP.SEN):
                 return  # generic zone classes
             if zone_type not in ZON_ROLE_MAP.HEAT_ZONES:
-                raise TypeError
+                raise exc.SchemaInconsistentError(f"Invalid zone type: {zone_type}")
 
             klass = ZON_ROLE_MAP.slug(zone_type)  # not incl. DHW?
 
@@ -511,10 +517,14 @@ class Zone(ZoneSchedule):
                 None,
                 ZoneRole.ELE,
             ):
-                raise ValueError(f"Not a compatible zone class for {self}: {zone_type}")
+                raise exc.SchemaInconsistentError(
+                    f"Not a compatible zone class for {self}: {zone_type}"
+                )
 
             elif klass not in ZONE_CLASS_BY_SLUG:
-                raise ValueError(f"Not a known zone class (for {self}): {zone_type}")
+                raise exc.SchemaInconsistentError(
+                    f"Not a known zone class (for {self}): {zone_type}"
+                )
 
             if self._SLUG is not None:
                 raise exc.SystemSchemaInconsistent(
@@ -831,7 +841,7 @@ class Zone(ZoneSchedule):
         elif setpoint is not None:  # unsure if Hometronics supports setpoint of None
             cmd = Command.set_zone_setpoint(self.ctl.id, self.idx, setpoint)
         else:
-            raise ValueError("Invalid mode/setpoint")
+            raise exc.CommandInvalid("Invalid mode/setpoint")
 
         return self._gwy.send_cmd(cmd, priority=Priority.HIGH)
 
@@ -879,9 +889,9 @@ class EleZone(Zone):  # BDR91A/T  # TODO: 0008/0009/3150
         # if msg.code == Code._0008:  # ZON zones are ELE zones that also call for heat
         #     self._update_schema(**{SZ_CLASS: ZON_ROLE_MAP[ZON_ROLE.VAL]})
         if msg.code == Code._3150:
-            raise TypeError("WHAT 1")
+            raise exc.SystemInconsistent("EleZone cannot process 3150 (heat demand)")
         elif msg.code == Code._3EF0:
-            raise TypeError("WHAT 2")
+            raise exc.SystemInconsistent("EleZone cannot process 3EF0")
 
     @property
     def heat_demand(self) -> float | None:

--- a/src/ramses_tx/exceptions.py
+++ b/src/ramses_tx/exceptions.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""RAMSES RF - exceptions within the packet/protocol/transport layer."""
+"""RAMSES RF - exceptions within the packet/protocol/transport layer.
+
+This module defines the centralized exception hierarchy for handling errors
+across the parser, protocol, and transport layers.
+"""
 
 from __future__ import annotations
 
@@ -11,15 +15,20 @@ class _RamsesBaseException(Exception):
 
 
 class RamsesException(_RamsesBaseException):
-    """Base class for all ramses_tx exceptions."""
+    """Base class for all ramses_tx exceptions providing hint support.
 
-    HINT: None | str = None
+    :param args: The arguments passed to the exception, typically the message.
+    """
+
+    HINT: str | None = None
 
     def __init__(self, *args: object) -> None:
+        """Initialize the exception with an optional message."""
         super().__init__(*args)
         self.message: str | None = str(args[0]) if args else None
 
     def __str__(self) -> str:
+        """Return the string representation of the exception including the hint."""
         if self.message and self.HINT:
             return f"{self.message} (hint: {self.HINT})"
         if self.message:
@@ -34,23 +43,12 @@ class _RamsesLowerError(RamsesException):
 
 
 ########################################################################################
-# Errors at/below the protocol/transport layer, incl. packet processing
+# Transport Layer Errors
+########################################################################################
 
 
-class ProtocolError(_RamsesLowerError):
-    """An error occurred when sending, receiving or exchanging packets."""
-
-
-class ProtocolFsmError(ProtocolError):
-    """The protocol FSM was/became inconsistent (this shouldn't happen)."""
-
-
-class ProtocolSendFailed(ProtocolFsmError):
-    """The Command failed to elicit an echo or (if any) the expected response."""
-
-
-class TransportError(ProtocolError):  # derived from ProtocolBaseError
-    """An error when sending or receiving frames (bytes)."""
+class TransportError(_RamsesLowerError):
+    """An error when sending or receiving frames (bytes) via the transport."""
 
 
 class TransportSerialError(TransportError):
@@ -58,7 +56,7 @@ class TransportSerialError(TransportError):
 
 
 class TransportSourceInvalid(TransportError):
-    """The source of packets (frames) is not valid type/configuration."""
+    """The source of packets (frames) is not a valid type or configuration."""
 
 
 class TransportZigbeeError(TransportError):
@@ -66,15 +64,37 @@ class TransportZigbeeError(TransportError):
 
 
 ########################################################################################
-# Errors at/below the protocol/transport layer, incl. packet processing
+# Protocol & FSM Layer Errors
+########################################################################################
+
+
+class ProtocolError(_RamsesLowerError):
+    """An error occurred when sending, receiving, or exchanging packets."""
+
+
+class ProtocolFsmError(ProtocolError):
+    """The protocol FSM was or became inconsistent (logical state error)."""
+
+
+class ProtocolSendFailed(ProtocolError):
+    """The Command failed to elicit an echo or the expected response."""
+
+
+class ProtocolTimeoutError(ProtocolSendFailed):
+    """A specific operational timeout occurred while waiting for a packet."""
+
+
+########################################################################################
+# Parser Layer Errors
+########################################################################################
 
 
 class ParserBaseError(_RamsesLowerError):
-    """The packet is corrupt/not internally consistent, or cannot be parsed."""
+    """The packet is corrupt, not internally consistent, or cannot be parsed."""
 
 
 class PacketInvalid(ParserBaseError):
-    """The packet is corrupt/not internally consistent."""
+    """The packet is corrupt or not internally consistent."""
 
 
 class PacketAddrSetInvalid(PacketInvalid):

--- a/src/ramses_tx/protocol/core.py
+++ b/src/ramses_tx/protocol/core.py
@@ -23,7 +23,7 @@ from ..const import (
     Code,
     Priority,
 )
-from ..exceptions import ProtocolError, ProtocolSendFailed
+from ..exceptions import ProtocolError, ProtocolSendFailed, ProtocolTimeoutError
 from ..interfaces import TransportInterface
 from ..packet import Packet
 from ..typing import DeviceListT, MsgHandlerT, QosParams
@@ -246,6 +246,9 @@ class PortProtocol(_DeviceIdFilterMixin):
 
         try:
             return await self._context.send_cmd(send_cmd, cmd, priority, qos)
+        except ProtocolTimeoutError as err:
+            _LOGGER.warning(f"{self}: Send timed out for {cmd._hdr}: {err}")
+            raise
         except ProtocolError as err:
             _LOGGER.info(f"{self}: Failed to send {cmd._hdr}: {err}")
             raise
@@ -277,8 +280,9 @@ class PortProtocol(_DeviceIdFilterMixin):
         sent first.
 
         Will raise:
-            ProtocolSendFailed: tried to Tx Command, but didn't get echo/reply
-            ProtocolError:      didn't attempt to Tx Command for some reason
+            ProtocolTimeoutError: global send timer expired before getting echo/reply.
+            ProtocolSendFailed:   tried to Tx Command, but didn't get echo/reply.
+            ProtocolError:        didn't attempt to Tx Command for some reason.
         """
         assert 0 <= gap_duration <= MAX_GAP_DURATION, "Out of range: gap_duration"
         assert 0 <= num_repeats <= MAX_NUM_REPEATS, "Out of range: num_repeats"

--- a/src/ramses_tx/protocol/fsm.py
+++ b/src/ramses_tx/protocol/fsm.py
@@ -29,6 +29,7 @@ from ..exceptions import (
     ProtocolError,
     ProtocolFsmError,
     ProtocolSendFailed,
+    ProtocolTimeoutError,
     TransportError,
 )
 from ..helpers import dt_now
@@ -295,7 +296,8 @@ class ProtocolContext(StateMachineInterface):
         :type qos: QosParams
         :return: The received response packet, or the echo if no response is expected.
         :rtype: Packet
-        :raises ProtocolSendFailed: If the send times out or retries are exhausted.
+        :raises ProtocolTimeoutError: If the global send timer expires.
+        :raises ProtocolSendFailed: If retries are exhausted.
         """
         self._send_fnc = send_fnc
 
@@ -320,7 +322,7 @@ class ProtocolContext(StateMachineInterface):
             )
             if self._qos_mgr.cmd is cmd:
                 self.set_state(IsInIdle, expired=True)
-            raise ProtocolSendFailed(msg) from err
+            raise ProtocolTimeoutError(msg) from err
 
         try:
             return fut.result()

--- a/tests/tests_rf/test_database.py
+++ b/tests/tests_rf/test_database.py
@@ -5,6 +5,7 @@ import contextlib
 from datetime import datetime as dt, timedelta as td
 
 from ramses_rf.database import MessageIndex
+from ramses_rf.exceptions import DatabaseQueryError
 from ramses_tx import Message, Packet
 
 
@@ -131,7 +132,7 @@ class TestMessageIndex:
             "payload keys skipped if value is None"
         )
 
-        with contextlib.suppress(ValueError):
+        with contextlib.suppress(DatabaseQueryError):
             msg_db.qry_field("RANDOM from messages", (self._SRC1, self._SRC1))
         # Only SELECT queries are allowed
 


### PR DESCRIPTION
### The Problem:
Currently, the codebase relies heavily on generic Python exceptions (such as `TypeError`, `ValueError`, and `LookupError`) to handle domain-specific failures. This makes it incredibly difficult to programmatically distinguish between a genuine Python bug (e.g., passing a string instead of an int) and an expected library state error (e.g., an unrecognized device address or an invalid system schema).

### Consequences: 
If left unaddressed, downstream consumers (like Home Assistant integrations) are forced to use excessively broad `try/except` blocks to catch expected operational failures. This anti-pattern can swallow real bugs, mask systemic issues, and makes automated error recovery nearly impossible. Furthermore, debugging log outputs are cluttered with generic errors that lack context.

### The Fix:
Introduced a robust, domain-specific exception hierarchy (primarily in `ramses_rf/exceptions.py` and `ramses_tx/exceptions.py`) and systematically replaced the generic exception raises throughout the transport, protocol, and application layers.

### Technical Implementation:
- **Device Discovery (`device/__init__.py`, `heat.py`, `hvac.py`):** Replaced `TypeError` with `DeviceNotRecognised`. Updated the dispatcher's fall-through logic to explicitly catch `DeviceNotRecognised` when attempting to classify devices.
- **System & Zone Validation (`system/*.py`):** Replaced `ValueError` and `LookupError` with `SchemaInconsistentError` and `SystemInconsistent` to clearly flag configuration or state mismatches.
- **Schedule Management (`schedule.py`):** Replaced bare `TimeoutError` and `zlib.error` occurrences with `ScheduleFlowError` and `ScheduleError` to isolate async I/O failures from logic errors.
- **Database (`database.py`):** Replaced `ValueError` with `DatabaseQueryError` for invalid SQLite queries.
- **Test Suite:** Updated test helpers and unit tests (e.g., `test_database.py`) to assert and suppress the newly introduced custom exception classes.

### Testing Performed:
- Executed the full `pytest` suite, validating that all regression, binding, parsing, and schema tests pass.
- Ran `mypy` in strict mode to ensure no typing regressions were introduced by the new exception classes.
- Specifically verified that device factory fallback logic properly catches the new exceptions during automated discovery sweeps.

### Risks of NOT Implementing:
Continued reliance on generic exceptions makes the library fragile and frustrating for external developers to integrate with. It hides true logic bugs behind expected domain errors and degrades the overall reliability of the system.

### Risks of Implementing:
Downstream consumers or internal integrations that are heavily dependent on catching specific generic exceptions (e.g., specifically catching a `ValueError` to detect a bad schema) might experience unhandled crashes if they do not update their error handling to look for the new `ramses_rf` exceptions.

### Mitigation Steps:
The new exceptions inherit from standard `RamsesException` base classes where applicable to maintain some level of backwards compatibility for generic `except` blocks. The internal control flows (like the `try/except` blocks in the device factories) have been thoroughly updated and validated against the full test suite to ensure no unhandled exceptions escape the internal library logic unexpectedly.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.