### PR TITLE
Style: Enforce and apply `datetime` as `dt` and `timedelta` as `td` import aliases

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,6 +83,13 @@ repos:
       args: [-i]
       exclude: .pre-commit-config.yaml  # avoid false +ve
 
+    - id: datetime_aliases
+      name: enforce datetime as dt and timedelta as td
+      entry: 'from datetime import.*\b(datetime(?! as dt)|timedelta(?! as td))\b'
+      language: pygrep
+      types: [python]
+      exclude: .pre-commit-config.yaml  # avoid false +ve
+
     # - id: private imports
     #   name: check for private imports
     #   entry: 'from .* import _.*'

--- a/tests/tests_cli/test_client.py
+++ b/tests/tests_cli/test_client.py
@@ -5,7 +5,7 @@ import asyncio
 import io
 import json
 from collections.abc import AsyncGenerator, Awaitable, Callable
-from datetime import datetime
+from datetime import datetime as dt
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
@@ -528,7 +528,7 @@ async def test_async_main_msg_handler(
         # Now test the callback with different message types
         # 1. Puzzle message
         msg1 = MagicMock(spec=Message)
-        msg1.dtm = datetime.now()
+        msg1.dtm = dt.now()
         msg1.code = Code._PUZZ
         # Mypy dislikes assigning to method slots on mocks without ignore
         msg1.__repr__ = MagicMock(return_value="PUZZLE_MSG")  # type: ignore[method-assign]
@@ -539,7 +539,7 @@ async def test_async_main_msg_handler(
         # 2. 1F09 (I) message
         # Use a fresh mock object to avoid state pollution
         msg2 = MagicMock(spec=Message)
-        msg2.dtm = datetime.now()
+        msg2.dtm = dt.now()
         msg2.code = Code._1F09
         msg2.verb = I_
         # Fix: Ensure src attribute exists for HGI check in handle_msg
@@ -585,7 +585,7 @@ async def test_async_main_long_format(
 
         # Trigger callback
         msg = MagicMock(spec=Message)
-        msg.dtm = datetime.now()
+        msg.dtm = dt.now()
         msg.__repr__ = MagicMock(return_value="LONG_MSG")  # type: ignore[method-assign]
         msg.payload = "PAYLOAD"
 

--- a/tests/tests_tx/test_transport_zigbee.py
+++ b/tests/tests_tx/test_transport_zigbee.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import unittest
-from datetime import timedelta
+from datetime import timedelta as td
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -1354,7 +1354,7 @@ class TestChunkBufferTTL(unittest.TestCase):
     def test_cleanup_removes_stale_buffers(self) -> None:
         from ramses_tx.helpers import dt_now
 
-        old_time = dt_now() - timedelta(seconds=self.t._CHUNK_TIMEOUT + 1)
+        old_time = dt_now() - td(seconds=self.t._CHUNK_TIMEOUT + 1)
         fresh_time = dt_now()
 
         self.t._chunk_buffers["stale_device"] = {
@@ -1376,7 +1376,7 @@ class TestChunkBufferTTL(unittest.TestCase):
     def test_maybe_handle_triggers_cleanup(self) -> None:
         from ramses_tx.helpers import dt_now
 
-        old_time = dt_now() - timedelta(seconds=self.t._CHUNK_TIMEOUT + 1)
+        old_time = dt_now() - td(seconds=self.t._CHUNK_TIMEOUT + 1)
         self.t._chunk_buffers["stale_device"] = {
             "timestamp": old_time,
             "total": 2,


### PR DESCRIPTION
### The Problem:

The codebase lacked a programmatic way to enforce specific import aliases for `datetime` and `timedelta`, leading to inconsistent import styles. The standard preference is to utilize the `dt` and `td` aliases, but without a linter rule, this relied entirely on manual code review.

### Consequences:

Without an automated check, future contributors could easily introduce inconsistent imports. This fragments the codebase style and wastes maintainer time on stylistic code-review corrections rather than focusing on core logic and architectural reviews.

### The Fix:

Implemented a custom pre-commit hook to strictly enforce the requested aliases and refactored the two non-compliant test files in the codebase to match this new rule.

### Technical Implementation:
- Added a new `datetime_aliases` hook to `.pre-commit-config.yaml` utilizing the local `pygrep` repository.
- Used a regular expression with a negative lookahead (`from datetime import.*\b(datetime(?! as dt)|timedelta(?! as td))\b`) to automatically flag any imports from the `datetime` module that lack the correct aliases.
- Updated the import statements in `tests/tests_tx/test_transport_zigbee.py` and `tests/tests_cli/test_client.py` to resolve the pre-commit failures.

### Testing Performed:
- Ran the full pre-commit suite (`prek run -a`) locally on the feature branch.
- Verified that the custom hook correctly flagged the initial non-compliant test files.
- Confirmed that the suite fully passes after updating the imports in the affected test files.
- Verified that Ruff linting and formatting continue to pass with the new aliases in place.

### Risks of NOT Implementing:

Ongoing style inconsistencies and unnecessary manual review overhead for maintainers dealing with import formatting on future pull requests.

### Risks of Implementing:

The risk is extremely minimal as this is a purely stylistic change. The only theoretical risk would be if the new `dt` or `td` aliases shadowed an existing local variable within `test_transport_zigbee.py` or `test_client.py`.

### Mitigation Steps:

Ran the project's strict Ruff linter via the pre-commit suite. Ruff successfully validated the changes, ensuring that substituting the aliases did not introduce any undefined variables, shadowed variables, or scope resolution issues in the updated test files.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.