### PR TITLE
`2e10` parser: add check for 000

### DIFF
--- a/src/ramses_tx/parsers.py
+++ b/src/ramses_tx/parsers.py
@@ -1284,7 +1284,15 @@ def parser_10e0(payload: str, msg: Message) -> dict[str, Any]:
             f"{msg!r} < {_INFORM_DEV_MSG}, with the make/model of device: {msg.src} ({err})"
         )
 
-    description, _, unknown = payload[36:].partition("00")
+    description, _, unknown = payload[36:].partition(
+        "00"
+    )  # intended: split description (product name) part before '00'
+    # some payloads contain a '000' substring, so we add an odd/even check:
+    if len(description) % 2 != 0:
+        description = description + "0"
+        if not unknown.startswith("0"):  # expected for '000'
+            _LOGGER.debug("Unexpected 2E10 payload: %s", payload)
+        unknown = unknown[1:]  # trim first char
 
     result = {
         SZ_OEM_CODE: payload[14:16],  # 00/FF is CH/DHW, 01/6x is HVAC

--- a/tests/tests/parsers/code_10e0.log
+++ b/tests/tests/parsers/code_10e0.log
@@ -85,7 +85,7 @@
 2021-12-20T08:24:09.117900 ...  I --- 34:021943 63:262142 --:------ 10E0 038 000001C8380A0100F1FF0C0107E1030B07DE5438375246323032350000000000000000000000  # {'description': 'T87RF2025',           'manufacturer_sub_id': 'C8', 'product_id': '38', 'oem_code': '00', 'date_1': '2014-11-03', 'date_2': '2017-01-12'}
 # oem_code '00' / sub-id 'C9', 30:069468 is a BUVA Boxstream
 2023-11-04T12:34:14.007611 062  I --- 30:068457 63:262142 --:------ 10E0 038 000001C9001B0000FEFEFFFFFFFF0E0507E2425244472D30324A415330310000000000000000  # {'description': 'BRDG-02JAS01',        'manufacturer_sub_id': 'C9', 'product_id': '00', 'date_2': '0000-00-00', 'date_1': '2018-05-14', 'oem_code': '00'}
-2022-01-01T00:00:00.000000 000  I --- 30:069468 63:262142 --:------ 10E0 038 000001C9001B0000FEFEFFFFFFFF0E0507E2425244472D30324A415330310000000000000000  # {'description': 'BRDG-02JAS01',        'manufacturer_sub_id': 'C9', 'product_id': '00', 'date_1': '2018-05-14', 'date_2': '0000-00-00', 'oem_code': '00'}  # BUVA Boxstrea,
+2022-01-01T00:00:00.000000 000  I --- 30:069468 63:262142 --:------ 10E0 038 000001C9001B0000FEFEFFFFFFFF0E0507E2425244472D30324A415330310000000000000000  # {'description': 'BRDG-02JAS01',        'manufacturer_sub_id': 'C9', 'product_id': '00', 'date_1': '2018-05-14', 'date_2': '0000-00-00', 'oem_code': '00'}  # BUVA Boxstream,
 
 #
 # oem_code '01' - Itho Spider HVAC (also Buva?)
@@ -132,6 +132,10 @@
 2022-01-01T00:00:00.000000 000  I --- 32:172522 63:262142 --:------ 10E0 029 000001C85901016CFFFFFFFFFFFF1F0507E0564D4E2D32334C4D333300                    # {'description': 'VMN-23LM33',          'manufacturer_sub_id': 'C8', 'product_id': '59', 'oem_code': '6C', 'date_2': '0000-00-00', 'date_1': '2016-05-31'}  # {"_SLUG": "???", "make": "Nuaire", "model": None}
 2022-02-19T18:00:35.234656 062  I --- 32:206250 63:262142 --:------ 10E0 030 000001C85A01016CFFFFFFFFFFFF010607E0564D4E2D32334C4D48323300                  # {'description': 'VMN-23LMH23',         'manufacturer_sub_id': 'C8', 'product_id': '5A', 'oem_code': '6C', 'date_1': '2016-06-01', 'date_2': '0000-00-00'}
 2026-02-22T10:56:43.770144 065  I --- 32:166025 63:262142 --:------ 10E0 038 000001C85701016CFFFFFFFFFFFF110607E0564D532D32334333330000000000000000000000  # {'description': 'VMS-23C33',           'manufacturer_sub_id': 'C8', 'product_id': '57', 'oem_code': '6C', 'date_1': '2016-06-17', 'date_2': '0000-00-00'}  # {"_SLUG": "RFG", "make": "Nuaire", "model": "Drimaster Eco-RM"}  # Remote Monitoring, has extra sensors, binds to CO2
+
+# evohome peternash 2026-03 issue 557
+2026-03-22T19:13:36.467000 ...  I --- 22:012299 63:262142 --:------ 10E0 038 000002FF1F00FFFFFFFFFFFFFFFFFFFFFFFF4454342030323000C958300B15E98602B58C57C7  # {'oem_code': 'FF', 'manufacturer_sub_id': 'FF', 'product_id': '1F', 'date_1': '0000-00-00', 'date_2': '0000-00-00', 'description': 'DT4 020', '_unknown': 'C958300B15E98602B58C57C7'}
+# < Coding error: ValueError(fromhex() arg must contain an even number of hexadecimal digits). Caused by byte 30. Add odd/even check
 
 #
 # WIP


### PR DESCRIPTION
This PR fixes [ramses_cc issue 557](https://github.com/ramses-rf/ramses_cc/issues/557)

- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: not used

**PR Summary**
Add an even/odd check and fix substrings if required.
Adds new packet to tests/parsers/2e10