### PR TITLE
Feat: Implement `set_fan_mode` for HvacVentilator to enable native fan control

### DIFF
--- a/src/ramses_rf/device/hvac.py
+++ b/src/ramses_rf/device/hvac.py
@@ -857,6 +857,34 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         _LOGGER.debug("No bound REM or DIS devices found for FAN %s", self.id)
         return None
 
+    async def set_fan_mode(self, fan_mode: str | int) -> Packet:
+        """Set the operating mode/speed of the ventilator.
+
+        :param fan_mode: The desired fan mode (e.g., 'low', 'medium', 'high', 'boost').
+        :return: The sent packet.
+        :raises CommandInvalid: If unable to determine a valid source ID.
+        """
+        # 22F1 commands to a FAN typically must originate from a bound Remote (REM)
+        # We attempt to impersonate the first bound REM. If none exists, fallback to HGI.
+        src_id = self.get_bound_rem()
+
+        if not src_id:
+            if self.hgi:
+                src_id = self.hgi.id
+            else:
+                raise exc.CommandInvalid(
+                    f"{self}: Cannot set fan mode without a bound REM or HGI"
+                )
+
+        _LOGGER.debug(
+            "Sending set_fan_mode '%s' to %s via src %s", fan_mode, self.id, src_id
+        )
+
+        cmd = Command.set_fan_mode(self.id, fan_mode, src_id=src_id)
+        return await self._gwy.async_send_cmd(
+            cmd, num_repeats=2, priority=Priority.HIGH
+        )
+
     async def air_quality(self) -> float | None:
         """Return the current air quality measurement.
 

--- a/src/ramses_tx/parsers.py
+++ b/src/ramses_tx/parsers.py
@@ -1365,7 +1365,7 @@ def parser_1100(
     """
 
     def complex_idx(seqx: str) -> PayDictT._1100_IDX | PayDictT.EMPTY:
-        return {SZ_DOMAIN_ID: seqx} if seqx[:1] == "F" else {}  # type: ignore[typeddict-item]  # only FC
+        return {SZ_DOMAIN_ID: seqx} if seqx[:1] == "F" else {}  # type: ignore[typeddict-item, unused-ignore]  # only FC
 
     if msg.src.type == DEV_TYPE_MAP.JIM:  # Honeywell Japser, DEX
         assert msg.len == 19, msg.len

--- a/tests/tests_rf/device/test_hvac_ventilator.py
+++ b/tests/tests_rf/device/test_hvac_ventilator.py
@@ -6,12 +6,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from ramses_rf import exceptions as exc
 from ramses_rf.const import DevType
 from ramses_rf.database import MessageIndex
 from ramses_rf.device.hvac import HvacVentilator
 from ramses_rf.gateway import Gateway
 from ramses_tx import Address
-from ramses_tx.const import Code
+from ramses_tx.const import Code, Priority
 from ramses_tx.typing import DeviceIdT
 
 # Test data
@@ -535,3 +536,71 @@ class TestHvacVentilator:
 
         if hvac_ventilator._gwy.msg_db:
             hvac_ventilator._gwy.msg_db.stop()
+
+
+async def test_set_fan_mode_with_bound_rem() -> None:
+    """Test set_fan_mode uses the bound REM as the source ID."""
+    dev = MagicMock(spec=HvacVentilator)
+    dev.id = "32:123456"
+    dev.get_bound_rem.return_value = "37:654321"
+
+    dev._gwy = MagicMock()
+    dev._gwy.async_send_cmd = AsyncMock(return_value="mock_packet")
+
+    # Patch the command builder so we can verify what gets passed to it
+    with patch("ramses_rf.device.hvac.Command.set_fan_mode") as mock_cmd:
+        mock_cmd.return_value = "mock_command"
+
+        # Call the unbound method passing our mock as 'self'
+        result = await HvacVentilator.set_fan_mode(dev, "low")
+
+        # 1. Verify it checked for a bound remote
+        dev.get_bound_rem.assert_called_once()
+
+        # 2. Verify the packet was built using the REM's ID ("37:654321")
+        mock_cmd.assert_called_once_with("32:123456", "low", src_id="37:654321")
+
+        # 3. Verify it was transmitted with the correct QoS
+        dev._gwy.async_send_cmd.assert_awaited_once_with(
+            "mock_command", num_repeats=2, priority=Priority.HIGH
+        )
+        assert result == "mock_packet"
+
+
+async def test_set_fan_mode_with_hgi_fallback() -> None:
+    """Test set_fan_mode falls back to the HGI if no REM is bound."""
+    dev = MagicMock(spec=HvacVentilator)
+    dev.id = "32:123456"
+    dev.get_bound_rem.return_value = None
+
+    # Simulate an available HGI
+    dev.hgi = MagicMock()
+    dev.hgi.id = "18:000730"
+
+    dev._gwy = MagicMock()
+    dev._gwy.async_send_cmd = AsyncMock(return_value="mock_packet")
+
+    with patch("ramses_rf.device.hvac.Command.set_fan_mode") as mock_cmd:
+        mock_cmd.return_value = "mock_command"
+
+        await HvacVentilator.set_fan_mode(dev, "high")
+
+        # Verify the packet was built using the HGI's ID ("18:000730")
+        mock_cmd.assert_called_once_with("32:123456", "high", src_id="18:000730")
+        dev._gwy.async_send_cmd.assert_awaited_once()
+
+
+async def test_set_fan_mode_no_src_id_raises() -> None:
+    """Test set_fan_mode raises CommandInvalid if no src_id can be determined."""
+    dev = MagicMock(spec=HvacVentilator)
+    dev.id = "32:123456"
+    dev.get_bound_rem.return_value = None
+
+    # Simulate NO available HGI (e.g. gateway not fully initialized)
+    dev.hgi = None
+
+    # Verify it raises the expected custom library exception
+    with pytest.raises(
+        exc.CommandInvalid, match="Cannot set fan mode without a bound REM or HGI"
+    ):
+        await HvacVentilator.set_fan_mode(dev, "auto")


### PR DESCRIPTION
### The Problem:

Home Assistant users attempting to control the fan speed of ventilation devices (like the Siber DF Evo 4) via standard UI climate cards were encountering a `NotImplementedError` (see `ramses_cc` Issue #210). While the `ramses_tx` layer already had the `Command.set_fan_mode` packet builder for `22F1` commands, the `HvacVentilator` class lacked the corresponding device-level method to invoke it.

### Consequences:

Without this method, users cannot control their ventilation speeds using standard smart home interfaces. They are forced to rely on complex, error-prone manual `send_command` YAML scripts to inject raw hex frames.

### The Fix:

Added the `set_fan_mode` asynchronous method to the `HvacVentilator` class in `src/ramses_rf/device/hvac.py`.

### Technical Implementation:
- Created `async def set_fan_mode(self, fan_mode: str | int)`.
- For a `22F1` command to be accepted by the ventilator, it typically expects the packet to originate from a bound remote (`REM`). The implementation first queries `self.get_bound_rem()` to impersonate the remote.
- If no remote is bound, the logic gracefully falls back to using the Gateway's own ID (`self.hgi.id`).
- The resolved `src_id` and requested `fan_mode` are passed to `Command.set_fan_mode()`, and the resulting packet is queued via `self._gwy.async_send_cmd()` using `Priority.HIGH` and 2 retries.
- If neither a remote nor an HGI is available, the method raises `exc.CommandInvalid`.

### Testing Performed:

Added the following tests to `tests_rf/device/test_hvac_ventilator.py` to ensure robust coverage:
- `test_set_fan_mode_with_bound_rem`: Verifies correct packet construction and QoS parameters when a bound remote is present.
- `test_set_fan_mode_with_hgi_fallback`: Verifies successful fallback to the HGI ID when no remote is bound in the system topology.
- `test_set_fan_mode_no_src_id_raises`: Ensures a `CommandInvalid` exception is cleanly raised if neither a bound remote nor an HGI is available to act as the packet source.

### Risks of NOT Implementing:

The `ramses_cc` integration will remain incapable of fully supporting standard Home Assistant climate entities for HVAC devices, degrading the user experience.

### Risks of Implementing:

Extremely low risk. This PR adds a discrete, previously missing control method and does not modify the existing message parsing or state management loops.

### Mitigation Steps:

Implemented strict `src_id` validation before packet construction. By safely raising a `CommandInvalid` exception when the topology lacks a valid source ID, we prevent the library from crafting malformed packets or crashing.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.
