### PR TITLE
bump ruff, pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ exclude: ^(.secrets|docs|misc|tests/deprecated)/
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.0
+    rev: v0.15.5
     hooks:
       - id: ruff-check   # linter
       - id: ruff-format  # formatter

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -11,7 +11,7 @@
 
 # used for development (linting)
   prek == 0.3.4                                  # latest, same as ramses_cc
-  ruff >= 0.13.0                                 # HA uses 0.13.0 ! also in: pre-commit-config.yaml
+  ruff >= 0.15.5                                 # HA uses 0.15.5 ! also in: pre-commit-config.yaml
 
 # used for development (typing)
   mypy >= 1.18.0                                 # HA uses  1.19.0a4 !


### PR DESCRIPTION
---
name: Bump `ruff`
about: linter, pre-commit hook
---

This PR bumps ruff to match HA/ramses_cc.

- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: not used

**PR Summary**
Update dev dependency to ruff 0.15.5.
Match pre-commit-config

Note: devs should run `pip install -r requirements/requirements_dev.txt`