### PR TITLE
Fix: Return transport exceptions from wait_for_connection_lost instead of raising (ramses-rf/ramses_cc#560)

### DIFF
--- a/src/ramses_tx/protocol/base.py
+++ b/src/ramses_tx/protocol/base.py
@@ -41,14 +41,7 @@ from ..interfaces import ProtocolInterface, TransportInterface
 from ..message import Message
 from ..packet import Packet
 from ..schemas import SZ_BLOCK_LIST, SZ_CLASS, SZ_INBOUND, SZ_KNOWN_LIST, SZ_OUTBOUND
-from ..typing import (
-    DeviceIdT,
-    DeviceListT,
-    ExceptionT,
-    MsgFilterT,
-    MsgHandlerT,
-    QosParams,
-)
+from ..typing import DeviceIdT, DeviceListT, MsgFilterT, MsgHandlerT, QosParams
 
 if TYPE_CHECKING:
     from .fsm import ProtocolContext
@@ -205,7 +198,7 @@ class _BaseProtocol(ProtocolInterface, asyncio.Protocol):
         else:
             self._wait_connection_lost.set_result(None)
 
-    async def wait_for_connection_lost(self, timeout: float = 1.0) -> ExceptionT | None:
+    async def wait_for_connection_lost(self, timeout: float = 1.0) -> Exception | None:
         """A courtesy function to wait until connection_lost() has been invoked.
 
         Includes scenarios where neither connection_made() nor connection_lost() were
@@ -217,11 +210,18 @@ class _BaseProtocol(ProtocolInterface, asyncio.Protocol):
             return None
 
         try:
-            return await asyncio.wait_for(self._wait_connection_lost, timeout)
+            await asyncio.wait_for(self._wait_connection_lost, timeout)
+            return None
         except TimeoutError as err:
             raise TransportError(
                 f"Transport did not unbind from Protocol within {timeout} secs"
             ) from err
+        except Exception as err:
+            # If the transport dropped unexpectedly, connection_lost(err) sets
+            # the exception on the future. Awaiting it raises the exception here.
+            # We catch and return it to satisfy the ExceptionT | None type hint
+            # and prevent teardown crashes in the caller.
+            return err
 
     def pause_writing(self) -> None:
         """Called when the transport's buffer goes over the high-water mark."""

--- a/tests/tests_tx/test_protocol_base.py
+++ b/tests/tests_tx/test_protocol_base.py
@@ -1,0 +1,220 @@
+"""Tests for the RAMSES-II base protocol layer."""
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ramses_tx.address import HGI_DEV_ADDR
+from ramses_tx.exceptions import ProtocolError, TransportError
+from ramses_tx.protocol.base import _DeviceIdFilterMixin
+from ramses_tx.typing import DeviceIdT
+
+# Ensure all tests in this file run within an asyncio event loop
+pytestmark = pytest.mark.asyncio
+
+
+class DummyProtocol(_DeviceIdFilterMixin):
+    """Testable protocol class incorporating device ID filtering."""
+
+    def __init__(self, msg_handler: Any) -> None:
+        # Initialize the mixin, which handles the exclusion/inclusion list setup
+        super().__init__(msg_handler)
+
+    async def _send_cmd(self, cmd: Any, **kwargs: Any) -> Any:
+        """Override the abstract _send_cmd to prevent NotImplementedError."""
+        return cmd
+
+
+@pytest.fixture
+def mock_msg_handler() -> AsyncMock:
+    """Provide a dummy message handler for the protocol."""
+    return AsyncMock()
+
+
+@pytest.fixture
+async def protocol(mock_msg_handler: AsyncMock) -> DummyProtocol:
+    """Provide a fresh instance of the testable base protocol."""
+    return DummyProtocol(mock_msg_handler)
+
+
+# --- CONNECTION LIFECYCLE TESTS (Issue #560 Fixes) ---
+
+
+async def test_wait_for_connection_lost_no_connection(protocol: DummyProtocol) -> None:
+    """Test wait_for_connection_lost when no connection was ever made."""
+    result = await protocol.wait_for_connection_lost()
+    assert result is None
+
+
+async def test_wait_for_connection_lost_clean_disconnect(
+    protocol: DummyProtocol,
+) -> None:
+    """Test wait_for_connection_lost returns None on a clean disconnect."""
+    mock_transport = MagicMock()
+    protocol.connection_made(mock_transport)
+    protocol.connection_lost(None)
+
+    result = await protocol.wait_for_connection_lost()
+    assert result is None
+
+
+async def test_wait_for_connection_lost_with_exception(protocol: DummyProtocol) -> None:
+    """Test wait_for_connection_lost returns (does not raise) transport exceptions."""
+    mock_transport = MagicMock()
+    protocol.connection_made(mock_transport)
+
+    expected_exc = Exception("Device disconnected unexpectedly")
+    protocol.connection_lost(expected_exc)
+
+    result = await protocol.wait_for_connection_lost()
+    assert result is expected_exc
+
+
+async def test_wait_for_connection_lost_timeout(protocol: DummyProtocol) -> None:
+    """Test wait_for_connection_lost raises TransportError if it times out."""
+    mock_transport = MagicMock()
+    protocol.connection_made(mock_transport)
+
+    with pytest.raises(TransportError, match="Transport did not unbind from Protocol"):
+        await protocol.wait_for_connection_lost(timeout=0.01)
+
+
+# --- DEVICE ID FILTERING TESTS (_is_wanted_addrs) ---
+
+
+async def test_is_wanted_addrs_empty_filters(protocol: DummyProtocol) -> None:
+    """Test default behavior with no filters set."""
+    assert (
+        protocol._is_wanted_addrs(DeviceIdT("01:111111"), DeviceIdT("01:222222"))
+        is True
+    )
+
+
+async def test_is_wanted_addrs_exclude_list(protocol: DummyProtocol) -> None:
+    """Test that devices in the exclude list are rejected."""
+    protocol._exclude = [DeviceIdT("01:111111")]
+    assert (
+        protocol._is_wanted_addrs(DeviceIdT("01:111111"), DeviceIdT("01:222222"))
+        is False
+    )
+    assert (
+        protocol._is_wanted_addrs(DeviceIdT("01:222222"), DeviceIdT("01:111111"))
+        is False
+    )
+    assert (
+        protocol._is_wanted_addrs(DeviceIdT("01:333333"), DeviceIdT("01:444444"))
+        is True
+    )
+
+
+async def test_is_wanted_addrs_enforce_include(protocol: DummyProtocol) -> None:
+    """Test enforce_include logic ensures ALL addresses are in the include list."""
+    protocol.enforce_include = True
+    protocol._include = [DeviceIdT("01:111111")]
+
+    # Only one device included, the other isn't -> False
+    assert (
+        protocol._is_wanted_addrs(DeviceIdT("01:111111"), DeviceIdT("01:222222"))
+        is False
+    )
+
+    # Both devices included -> True
+    protocol._include = [DeviceIdT("01:111111"), DeviceIdT("01:222222")]
+    assert (
+        protocol._is_wanted_addrs(DeviceIdT("01:111111"), DeviceIdT("01:222222"))
+        is True
+    )
+
+
+async def test_is_wanted_addrs_active_hgi(protocol: DummyProtocol) -> None:
+    """Test that the active HGI bypasses the enforce_include filter."""
+    protocol.enforce_include = True
+    protocol._include = [DeviceIdT("01:111111")]
+    protocol._active_hgi = DeviceIdT("18:999999")
+
+    # 18:999999 is the active HGI, so it should be permitted despite not being in _include
+    assert (
+        protocol._is_wanted_addrs(DeviceIdT("01:111111"), DeviceIdT("18:999999"))
+        is True
+    )
+
+
+async def test_is_wanted_addrs_sending_to_hgi(protocol: DummyProtocol) -> None:
+    """Test that sending to the generic HGI address is permitted."""
+    protocol.enforce_include = True
+    protocol._include = [DeviceIdT("01:111111")]
+
+    # When sending, HGI_DEV_ADDR (18:000730) is always allowed
+    assert (
+        protocol._is_wanted_addrs(DeviceIdT("01:111111"), HGI_DEV_ADDR.id, sending=True)
+        is True
+    )
+    # But not when receiving
+    assert (
+        protocol._is_wanted_addrs(
+            DeviceIdT("01:111111"), HGI_DEV_ADDR.id, sending=False
+        )
+        is False
+    )
+
+
+# --- INBOUND PACKET TESTS (_pkt_received) ---
+
+
+async def test_pkt_received_included(protocol: DummyProtocol) -> None:
+    """Test that wanted packets are passed up to the parent class."""
+    mock_pkt = MagicMock()
+    mock_pkt.src.id = "01:111111"
+    mock_pkt.dst.id = "01:222222"
+
+    # Patch the base class to prevent the mock from triggering validation errors
+    with patch("ramses_tx.protocol.base._BaseProtocol._pkt_received") as mock_base_recv:
+        protocol._pkt_received(mock_pkt)
+        mock_base_recv.assert_called_once_with(mock_pkt)
+
+
+async def test_pkt_received_excluded(
+    protocol: DummyProtocol, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that unwanted packets are dropped and logged."""
+    protocol._exclude = [DeviceIdT("01:111111")]
+    mock_pkt = MagicMock()
+    mock_pkt.src.id = "01:111111"
+    mock_pkt.dst.id = "01:222222"
+
+    with (
+        caplog.at_level(logging.DEBUG),
+        patch("ramses_tx.protocol.base._BaseProtocol._pkt_received") as mock_base_recv,
+    ):
+        protocol._pkt_received(mock_pkt)
+        mock_base_recv.assert_not_called()
+
+    assert "Packet excluded by device_id filter" in caplog.text
+
+
+# --- OUTBOUND COMMAND TESTS (send_cmd) ---
+
+
+async def test_send_cmd_included(protocol: DummyProtocol) -> None:
+    """Test that wanted commands are sent down to the parent class."""
+    mock_cmd = MagicMock()
+    mock_cmd.src.id = "01:111111"
+    mock_cmd.dst.id = "01:222222"
+    protocol._is_evofw3 = False  # Avoids triggering deep address parsing on the mock
+
+    result = await protocol.send_cmd(mock_cmd)
+
+    assert result is mock_cmd
+
+
+async def test_send_cmd_excluded(protocol: DummyProtocol) -> None:
+    """Test that sending unwanted commands raises a ProtocolError."""
+    protocol._exclude = [DeviceIdT("01:111111")]
+    mock_cmd = MagicMock()
+    mock_cmd.src.id = "01:111111"
+    mock_cmd.dst.id = "01:222222"
+
+    with pytest.raises(ProtocolError, match="Command excluded by device_id filter"):
+        await protocol.send_cmd(mock_cmd)


### PR DESCRIPTION
### The Problem:

During teardown (e.g., `client.stop()`), heavy I/O from closing the Flightrecorder log can cause the `pyserial` connection to drop, generating a `SerialException`. `port.py` correctly catches this and triggers `connection_lost(err)` on the protocol, which sets the exception on the `_wait_connection_lost` Future.

However, when `gateway.py` awaits `wait_for_connection_lost()`, the `await` unpacks and raises the Future's exception, crashing the teardown sequence and bubbling a severe task exception up to the Home Assistant runner (Issue #560 in `ramses_cc`).

### Consequences:

Uncaught `SerialException` or `TimeoutError` during shutdown crashes the teardown task, leaving the integration in a dirty state during Home Assistant restarts or integration reloads, and generating severe core log errors.

### The Fix:

Updated `wait_for_connection_lost` in `src/ramses_tx/protocol/base.py` to catch unpacked exceptions and explicitly return them, satisfying the intended return signature rather than blowing up the call stack.

### Technical Implementation:
- Modified the signature of `wait_for_connection_lost` from `-> ExceptionT | None` to `-> Exception | None` to correct a strict-typing anti-pattern where a `TypeVar` was used as a generic instance.
- Added a `try/except Exception as err:` block inside the wait loop.
- If an exception was set on the Future via `connection_lost(err)`, it is now caught and safely returned.

### Testing Performed:
- Created `tests/tests_tx/test_protocol_base.py` with 13 new async tests.
- Explicitly verified that `test_wait_for_connection_lost_with_exception` safely returns an injected exception instead of raising it.
- Expanded coverage to include `_is_wanted_addrs`, `_pkt_received`, and `send_cmd` to verify `_DeviceIdFilterMixin` logic.
- `mypy --strict` passes completely.
- All 857 Pytest suites pass (818 passed, 39 skipped).

### Risks of NOT Implementing:

The teardown sequence will remain brittle to transport layer instability (like USB disconnects or heavy disk I/O contention), causing downstream integrations to crash during normal shutdown routines.

### Risks of Implementing:

Low. The method signature already hinted that it should return an exception (`ExceptionT | None`), so upstream callers expecting this method to raise rather than return are highly unlikely.

### Mitigation Steps:

Added full unit test coverage to `test_protocol_base.py` to lock in the expected behavior of all 4 connection drop states (none, clean, dirty, timeout) and ensure no regressions in device ID filtering.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.
