### PR TITLE
Refactor: Remove Legacy Gateway Bridges and Finalize DeviceRegistry DI

### DIFF
--- a/src/ramses_cli/client.py
+++ b/src/ramses_cli/client.py
@@ -445,7 +445,9 @@ def print_results(gwy: Gateway, **kwargs: Any) -> None:
     :param kwargs: The command arguments.
     """
     if kwargs[GET_FAULTS]:
-        fault_log = gwy.system_by_id[kwargs[GET_FAULTS]]._faultlog.faultlog
+        fault_log = gwy.device_registry.system_by_id[
+            kwargs[GET_FAULTS]
+        ]._faultlog.faultlog
 
         if fault_log:
             [print(f"{k:02X}", v) for k, v in fault_log.items()]
@@ -455,10 +457,10 @@ def print_results(gwy: Gateway, **kwargs: Any) -> None:
     if kwargs[GET_SCHED][0]:
         system_id, zone_idx = kwargs[GET_SCHED]
         if zone_idx == "HW":
-            dhw = gwy.system_by_id[system_id].dhw
+            dhw = gwy.device_registry.system_by_id[system_id].dhw
             zone: Any = dhw
         else:
-            zone = gwy.system_by_id[system_id].zone_by_idx[zone_idx]
+            zone = gwy.device_registry.system_by_id[system_id].zone_by_idx[zone_idx]
         assert zone
         schedule = zone.schedule
 
@@ -517,19 +519,19 @@ async def print_summary(gwy: Gateway, **kwargs: Any) -> None:
     if kwargs.get("show_schema"):
         print(f"Schema[{entity}] = {json.dumps(await entity.schema(), indent=4)}\r\n")
 
-        # schema = {d.id: await d.schema() for d in sorted(gwy.devices)}
+        # schema = {d.id: await d.schema() for d in sorted(gwy.device_registry.devices)}
         # print(f"Schema[devices] = {json.dumps({'schema': schema}, indent=4)}\r\n")
 
     if kwargs.get("show_params"):
         print(f"Params[{entity}] = {json.dumps(await entity.params(), indent=4)}\r\n")
 
-        params = {d.id: await d.params() for d in sorted(gwy.devices)}
+        params = {d.id: await d.params() for d in sorted(gwy.device_registry.devices)}
         print(f"Params[devices] = {json.dumps({'params': params}, indent=4)}\r\n")
 
     if kwargs.get("show_status"):
         print(f"Status[{entity}] = {json.dumps(await entity.status(), indent=4)}\r\n")
 
-        status = {d.id: await d.status() for d in sorted(gwy.devices)}
+        status = {d.id: await d.status() for d in sorted(gwy.device_registry.devices)}
         print(f"Status[devices] = {json.dumps({'status': status}, indent=4)}\r\n")
 
     if kwargs.get("show_knowns"):  # show device hints (show-knowns)
@@ -538,12 +540,14 @@ async def print_summary(gwy: Gateway, **kwargs: Any) -> None:
     if kwargs.get("show_traits"):  # show device traits
         result = {
             d.id: await d.traits()  # {k: v for k, v in (await d.traits()).items() if k[:1] == "_"}
-            for d in sorted(gwy.devices)
+            for d in sorted(gwy.device_registry.devices)
         }
         print(json.dumps(result, indent=4), "\r\n")
 
     if kwargs.get("show_crazys"):
-        for device in [d for d in gwy.devices if d.type == DEV_TYPE_MAP.CTL]:
+        for device in [
+            d for d in gwy.device_registry.devices if d.type == DEV_TYPE_MAP.CTL
+        ]:
             if gwy.msg_db:
                 for msg in await gwy.msg_db.get(device=device.id, code=Code._0005):
                     print(f"{msg._pkt}")
@@ -557,7 +561,9 @@ async def print_summary(gwy: Gateway, **kwargs: Any) -> None:
                             for pkt in verb.values():
                                 print(f"{pkt}")
             print()
-        for device in [d for d in gwy.devices if d.type == DEV_TYPE_MAP.UFC]:
+        for device in [
+            d for d in gwy.device_registry.devices if d.type == DEV_TYPE_MAP.UFC
+        ]:
             if gwy.msg_db:
                 for msg in await gwy.msg_db.get(device=device.id):
                     print(f"{msg._pkt}")

--- a/src/ramses_cli/discovery.py
+++ b/src/ramses_cli/discovery.py
@@ -130,7 +130,7 @@ async def get_faults(
     :param start: The index to start querying from.
     :param limit: The maximum number of fault entries to return.
     """
-    ctl = cast("Controller", gwy.get_device(ctl_id))
+    ctl = cast("Controller", gwy.device_registry.get_device(ctl_id))
 
     try:
         if ctl.tcs:
@@ -146,7 +146,7 @@ async def get_schedule(gwy: Gateway, ctl_id: DeviceIdT, zone_idx: str) -> None:
     :param ctl_id: The device ID of the controller.
     :param zone_idx: The zone index string (e.g. "00" or "HW").
     """
-    ctl = cast("Controller", gwy.get_device(ctl_id))
+    ctl = cast("Controller", gwy.device_registry.get_device(ctl_id))
     if not ctl.tcs:
         _LOGGER.error("get_schedule(): Controller has no TCS active.")
         return
@@ -169,7 +169,7 @@ async def set_schedule(gwy: Gateway, ctl_id: DeviceIdT, schedule: str) -> None:
     schedule_ = json.loads(schedule)
     zone_idx = schedule_[SZ_ZONE_IDX]
 
-    ctl = cast("Controller", gwy.get_device(ctl_id))
+    ctl = cast("Controller", gwy.device_registry.get_device(ctl_id))
     if not ctl.tcs:
         _LOGGER.error("set_schedule(): Controller has no TCS active.")
         return
@@ -191,7 +191,7 @@ async def script_bind_req(
     :param dev_id: The device ID to transition to binding state.
     :param code: The code to offer during the bind request.
     """
-    dev = gwy.get_device(dev_id)
+    dev = gwy.device_registry.get_device(dev_id)
     assert isinstance(dev, Fakeable)  # mypy
     dev._make_fake()
     await dev._initiate_binding_process([code])
@@ -207,7 +207,7 @@ async def script_bind_wait(
     :param code: The expected bind code to accept.
     :param idx: The internal domain or zone index to map to.
     """
-    dev = gwy.get_device(dev_id)
+    dev = gwy.device_registry.get_device(dev_id)
     assert isinstance(dev, Fakeable)  # mypy
     dev._make_fake()
     await dev._wait_for_binding_request([code], idx=idx)
@@ -262,7 +262,7 @@ async def script_scan_disc(gwy: Gateway, dev_id: DeviceIdT) -> None:
     """
     _LOGGER.warning("scan_disc() invoked...")
 
-    await gwy.get_device(dev_id).discovery.discover()
+    await gwy.device_registry.get_device(dev_id).discovery.discover()
 
 
 @script_decorator

--- a/src/ramses_rf/device/base.py
+++ b/src/ramses_rf/device/base.py
@@ -437,7 +437,7 @@ class Device(Child, DeviceBase):
         _LOGGER.debug("Creating a Device: %s (%s)", dev_addr.id, self.__class__)
         super().__init__(gwy, dev_addr, traits=traits, **kwargs)
 
-        gwy._add_device(self)
+        gwy.device_registry._add_device(self)
 
 
 class HgiGateway(Device):  # HGI (18:)

--- a/src/ramses_rf/device/heat.py
+++ b/src/ramses_rf/device/heat.py
@@ -482,7 +482,9 @@ class UfhController(Parent, DeviceHeat):  # UFC (02):
             self.circuit_by_id[ufh_idx] = {SZ_ZONE_IDX: msg.payload[SZ_ZONE_IDX]}
             if msg.payload[SZ_ZONE_IDX] is not None:  # [SZ_DEVICES][0] will be the CTL
                 self.set_parent(
-                    self._gwy.get_device(msg.payload[SZ_DEVICES][0]).tcs,
+                    self._gwy.device_registry.get_device(
+                        msg.payload[SZ_DEVICES][0]
+                    ).tcs,
                     # child_id=msg.payload[SZ_ZONE_IDX],
                 )
 
@@ -1567,8 +1569,8 @@ class UfhCircuit(Child, Entity):  # FIXME
         if len(dev_ids) != 1:
             raise exc.PacketPayloadInvalid("No devices")
 
-        # ctl = self._gwy.device_by_id.get(dev_ids[0])
-        ctl: Controller = self._gwy.get_device(dev_ids[0])
+        # ctl = self._gwy.device_registry.device_by_id.get(dev_ids[0])
+        ctl: Controller = self._gwy.device_registry.get_device(dev_ids[0])
         if not ctl or (self._ctl and self._ctl is not ctl):
             raise exc.PacketPayloadInvalid("No CTL")
         self._ctl = ctl

--- a/src/ramses_rf/device_registry.py
+++ b/src/ramses_rf/device_registry.py
@@ -139,7 +139,7 @@ class DeviceRegistry:
 
         if (dev := self.get_device(device_id)) and isinstance(dev, Fakeable):
             dev._make_fake()
-            return dev
+            return cast("Device | Fakeable", dev)
 
         raise DeviceNotFaked(f"The device is not fakeable: {device_id}")
 

--- a/src/ramses_rf/dispatcher.py
+++ b/src/ramses_rf/dispatcher.py
@@ -67,8 +67,8 @@ def _create_devices_from_addrs(gwy: Gateway, this: Message) -> None:
 
     # FIXME: changing Address to Devices is messy: ? Protocol for same method signatures
     # prefer Devices but can continue with Addresses if required...
-    this.src = gwy.device_by_id.get(this.src.id, this.src)  # type: ignore[assignment]
-    this.dst = gwy.device_by_id.get(this.dst.id, this.dst)  # type: ignore[assignment]
+    this.src = gwy.device_registry.device_by_id.get(this.src.id, this.src)
+    this.dst = gwy.device_registry.device_by_id.get(this.dst.id, this.dst)
 
     # Devices need to know their controller, ?and their location ('parent' domain)
     # NB: only addrs processed here, packet metadata is processed elsewhere
@@ -86,7 +86,7 @@ def _create_devices_from_addrs(gwy: Gateway, this: Message) -> None:
 
     if not isinstance(this.src, Device):  # type: ignore[unreachable]
         # may: DeviceNotFoundError, but don't suppress
-        this.src = gwy.get_device(this.src.id)  # type: ignore[assignment]
+        this.src = gwy.device_registry.get_device(this.src.id)
         if this.dst.id == this.src.id:
             this.dst = this.src
             return
@@ -96,7 +96,7 @@ def _create_devices_from_addrs(gwy: Gateway, this: Message) -> None:
 
     if not isinstance(this.dst, Device) and this.src != gwy.hgi:  # type: ignore[unreachable]
         with contextlib.suppress(exc.DeviceNotFoundError):
-            this.dst = gwy.get_device(this.dst.id)  # type: ignore[assignment]
+            this.dst = gwy.device_registry.get_device(this.dst.id)
 
 
 def _check_msg_addrs(msg: Message) -> None:  # TODO
@@ -270,10 +270,14 @@ def process_msg(gwy: Gateway, msg: Message) -> None:
             and isinstance(msg.payload, dict)  # 1. Ensure it's a dict (not bytes)
             and msg.payload.get(SZ_PHASE) == SZ_OFFER  # 2. Safely check for key
         ):
-            devices = [d for d in gwy.devices if d != msg.src and d._is_binding]
+            devices = [
+                d for d in gwy.device_registry.devices if d != msg.src and d._is_binding
+            ]
 
         elif msg.dst == ALL_DEV_ADDR:  # some offers use dst=63:, so after 1FC9 offer
-            devices = [d for d in gwy.devices if d != msg.src and d.is_faked]
+            devices = [
+                d for d in gwy.device_registry.devices if d != msg.src and d.is_faked
+            ]
 
         elif msg.dst is not msg.src and isinstance(msg.dst, Fakeable):  # type: ignore[unreachable]
             # to eavesdrop pkts from other devices, but relevant to this device

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -60,7 +60,7 @@ from ramses_tx.transport import TransportConfig
 from ramses_tx.typing import PktLogConfigT, PortConfigT
 
 from .database import MessageIndex
-from .device import Fakeable, HgiGateway
+from .device import HgiGateway
 from .device_filter import DeviceFilter
 from .device_registry import DeviceRegistry
 from .dispatcher import detect_array_fragment, process_msg
@@ -72,13 +72,12 @@ from .interfaces import (
 )
 from .schemas import load_schema
 from .system import Evohome
-from .typing import DeviceIdT, DeviceListT
+from .typing import DeviceListT
 
 if TYPE_CHECKING:
     from ramses_tx import RamsesTransportT
 
     from .device import Device
-    from .topology import Parent
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -261,24 +260,6 @@ class Gateway(Engine, GatewayInterface):
         return self._device_registry
 
     @property
-    def devices(self) -> list[Device]:
-        """Return the list of devices (delegated to DeviceRegistry).
-
-        :returns: A list of all known Device instances.
-        :rtype: list[Device]
-        """
-        return self.device_registry.devices
-
-    @property
-    def device_by_id(self) -> dict[DeviceIdT, Device]:
-        """Return the mapping of device IDs to devices (delegated to DeviceRegistry).
-
-        :returns: A dictionary mapping Device IDs to Device instances.
-        :rtype: dict[DeviceIdT, Device]
-        """
-        return self.device_registry.device_by_id
-
-    @property
     def config(self) -> GatewayConfig:
         """Return the gateway configuration.
 
@@ -315,7 +296,7 @@ class Gateway(Engine, GatewayInterface):
         if not self._transport:
             return None
         if device_id := self._transport.get_extra_info(SZ_ACTIVE_HGI):
-            return self.device_by_id.get(device_id)  # type: ignore[return-value]
+            return self.device_registry.device_by_id.get(device_id)
         return None
 
     async def start(
@@ -394,7 +375,9 @@ class Gateway(Engine, GatewayInterface):
             and not self.config.disable_discovery
             and start_discovery
         ):
-            initiate_discovery(self.devices, self.systems)
+            initiate_discovery(
+                self.device_registry.devices, self.device_registry.systems
+            )
 
     def create_sqlite_message_index(self) -> None:
         """Initialize the SQLite MessageIndex.
@@ -508,9 +491,9 @@ class Gateway(Engine, GatewayInterface):
             }
         else:  # deprecated, to be removed in Q1 2026
             msgs = []
-            for device in self.devices:
+            for device in self.device_registry.devices:
                 msgs.extend(await device.state_store._msg_list())
-            for system in self.systems:
+            for system in self.device_registry.systems:
                 msgs.extend(list((await system.state_store._msgs()).values()))
                 for z in system.zones:
                     msgs.extend(list((await z.state_store._msgs()).values()))
@@ -600,66 +583,6 @@ class Gateway(Engine, GatewayInterface):
         _LOGGER.debug("Gateway: Restored, resuming")
         await self._resume()
 
-    def _add_device(self, dev: Device) -> None:  # TODO: also: _add_system()
-        """Add a device to the gateway (called by devices during instantiation).
-
-        :param dev: The device instance to add.
-        :type dev: Device
-        :returns: None
-        :rtype: None
-        """
-        self.device_registry._add_device(dev)
-
-    def get_device(
-        self,
-        device_id: DeviceIdT,
-        *,
-        msg: Message | None = None,
-        parent: Parent | None = None,
-        child_id: str | None = None,
-        is_sensor: bool | None = None,
-    ) -> Device:
-        """Return a device, creating it if it does not already exist.
-
-        :param device_id: The unique identifier for the device (e.g., '01:123456').
-        :type device_id: DeviceIdT
-        :param msg: An optional initial message for the device to process, defaults to None.
-        :type msg: Message | None, optional
-        :param parent: The parent entity of this device, if any, defaults to None.
-        :type parent: Parent | None, optional
-        :param child_id: The specific ID of the child component if applicable, defaults to None.
-        :type child_id: str | None, optional
-        :param is_sensor: Indicates if this device should be treated as a sensor, defaults to None.
-        :type is_sensor: bool | None, optional
-        :returns: The existing or newly created device instance.
-        :rtype: Device
-        """
-        return self.device_registry.get_device(  # type: ignore[no-any-return]
-            device_id,
-            msg=msg,
-            parent=parent,
-            child_id=child_id,
-            is_sensor=is_sensor,
-        )
-
-    async def fake_device(
-        self,
-        device_id: DeviceIdT,
-        create_device: bool = False,
-    ) -> Device | Fakeable:
-        """Create a faked device.
-
-        :param device_id: The unique identifier for the device to fake.
-        :type device_id: DeviceIdT
-        :param create_device: Allow creation if the device does not exist, defaults to False.
-        :type create_device: bool, optional
-        :returns: The instantiated faked device.
-        :rtype: Device | Fakeable
-        """
-        return await self.device_registry.fake_device(  # type: ignore[no-any-return]
-            device_id, create_device=create_device
-        )
-
     @property
     def tcs(self) -> Evohome | None:
         """Return the primary Temperature Control System (TCS), if any.
@@ -668,35 +591,9 @@ class Gateway(Engine, GatewayInterface):
         :rtype: Evohome | None
         """
 
-        if self._tcs is None and self.systems:
-            self._tcs = self.systems[0]
+        if self._tcs is None and self.device_registry.systems:
+            self._tcs = self.device_registry.systems[0]
         return self._tcs
-
-    async def known_list(self) -> DeviceListT:
-        """Return the working known_list (a superset of the provided known_list).
-
-        :returns: A dictionary mapping device IDs to their traits.
-        :rtype: DeviceListT
-        """
-        return await self.device_registry.known_list()
-
-    @property
-    def system_by_id(self) -> dict[DeviceIdT, Evohome]:
-        """Return a mapping of device IDs to their associated Evohome systems.
-
-        :returns: Dictionary mapping device ID to Evohome system.
-        :rtype: dict[DeviceIdT, Evohome]
-        """
-        return self.device_registry.system_by_id
-
-    @property
-    def systems(self) -> list[Evohome]:
-        """Return a list of all identified Evohome systems.
-
-        :returns: A list of Evohome instances.
-        :rtype: list[Evohome]
-        """
-        return self.device_registry.systems
 
     async def _config(self) -> dict[str, Any]:
         """Return the working configuration.
@@ -708,7 +605,7 @@ class Gateway(Engine, GatewayInterface):
             "_gateway_id": self.hgi.id if self.hgi else None,
             SZ_MAIN_TCS: self.tcs.id if self.tcs else None,
             SZ_CONFIG: {SZ_ENFORCE_KNOWN_LIST: self._enforce_known_list},
-            SZ_KNOWN_LIST: await self.known_list(),
+            SZ_KNOWN_LIST: await self.device_registry.known_list(),
             SZ_BLOCK_LIST: [{k: v} for k, v in self._exclude.items()],
             "_unwanted": sorted(self._unwanted),
         }
@@ -722,7 +619,7 @@ class Gateway(Engine, GatewayInterface):
 
         schema: dict[str, Any] = {SZ_MAIN_TCS: self.tcs.ctl.id if self.tcs else None}
 
-        for tcs in self.systems:
+        for tcs in self.device_registry.systems:
             schema[tcs.ctl.id] = await tcs.schema()
 
         schema[f"{SZ_ORPHANS}_heat"] = await self.device_registry.get_heat_orphans()

--- a/src/ramses_rf/interfaces.py
+++ b/src/ramses_rf/interfaces.py
@@ -194,18 +194,6 @@ class GatewayInterface(Protocol):
         """Return the gateway configuration."""
         ...
 
-    def get_device(
-        self,
-        device_id: DeviceIdT,
-        *,
-        msg: Message | None = None,
-        parent: "Parent | None" = None,
-        child_id: str | None = None,
-        is_sensor: bool | None = None,
-    ) -> DeviceInterface:
-        """Retrieve or create a device."""
-        ...
-
     async def async_send_cmd(
         self,
         cmd: Command,

--- a/src/ramses_rf/schemas.py
+++ b/src/ramses_rf/schemas.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, cast
 
 import voluptuous as vol
 
@@ -348,7 +348,7 @@ def _get_device(gwy: Gateway, dev_id: DeviceIdT, **kwargs: Any) -> Device:  # , 
 
     check_filter_lists(dev_id)
 
-    return gwy.get_device(dev_id, **kwargs)
+    return cast("Device", gwy.device_registry.get_device(dev_id, **kwargs))
 
 
 def load_schema(
@@ -368,7 +368,7 @@ def load_schema(
         if re.match(DEVICE_ID_REGEX.ANY, ctl_id) and SZ_REMOTES not in schema
     ]
     if schema.get(SZ_MAIN_TCS):
-        gwy._tcs = gwy.system_by_id.get(schema[SZ_MAIN_TCS])
+        gwy._tcs = gwy.device_registry.system_by_id.get(schema[SZ_MAIN_TCS])
     [
         load_fan(gwy, fan_id, schema)  # type: ignore[arg-type]
         for fan_id, schema in schema.items()
@@ -417,7 +417,7 @@ def load_tcs(gwy: Gateway, ctl_id: DeviceIdT, schema: dict[str, Any]) -> Evohome
     #     import json
 
     #     src = json.dumps(shrink(schema), sort_keys=True)
-    #     dst = json.dumps(shrink(gwy.system_by_id[ctl.id].schema), sort_keys=True)
+    #     dst = json.dumps(shrink(gwy.device_registry.system_by_id[ctl.id].schema), sort_keys=True)
     #     # assert dst == src, "They don't match!"
     #     print(src)
     #     print(dst)

--- a/src/ramses_rf/system/heat.py
+++ b/src/ramses_rf/system/heat.py
@@ -121,7 +121,7 @@ class SystemBase(Parent, Entity):  # 3B00 (multi-relay)
     def __init__(self, ctl: Controller) -> None:
         _LOGGER.debug("Creating a TCS for CTL: %s (%s)", ctl.id, self.__class__)
 
-        if ctl.id in ctl._gwy.system_by_id:
+        if ctl.id in ctl._gwy.device_registry.system_by_id:
             raise SchemaInconsistentError(f"Duplicate TCS for CTL: {ctl.id}")
         if not isinstance(ctl, Controller):  # TODO
             raise SchemaInconsistentError(f"Invalid CTL: {ctl} (is not a controller)")
@@ -223,7 +223,7 @@ class SystemBase(Parent, Entity):  # 3B00 (multi-relay)
                 if msg.payload[SZ_ZONE_TYPE] == DEV_ROLE_MAP.APP and msg.payload.get(
                     SZ_DEVICES
                 ):
-                    self._gwy.get_device(
+                    self._gwy.device_registry.get_device(
                         msg.payload[SZ_DEVICES][0], parent=self, child_id=FC
                     )  # sets self._app_cntrl
             else:
@@ -424,7 +424,7 @@ class MultiZone(SystemBase):  # 0005 (+/- 000C?)
                 return  # no testable zones
 
             testable_sensors = {}
-            for d in self._gwy.devices:
+            for d in self._gwy.device_registry.devices:
                 if isinstance(d, Temperature) and d.ctl in (self.ctl, None):
                     d_temp = await d.temperature()
                     d_msgs = await d.state_store._msgs()
@@ -447,7 +447,9 @@ class MultiZone(SystemBase):  # 0005 (+/- 000C?)
 
             for sensor, zone_idx in matched_pairs.items():
                 zone = self.zone_by_idx[zone_idx]
-                self._gwy.get_device(sensor.id, parent=zone, is_sensor=True)
+                self._gwy.device_registry.get_device(
+                    sensor.id, parent=zone, is_sensor=True
+                )
 
             # _LOGGER.warning("System state (after): %s", self.schema)
 
@@ -464,7 +466,9 @@ class MultiZone(SystemBase):  # 0005 (+/- 000C?)
             # can safely(?) assume this zone is using the CTL as a sensor...
             if not [s for s in testable_sensors if s == temp]:
                 zone = self.zone_by_idx[zone_idx]
-                self._gwy.get_device(self.ctl.id, parent=zone, is_sensor=True)
+                self._gwy.device_registry.get_device(
+                    self.ctl.id, parent=zone, is_sensor=True
+                )
 
             # _LOGGER.warning("System state (finally): %s", self.schema)
 
@@ -1017,7 +1021,9 @@ class System(StoredHw, Datetime, Logbook, SystemBase):
         if schema.get(SZ_SYSTEM) and (
             dev_id := schema[SZ_SYSTEM].get(SZ_APPLIANCE_CONTROL)
         ):
-            self._app_cntrl = self._gwy.get_device(dev_id, parent=self, child_id=FC)  # type: ignore[assignment]
+            self._app_cntrl = self._gwy.device_registry.get_device(
+                dev_id, parent=self, child_id=FC
+            )
 
         if _schema := (schema.get(SZ_DHW_SYSTEM)):  # type: ignore[assignment]
             self.get_dhw_zone(**_schema)  # self._dhw = ...

--- a/src/ramses_rf/system/zones.py
+++ b/src/ramses_rf/system/zones.py
@@ -280,7 +280,7 @@ class DhwZone(ZoneSchedule):  # CS92A
 
         assert len(msg.payload[SZ_DEVICES]) == 1
 
-        self._gwy.get_device(
+        self._gwy.device_registry.get_device(
             msg.payload[SZ_DEVICES][0],
             parent=self,
             child_id=msg.payload[SZ_DOMAIN_ID],
@@ -314,19 +314,23 @@ class DhwZone(ZoneSchedule):  # CS92A
         schema = shrink(SCH_TCS_DHW(schema))
 
         if dev_id := schema.get(SZ_SENSOR):
-            dhw_sensor = self._gwy.get_device(
+            dhw_sensor = self._gwy.device_registry.get_device(
                 dev_id, parent=self, child_id=FA, is_sensor=True
             )
             assert isinstance(dhw_sensor, DhwSensor)  # mypy
             self._dhw_sensor = dhw_sensor
 
         if dev_id := schema.get(DEV_ROLE_MAP[DevRole.HTG]):
-            dhw_valve = self._gwy.get_device(dev_id, parent=self, child_id=FA)
+            dhw_valve = self._gwy.device_registry.get_device(
+                dev_id, parent=self, child_id=FA
+            )
             assert isinstance(dhw_valve, BdrSwitch)  # mypy
             self._dhw_valve = dhw_valve
 
         if dev_id := schema.get(DEV_ROLE_MAP[DevRole.HT1]):
-            htg_valve = self._gwy.get_device(dev_id, parent=self, child_id=F9)
+            htg_valve = self._gwy.device_registry.get_device(
+                dev_id, parent=self, child_id=F9
+            )
             assert isinstance(htg_valve, BdrSwitch)  # mypy
             self._htg_valve = htg_valve
 
@@ -553,10 +557,12 @@ class Zone(ZoneSchedule):
             set_zone_type(ZON_ROLE_MAP[klass])
 
         if dev_id := schema.get(SZ_SENSOR):
-            self._sensor = self._gwy.get_device(dev_id, parent=self, is_sensor=True)
+            self._sensor = self._gwy.device_registry.get_device(
+                dev_id, parent=self, is_sensor=True
+            )
 
         for dev_id in schema.get(SZ_ACTUATORS, []):
-            self._gwy.get_device(dev_id, parent=self)
+            self._gwy.device_registry.get_device(dev_id, parent=self)
 
     def _setup_discovery_cmds(self) -> None:
         # super()._setup_discovery_cmds()
@@ -654,15 +660,17 @@ class Zone(ZoneSchedule):
 
             if msg.payload[SZ_ZONE_TYPE] == DEV_ROLE_MAP.SEN:
                 dev_id = msg.payload[SZ_DEVICES][0]
-                self._sensor = self._gwy.get_device(dev_id, parent=self, is_sensor=True)
+                self._sensor = self._gwy.device_registry.get_device(
+                    dev_id, parent=self, is_sensor=True
+                )
 
             elif msg.payload[SZ_ZONE_TYPE] == DEV_ROLE_MAP.ACT:
                 for dev_id in msg.payload[SZ_DEVICES]:
-                    self._gwy.get_device(dev_id, parent=self)
+                    self._gwy.device_registry.get_device(dev_id, parent=self)
 
             elif msg.payload[SZ_ZONE_TYPE] in ZON_ROLE_MAP.HEAT_ZONES:
                 for dev_id in msg.payload[SZ_DEVICES]:
-                    self._gwy.get_device(dev_id, parent=self)
+                    self._gwy.device_registry.get_device(dev_id, parent=self)
                 self._update_schema(
                     **{SZ_CLASS: ZON_ROLE_MAP[msg.payload[SZ_ZONE_TYPE]]}
                 )

--- a/tests/deprecated/common.py
+++ b/tests/deprecated/common.py
@@ -54,9 +54,9 @@ def abort_if_rf_test_fails(fnc):
 
 def find_test_tcs(gwy: Gateway) -> System:
     if isinstance(gwy, MockGateway):
-        return gwy.system_by_id[CTL_ID]
-    systems = [s for s in gwy.systems if s.id != CTL_ID]
-    return systems[0] if systems else gwy.system_by_id[CTL_ID]
+        return gwy.device_registry.system_by_id[CTL_ID]
+    systems = [s for s in gwy.device_registry.systems if s.id != CTL_ID]
+    return systems[0] if systems else gwy.device_registry.system_by_id[CTL_ID]
 
 
 async def load_test_gwy(

--- a/tests/deprecated/mocked_devices/device_heat.py
+++ b/tests/deprecated/mocked_devices/device_heat.py
@@ -443,7 +443,7 @@ class MockDeviceCtl(MockDeviceBase):
     ) -> None:
         super().__init__(gwy, device_id)
 
-        self._ref = gwy.get_device(device_id)  # device_factory(gwy, self._addr)
+        self._ref = gwy.device_registry.get_device(device_id)  # device_factory(gwy, self._addr)
         self._tcs = self._ref.tcs
 
         self._change_counter: int = 8

--- a/tests/tests/helpers.py
+++ b/tests/tests/helpers.py
@@ -96,7 +96,7 @@ async def assert_expected_set(gwy: Gateway, expected: dict) -> None:
     assert_expected(await gwy.schema(), expected.get("schema"))
     assert_expected(await gwy.params(), expected.get("params"))
     assert_expected(await gwy.status(), expected.get("status"))
-    assert_expected(await gwy.known_list(), expected.get("known_list"))
+    assert_expected(await gwy.device_registry.known_list(), expected.get("known_list"))
 
 
 def assert_raises(

--- a/tests/tests/test_apis_binding.py
+++ b/tests/tests/test_apis_binding.py
@@ -49,6 +49,11 @@ class GatewayStub:
     _include: dict[str] = {}
     msg_db = MessageIndex(maintain=False)
 
+    @property
+    def device_registry(self) -> "GatewayStub":
+        """Act as our own DeviceRegistry for testing purposes."""
+        return self
+
     def _add_device(self, dev: Fakeable) -> None:
         self.device_by_id[dev.id] = dev
         self.devices.append(dev)

--- a/tests/tests/test_eavesdrop_dev_class.py
+++ b/tests/tests/test_eavesdrop_dev_class.py
@@ -50,7 +50,9 @@ async def test_dev_eavesdrop_on_(dir_name: Path) -> None:
     await gwy.start()
 
     with open(f"{dir_name}/known_list_eavesdrop_on.json") as f:
-        assert_expected(await gwy.known_list(), json.load(f).get("known_list"))
+        assert_expected(
+            await gwy.device_registry.known_list(), json.load(f).get("known_list")
+        )
 
     try:
         with open(f"{dir_name}/schema_eavesdrop_on.json") as f:
@@ -71,7 +73,9 @@ async def test_dev_eavesdrop_off(dir_name: Path) -> None:
 
     try:
         with open(f"{dir_name}/known_list_eavesdrop_off.json") as f:
-            assert_expected(await gwy.known_list(), json.load(f).get("known_list"))
+            assert_expected(
+                await gwy.device_registry.known_list(), json.load(f).get("known_list")
+            )
     except FileNotFoundError:
         pass
 

--- a/tests/tests/test_eavesdrop_schema.py
+++ b/tests/tests/test_eavesdrop_schema.py
@@ -47,7 +47,9 @@ async def test_eavesdrop_off(dir_name: Path) -> None:
 
     try:
         with open(f"{dir_name}/known_list_eavesdrop_off.json") as f:
-            assert_expected(await gwy.known_list(), json.load(f).get("known_list"))
+            assert_expected(
+                await gwy.device_registry.known_list(), json.load(f).get("known_list")
+            )
     except FileNotFoundError:
         pass
 
@@ -67,7 +69,9 @@ async def test_eavesdrop_on_(dir_name: Path) -> None:
 
     try:
         with open(f"{dir_name}/known_list_eavesdrop_on.json") as f:
-            assert_expected(await gwy.known_list(), json.load(f).get("known_list"))
+            assert_expected(
+                await gwy.device_registry.known_list(), json.load(f).get("known_list")
+            )
     except FileNotFoundError:
         pass
 

--- a/tests/tests/test_systems.py
+++ b/tests/tests/test_systems.py
@@ -128,7 +128,7 @@ async def test_fuzz_from_log_file(dir_name: Path) -> None:
     expected: dict = load_expected_results(dir_name) or {}
     gwy: Gateway = await load_test_gwy(dir_name)
 
-    # for dev in gwy.devices:
+    # for dev in gwy.device_registry.devices:
     #     if dev._msgs:
     #         assert dev._msgs == gwy.msg_db.get(
     #             src=dev.id, dtms=list(dev._msgs.keys())
@@ -144,7 +144,7 @@ async def test_fuzz_from_log_file(dir_name: Path) -> None:
         await gwy._restore_cached_packets(packets)
         await assert_expected_set(gwy, expected)
 
-    # for dev in gwy.devices:
+    # for dev in gwy.device_registry.devices:
     #     if dev._msgs:
     #         assert dev._msgs == gwy.msg_db.get(
     #             src=dev.id, dtms=list(dev._msgs.keys())
@@ -159,7 +159,7 @@ async def test_fuzz_from_log_file_sql(dir_name: Path) -> None:
     expected: dict = load_expected_results(dir_name) or {}
     gwy: Gateway = await load_test_gwy(dir_name, _sqlite_index=True)
 
-    # for dev in gwy.devices:
+    # for dev in gwy.device_registry.devices:
     #     if dev._msgs:
     #         assert dev._msgs == gwy.msg_db.get(
     #             src=dev.id, dtms=list(dev._msgs.keys())
@@ -179,7 +179,7 @@ async def test_fuzz_from_log_file_sql(dir_name: Path) -> None:
 
         await assert_expected_set(gwy, expected)
 
-    # for dev in gwy.devices:
+    # for dev in gwy.device_registry.devices:
     #     if dev._msgs:
     #         assert dev._msgs == gwy.msg_db.get(
     #             src=dev.id, dtms=list(dev._msgs.keys())

--- a/tests/tests_cli/test_client.py
+++ b/tests/tests_cli/test_client.py
@@ -101,7 +101,7 @@ async def mock_gateway() -> AsyncGenerator[MagicMock, None]:
         }
     )
 
-    gateway.devices = [mock_dev]
+    gateway.device_registry.devices = [mock_dev]
     gateway.tcs = None  # mimic no TCS
     gateway.schema = AsyncMock(return_value={"global": "schema"})
     gateway.params = AsyncMock(return_value={"global": "params"})
@@ -116,7 +116,7 @@ async def mock_gateway() -> AsyncGenerator[MagicMock, None]:
     mock_sys.zone_by_idx = {"01": MagicMock(schedule=[{"day": "Tuesday"}])}
     # Fix: Use integer key for faultlog to match expectations of print_results
     mock_sys._faultlog.faultlog = {0: "fault_data"}
-    gateway.system_by_id = {"01:123456": mock_sys}
+    gateway.device_registry.system_by_id = {"01:123456": mock_sys}
 
     yield gateway
 

--- a/tests/tests_cli/test_discovery.py
+++ b/tests/tests_cli/test_discovery.py
@@ -66,7 +66,7 @@ def mock_gateway() -> MagicMock:
     mock_dev._initiate_binding_process = AsyncMock()
     mock_dev._wait_for_binding_request = AsyncMock()
 
-    gateway.get_device.return_value = mock_dev
+    gateway.device_registry.get_device.return_value = mock_dev
 
     # IMPORTANT: Configure config so scripts don't return early
     gateway.config = MagicMock()
@@ -148,7 +148,7 @@ async def test_execution_of_exec_cmd(mock_gateway: MagicMock) -> None:
 async def test_execution_of_get_faults(mock_gateway: MagicMock) -> None:
     """Test execution of get_faults logic."""
     await get_faults(mock_gateway, DEV_ID)  # type: ignore[arg-type]
-    mock_dev = mock_gateway.get_device(DEV_ID)
+    mock_dev = mock_gateway.device_registry.get_device(DEV_ID)
     mock_dev.tcs.get_faultlog.assert_awaited_once()
 
 
@@ -156,7 +156,7 @@ async def test_execution_of_get_faults(mock_gateway: MagicMock) -> None:
 async def test_execution_of_get_schedule(mock_gateway: MagicMock) -> None:
     """Test execution of get_schedule logic."""
     await get_schedule(mock_gateway, DEV_ID, "01")  # type: ignore[arg-type]
-    mock_dev = mock_gateway.get_device(DEV_ID)
+    mock_dev = mock_gateway.device_registry.get_device(DEV_ID)
     mock_zone = mock_dev.tcs.get_htg_zone("01")
     mock_zone.get_schedule.assert_awaited_once()
 
@@ -166,7 +166,7 @@ async def test_execution_of_set_schedule(mock_gateway: MagicMock) -> None:
     """Test execution of set_schedule logic."""
     sched_json = f'{{"{SZ_ZONE_IDX}": "01", "{SZ_SCHEDULE}": []}}'
     await set_schedule(mock_gateway, DEV_ID, sched_json)  # type: ignore[arg-type]
-    mock_dev = mock_gateway.get_device(DEV_ID)
+    mock_dev = mock_gateway.device_registry.get_device(DEV_ID)
     mock_zone = mock_dev.tcs.get_htg_zone("01")
     mock_zone.set_schedule.assert_awaited_once()
 
@@ -196,7 +196,7 @@ async def test_script_decorator_behavior(mock_gateway: MagicMock) -> None:
 async def test_script_scan_disc(mock_gateway: MagicMock) -> None:
     """Test script_scan_disc."""
     await script_scan_disc(mock_gateway, DEV_ID)
-    mock_dev = mock_gateway.get_device(DEV_ID)
+    mock_dev = mock_gateway.device_registry.get_device(DEV_ID)
     # Phase 4 update: Verify the discovery component method was called
     mock_dev.discovery.discover.assert_awaited_once()
 
@@ -248,11 +248,11 @@ async def test_script_binding(mock_gateway: MagicMock) -> None:
     class MockFakeable:
         pass
 
-    mock_gateway.get_device.return_value.__class__ = MockFakeable
+    mock_gateway.device_registry.get_device.return_value.__class__ = MockFakeable
 
     with patch("ramses_cli.discovery.Fakeable", MockFakeable):
         await script_bind_req(mock_gateway, DEV_ID)  # type: ignore[arg-type]
-        mock_dev = mock_gateway.get_device(DEV_ID)
+        mock_dev = mock_gateway.device_registry.get_device(DEV_ID)
         mock_dev._initiate_binding_process.assert_awaited()
 
         await script_bind_wait(mock_gateway, DEV_ID)  # type: ignore[arg-type]

--- a/tests/tests_rf/conftest.py
+++ b/tests/tests_rf/conftest.py
@@ -184,7 +184,7 @@ async def _gateway(gwy_port: PortStrT, gwy_config: _GwyConfigDictT) -> Gateway:
 
     gwy = Gateway(gwy_port, **gwy_config)
 
-    assert gwy.hgi is None and gwy.devices == []
+    assert gwy.hgi is None and gwy.device_registry.devices == []
 
     await gwy.start()
     return gwy
@@ -280,7 +280,9 @@ async def mqtt_evofw3(
     gwy_config: _GwyConfigDictT = request.getfixturevalue(SZ_GWY_CONFIG)
     gwy = await _gateway(mqtt_evofw3_port, gwy_config)
 
-    gwy.get_device(gwy._protocol.hgi_id)  # HACK: not instantiated: no puzzle pkts sent
+    gwy.device_registry.get_device(
+        gwy._protocol.hgi_id
+    )  # HACK: not instantiated: no puzzle pkts sent
 
     assert isinstance(gwy.hgi, HgiGateway) and gwy.hgi.id not in (None, HGI_DEVICE_ID)
     assert gwy._protocol._is_evofw3 is True

--- a/tests/tests_rf/test_api_faultlog.py
+++ b/tests/tests_rf/test_api_faultlog.py
@@ -65,7 +65,7 @@ async def _test_get_faultlog(gwy: Gateway, ctl_id: DeviceIdT) -> None:
     assert isinstance(gwy._protocol, PortProtocol)  # mypy
     assert gwy._protocol._disable_qos is False  # QoS is required for this test
 
-    _: Controller = gwy.get_device(ctl_id)  # type: ignore[assignment]
+    _: Controller = gwy.device_registry.get_device(ctl_id)
 
     tcs: Evohome | None = gwy.tcs
     assert isinstance(tcs, Evohome)  # mypy

--- a/tests/tests_rf/test_api_schedule.py
+++ b/tests/tests_rf/test_api_schedule.py
@@ -53,7 +53,7 @@ async def _test_get_schedule(gwy: Gateway, ctl_id: DeviceIdT, idx: str) -> None:
     assert isinstance(gwy._protocol, PortProtocol)  # mypy
     assert gwy._protocol._disable_qos is False  # QoS is required for this test
 
-    _: Controller = gwy.get_device(ctl_id)  # type: ignore[assignment]
+    _: Controller = gwy.device_registry.get_device(ctl_id)
 
     tcs: Evohome | None = gwy.tcs
     assert isinstance(tcs, Evohome)  # mypy

--- a/tests/tests_rf/test_binding_fsm.py
+++ b/tests/tests_rf/test_binding_fsm.py
@@ -198,8 +198,8 @@ async def _test_flow_10x(
     # asyncio.create_task() should be OK (no need to pass in an event loop)
 
     # STEP 0: Setup...
-    respondent = gwy_r.devices[0]
-    supplicant = gwy_s.devices[0]
+    respondent = gwy_r.device_registry.devices[0]
+    supplicant = gwy_s.device_registry.devices[0]
     ensure_fakeable(respondent)
 
     assert isinstance(respondent, Fakeable)  # mypy
@@ -329,8 +329,8 @@ async def _test_flow_20x(
     """Check the change of state during a binding at device layer."""
 
     # STEP 0: Setup...
-    respondent = gwy_r.devices[0]
-    supplicant = gwy_s.devices[0]
+    respondent = gwy_r.device_registry.devices[0]
+    supplicant = gwy_s.device_registry.devices[0]
     ensure_fakeable(respondent)
 
     assert isinstance(respondent, Fakeable)  # mypy

--- a/tests/tests_rf/test_regression_rf.py
+++ b/tests/tests_rf/test_regression_rf.py
@@ -217,7 +217,7 @@ async def test_gateway_replay_regression(snapshot: SnapshotAssertion) -> None:
         # 5. Extract State for Snapshot
         # We create a deterministic dictionary of the system state
         devices_data = []
-        for d in sorted(gwy.devices, key=lambda x: x.id):
+        for d in sorted(gwy.device_registry.devices, key=lambda x: x.id):
             devices_data.append(await serialize_device(d))
 
         system_state: dict[str, Any] = {

--- a/tests/tests_rf/test_virt_network.py
+++ b/tests/tests_rf/test_virt_network.py
@@ -53,7 +53,7 @@ async def assert_code_in_device_msgindex(
     """Fail if the device doesn't exist, or if it doesn't have the code in its msg_db."""
 
     async def _has_code() -> bool:
-        dev = gwy.device_by_id.get(dev_id)
+        dev = gwy.device_registry.device_by_id.get(dev_id)
         if not dev:
             return False
 
@@ -86,10 +86,10 @@ async def assert_devices(
     for _ in range(int(max_sleep / ASSERT_CYCLE_TIME)):
         await asyncio.sleep(ASSERT_CYCLE_TIME)
         # Fix: ensure contents actually match before breaking early
-        if sorted(d.id for d in gwy.devices) == expected:
+        if sorted(d.id for d in gwy.device_registry.devices) == expected:
             break
 
-    assert sorted(d.id for d in gwy.devices) == expected
+    assert sorted(d.id for d in gwy.device_registry.devices) == expected
 
 
 async def assert_this_pkt(

--- a/tests/tests_rf/virtual_rf/__init__.py
+++ b/tests/tests_rf/virtual_rf/__init__.py
@@ -122,7 +122,7 @@ async def rf_factory(
 
             if start_gwys:
                 await gwy.start()
-            gwy.get_device(hgi_id)
+            gwy.device_registry.get_device(hgi_id)
 
         gwys.append(gwy)
 

--- a/tests/utils/analyze_diff_rf.py
+++ b/tests/utils/analyze_diff_rf.py
@@ -225,7 +225,8 @@ async def generate_actual_state() -> dict[str, Any]:
         system_state: dict[str, Any] = {
             "schema": gwy.schema,
             "devices": [
-                serialize_device(d) for d in sorted(gwy.devices, key=lambda x: x.id)
+                serialize_device(d)
+                for d in sorted(gwy.device_registry.devices, key=lambda x: x.id)
             ],
         }
 


### PR DESCRIPTION
## The Problem:

During the previous phase of deconstructing the `Gateway` God Object (where we successfully extracted `DeviceRegistry` and `DeviceFilter`, and applied Composition Root), we temporarily left "bridge" methods on the `Gateway` class (e.g., `@property def devices`, `get_device()`). These were left in place so existing files wouldn't break immediately. However, leaving these legacy wrappers in place obscures the new architecture, keeps the `Gateway` API surface artificially bloated, and encourages continued tight coupling.

## Consequences:

If these bridge methods are not removed, new code will continue to rely on the `Gateway` for device management. This negates the architectural benefits of the Dependency Injection work, maintains technical debt, and prevents true interface segregation.

## The Fix:

Removed all temporary forwarding/bridge methods from the `Gateway` and its interface. Updated the entire codebase and test suite to explicitly interact with the newly decoupled `DeviceRegistry`.

## Technical Implementation:
- Removed `@property def devices`, `device_by_id`, `system_by_id`, `systems`, and functions like `get_device()`, `fake_device()`, `known_list()`, and `_add_device()` directly from `gateway.py`.
- Cleaned up `GatewayInterface` in `interfaces.py` to ensure it no longer mandates device-handling methods.
- Updated all internal routing (`dispatcher.py`, `schemas.py`, `device/base.py`, `system/heat.py`, and CLI modules) to explicitly call `gwy.device_registry.X`.
- Updated `GatewayStub` and `mock_gateway` in the test suite to expose a `device_registry` property, repairing the test doubles.
- Applied `typing.cast()` in internal builder modules (like `schemas.py`) to satisfy strict Mypy checks where concrete `Device` objects are required from the generalized interface.

## Testing Performed:
- Executed the full `pytest` suite (825 tests) with a 100% pass rate.
- Executed strict `mypy` static type checking across all 130 source files, resolving all 60+ initial fallout errors down to 0.

## Risks of NOT Implementing:

Technical debt will accumulate as developers continue using the old `gwy.get_device()` patterns instead of fully adopting the `DeviceRegistry` pattern.

## Risks of Implementing:

This is a high-touch cleanup PR impacting many files. Un-merged feature branches or downstream scripts relying on `gwy.devices`, `gwy.get_device()`, or `gwy.device_by_id` will experience `AttributeError` breakages upon rebasing.

## Mitigation Steps:
- Utilized global regex search-and-replace to ensure comprehensive updates across the entire repository.
- Relied heavily on strict Mypy typing to mathematically prove that no legacy `Gateway` attribute references were left behind.
- Maintained identical data structures and method signatures inside the `DeviceRegistry` so the underlying logic of the consumers remains untouched.

## AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.
