### PR TITLE
Implement dynamic device availability logic and centralized heartbeat timeouts

### DIFF
--- a/src/ramses_rf/const.py
+++ b/src/ramses_rf/const.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from enum import IntEnum
 from typing import TYPE_CHECKING, Final
 
@@ -155,3 +156,10 @@ WB_STATUS_CODES: Final[dict[str, str]] = {
     "357": "Appliance in air purge mode. Primary heat exchanger air venting program active - approximately 100 seconds.",
     "358": "Three way valve kick. If the 3-way valve hasn't moved in within 48 hours, the valve will operate once to prevent seizure",
 }
+
+# Device Availability Timeouts
+HEARTBEAT_TIMEOUT_DEFAULT = timedelta(hours=1)
+HEARTBEAT_TIMEOUT_OTB = timedelta(hours=24)
+HEARTBEAT_TIMEOUT_TRV = timedelta(hours=12)
+HEARTBEAT_TIMEOUT_REMOTE = timedelta(hours=24)
+HEARTBEAT_TIMEOUT_SENSOR = timedelta(hours=12)

--- a/src/ramses_rf/const.py
+++ b/src/ramses_rf/const.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import timedelta as td
 from enum import IntEnum
 from typing import TYPE_CHECKING, Final
 
@@ -158,8 +158,8 @@ WB_STATUS_CODES: Final[dict[str, str]] = {
 }
 
 # Device Availability Timeouts
-HEARTBEAT_TIMEOUT_DEFAULT = timedelta(hours=1)
-HEARTBEAT_TIMEOUT_OTB = timedelta(hours=24)
-HEARTBEAT_TIMEOUT_TRV = timedelta(hours=12)
-HEARTBEAT_TIMEOUT_REMOTE = timedelta(hours=24)
-HEARTBEAT_TIMEOUT_SENSOR = timedelta(hours=12)
+HEARTBEAT_TIMEOUT_DEFAULT = td(hours=1)
+HEARTBEAT_TIMEOUT_OTB = td(hours=24)
+HEARTBEAT_TIMEOUT_TRV = td(hours=12)
+HEARTBEAT_TIMEOUT_REMOTE = td(hours=24)
+HEARTBEAT_TIMEOUT_SENSOR = td(hours=12)

--- a/src/ramses_rf/device/base.py
+++ b/src/ramses_rf/device/base.py
@@ -9,10 +9,16 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Iterable
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, cast
 
 from ramses_rf.binding_fsm import BindingManager, Vendor
-from ramses_rf.const import DEV_TYPE_MAP, SZ_OEM_CODE, DevType
+from ramses_rf.const import (
+    DEV_TYPE_MAP,
+    HEARTBEAT_TIMEOUT_DEFAULT,
+    SZ_OEM_CODE,
+    DevType,
+)
 from ramses_rf.entity_base import Entity, class_by_attr
 from ramses_rf.exceptions import DeviceNotFaked, SchemaInconsistentError
 from ramses_rf.schemas import SZ_ALIAS, SZ_CLASS, SZ_FAKED, SZ_KNOWN_LIST
@@ -76,6 +82,7 @@ class DeviceBase(Entity):
         self.type = dev_addr.type  # DEX  # TODO: remove this attr? use SLUG?
 
         self._scheme: Vendor | None = traits.scheme if traits else None
+        self._last_msg_dtm: datetime | None = None
 
     def __str__(self) -> str:
         if self._STATE_ATTR and hasattr(self, self._STATE_ATTR):
@@ -87,6 +94,32 @@ class DeviceBase(Entity):
         if not hasattr(other, "id"):
             return NotImplemented
         return self.id < other.id  # type: ignore[no-any-return]
+
+    @property
+    def heartbeat_timeout(self) -> timedelta:
+        """Return the timeout before the device is considered unavailable.
+
+        :return: The timeout duration before going unavailable.
+        :rtype: timedelta
+        """
+        return HEARTBEAT_TIMEOUT_DEFAULT
+
+    @property
+    def is_available(self) -> bool:
+        """Return True if the device is available based on its heartbeat.
+
+        :return: Availability status based on the latest message timestamp.
+        :rtype: bool
+        """
+        if self._last_msg_dtm is None:
+            return True  # Assume available until we receive baseline telemetry
+
+        if self._last_msg_dtm.tzinfo is not None:
+            now = datetime.now(UTC).astimezone(self._last_msg_dtm.tzinfo)
+        else:
+            now = datetime.now()
+
+        return (now - self._last_msg_dtm) <= self.heartbeat_timeout
 
     def _update_traits(self, traits: DeviceTraits) -> None:
         """Update a device with new schema attributes.
@@ -147,6 +180,7 @@ class DeviceBase(Entity):
         # # ), f"msg from {msg.src} inappropriately routed to {self}"
 
         super()._handle_msg(msg)
+        self._last_msg_dtm = getattr(msg, "dtm", None)
 
         if self._SLUG in DEV_TYPE_MAP.PROMOTABLE_SLUGS:  # HACK: can get precise class?
             from . import best_dev_role

--- a/src/ramses_rf/device/base.py
+++ b/src/ramses_rf/device/base.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Iterable
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime as dt, timedelta as td
 from typing import TYPE_CHECKING, Any, cast
 
 from ramses_rf.binding_fsm import BindingManager, Vendor
@@ -82,7 +82,7 @@ class DeviceBase(Entity):
         self.type = dev_addr.type  # DEX  # TODO: remove this attr? use SLUG?
 
         self._scheme: Vendor | None = traits.scheme if traits else None
-        self._last_msg_dtm: datetime | None = None
+        self._last_msg_dtm: dt | None = None
 
     def __str__(self) -> str:
         if self._STATE_ATTR and hasattr(self, self._STATE_ATTR):
@@ -96,7 +96,7 @@ class DeviceBase(Entity):
         return self.id < other.id  # type: ignore[no-any-return]
 
     @property
-    def heartbeat_timeout(self) -> timedelta:
+    def heartbeat_timeout(self) -> td:
         """Return the timeout before the device is considered unavailable.
 
         :return: The timeout duration before going unavailable.
@@ -115,9 +115,9 @@ class DeviceBase(Entity):
             return True  # Assume available until we receive baseline telemetry
 
         if self._last_msg_dtm.tzinfo is not None:
-            now = datetime.now(UTC).astimezone(self._last_msg_dtm.tzinfo)
+            now = dt.now(UTC).astimezone(self._last_msg_dtm.tzinfo)
         else:
-            now = datetime.now()
+            now = dt.now()
 
         return (now - self._last_msg_dtm) <= self.heartbeat_timeout
 

--- a/src/ramses_rf/device/heat.py
+++ b/src/ramses_rf/device/heat.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
 from ramses_rf import exceptions as exc
@@ -12,6 +13,8 @@ from ramses_rf.const import (
     DEV_ROLE_MAP,
     DEV_TYPE_MAP,
     DOMAIN_TYPE_MAP,
+    HEARTBEAT_TIMEOUT_OTB,
+    HEARTBEAT_TIMEOUT_TRV,
     SZ_DEVICES,
     SZ_DOMAIN_ID,
     SZ_HEAT_DEMAND,
@@ -719,6 +722,15 @@ class OtbGateway(Actuator, HeatDemand):  # OTB (10): 3220 (22D9, others)
         # lf._use_ot = self._gwy.config.use_native_ot
         self._msgs_ot: dict[MsgId, Message] = {}
         # lf._msgs_ot_ctl_polled = {}
+
+    @property
+    def heartbeat_timeout(self) -> timedelta:
+        """Return the timeout before the device is considered unavailable.
+
+        :return: The timeout duration.
+        :rtype: timedelta
+        """
+        return HEARTBEAT_TIMEOUT_OTB
 
     def _setup_discovery_cmds(self) -> None:
         def which_cmd(
@@ -1490,6 +1502,15 @@ class TrvActuator(BatteryState, HeatDemand, Setpoint, Temperature):  # TRV (04):
 
     _SLUG = DevType.TRV
     _STATE_ATTR = SZ_HEAT_DEMAND
+
+    @property
+    def heartbeat_timeout(self) -> timedelta:
+        """Return the timeout before the device is considered unavailable.
+
+        :return: The timeout duration.
+        :rtype: timedelta
+        """
+        return HEARTBEAT_TIMEOUT_TRV
 
     async def heat_demand(self) -> float | None:  # 3150
         if (heat_demand := await super().heat_demand()) is None:

--- a/src/ramses_rf/device/hvac.py
+++ b/src/ramses_rf/device/hvac.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from ramses_rf import exceptions as exc
 from ramses_rf.const import (
+    HEARTBEAT_TIMEOUT_REMOTE,
+    HEARTBEAT_TIMEOUT_SENSOR,
     SZ_AIR_QUALITY,
     SZ_AIR_QUALITY_BASIS,
     SZ_BOOST_TIMER,
@@ -85,7 +88,14 @@ class HvacRemoteBase(DeviceHvac):
     It provides common functionality and interfaces for remote control operations.
     """
 
-    pass
+    @property
+    def heartbeat_timeout(self) -> timedelta:
+        """Return the timeout before the device is considered unavailable.
+
+        :return: The timeout duration.
+        :rtype: timedelta
+        """
+        return HEARTBEAT_TIMEOUT_REMOTE
 
 
 class HvacSensorBase(DeviceHvac):
@@ -95,7 +105,14 @@ class HvacSensorBase(DeviceHvac):
     It provides common functionality for sensor data collection and processing.
     """
 
-    pass
+    @property
+    def heartbeat_timeout(self) -> timedelta:
+        """Return the timeout before the device is considered unavailable.
+
+        :return: The timeout duration.
+        :rtype: timedelta
+        """
+        return HEARTBEAT_TIMEOUT_SENSOR
 
 
 class CarbonDioxide(HvacSensorBase):  # 1298


### PR DESCRIPTION
## The Problem:

Currently, the Home Assistant integration (`ramses_cc`) determines device availability using a hardcoded 60-minute timeout applied globally across all entities. This approach violates the principle of separation of concerns—as RF protocol logic belongs in the library—and fails to account for the diverse "heartbeat" intervals of different hardware. Specifically, battery-powered TRVs and remote sensors often sit idle for longer than 60 minutes, causing them to incorrectly transition to an "Unavailable" state in Home Assistant.

## Consequences:

If this is not fixed, users with low-traffic RF devices will continue to experience "fragile" entity availability. This results in broken Home Assistant automations, incorrect state history, and a poor user experience as healthy devices appear offline simply because they have not needed to transmit a message recently.

## The Fix:

This PR pushes the responsibility for availability logic down into `ramses_rf`. It introduces a mechanism to track the latest message timestamp per device and evaluates availability against a `heartbeat_timeout` that is specific to the device class (e.g., 12 hours for TRVs, 24 hours for HVAC remotes).

## Technical Implementation:
- **Centralized Configuration:** Defined `HEARTBEAT_TIMEOUT_*` constants in `src/ramses_rf/const.py`.
- **State Tracking:** Modified `DeviceBase` to capture the timestamp of the latest processed message within the `_handle_msg` pipeline.
- **Logic Delegation:** Implemented a base `is_available` property in `DeviceBase` that compares the current time against the last message received plus the allowed timeout.
- **Class Overrides:** Provided specific `heartbeat_timeout` overrides for `OtbGateway`, `TrvActuator`, `HvacRemoteBase`, and `HvacSensorBase` to reflect real-world transmission intervals.

## Testing Performed:
- **Unit Testing:** Ran the full `pytest` suite; all existing protocol tests passed.
- **Type Checking:** Verified the changes are `mypy` compliant (strict mode).
- **Linting:** Verified code adheres to `ruff` standards.
- **Manual Verification:** Confirmed that `_last_msg_dtm` correctly updates upon message reception and that the `is_available` logic handles `None` cases (pre-telemetry) gracefully.

## Risks of NOT Implementing:

Persistent bugs regarding entity availability in the Home Assistant integration and continued violation of architectural separation between the protocol library and the HA component.

## Risks of Implementing:

There is a minor risk that a specific device model within a class might have a heartbeat longer than the assigned constant, leading to it still going "Unavailable" eventually. However, by using centralized constants, these can now be adjusted in a single location.

## Mitigation Steps:
- Implemented a conservative default timeout of 1 hour for unknown devices.
- Centralized all timeout values in `const.py` to allow for rapid tuning based on user feedback without modification of core logic.
- Ensured that devices are considered "Available" if no message has been received yet to prevent premature unavailability during system startup.

## AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 1.5 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.
