### PR TITLE
Feature: Phase 2.4 - MessageStore Hydration & Disk Snapshots (#530)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,7 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Local SQLite databases
+ramses.db
+*.sqlite

--- a/src/ramses_rf/database.py
+++ b/src/ramses_rf/database.py
@@ -27,6 +27,7 @@ import contextlib
 import logging
 import os
 import sqlite3
+import threading
 import uuid
 from collections import OrderedDict
 from datetime import datetime as dt, timedelta as td
@@ -110,6 +111,9 @@ class MessageStore:
         self._msgs: MsgDdT = OrderedDict()  # stores all messages for retrieval.
         self._msgz_: dict[str, Message] = {}  # Phase 2.4: hdr-based retrieval.
         # Filled & cleaned up in housekeeping_loop.
+
+        # Thread-safety lock to prevent Python 3.13 Segfaults
+        self._db_lock = threading.Lock()
 
         # For :memory: databases with multiple connections (Reader vs Worker)
         # We must use a Shared Cache URI so both threads see the same data.
@@ -197,11 +201,12 @@ class MessageStore:
 
         self._worker.stop()  # Stop the background thread
 
-        try:
-            self._cx.commit()  # just in case
-            self._cx.close()  # safely close reader connection
-        except sqlite3.ProgrammingError:
-            pass  # Connection might already be closed
+        with self._db_lock:
+            try:
+                self._cx.commit()  # just in case
+                self._cx.close()  # safely close reader connection
+            except sqlite3.ProgrammingError:
+                pass  # Connection might already be closed
 
     @property
     def msgs(self) -> MsgDdT:
@@ -222,9 +227,10 @@ class MessageStore:
         """
 
         def _fetch_all() -> list[Any]:
-            return self._cx.execute(
-                "SELECT * FROM messages ORDER BY dtm ASC"
-            ).fetchall()
+            with self._db_lock:
+                return self._cx.execute(
+                    "SELECT * FROM messages ORDER BY dtm ASC"
+                ).fetchall()
 
         try:
             rows = await asyncio.to_thread(_fetch_all)
@@ -499,7 +505,8 @@ class MessageStore:
         sql += " AND ".join(f"{k} = ?" for k in kwargs)
 
         def _execute_delete() -> None:
-            self._cx.execute(sql, tuple(kwargs.values()))
+            with self._db_lock:
+                self._cx.execute(sql, tuple(kwargs.values()))
 
         await asyncio.to_thread(_execute_delete)
 
@@ -578,7 +585,8 @@ class MessageStore:
         sql += " AND ".join(f"{k} = ?" for k in kw)
 
         def _fetch_dtms() -> list[Any]:
-            return self._cx.execute(sql, tuple(kw.values())).fetchall()
+            with self._db_lock:
+                return self._cx.execute(sql, tuple(kw.values())).fetchall()
 
         try:
             return await asyncio.to_thread(_fetch_dtms)
@@ -598,7 +606,8 @@ class MessageStore:
             raise DatabaseQueryError(f"{self}: Only SELECT queries are allowed")
 
         def _fetch_qry() -> list[Any]:
-            return self._cx.execute(sql, parameters).fetchall()
+            with self._db_lock:
+                return self._cx.execute(sql, parameters).fetchall()
 
         try:
             rows = await asyncio.to_thread(_fetch_qry)
@@ -637,7 +646,8 @@ class MessageStore:
             raise DatabaseQueryError(f"{self}: Only SELECT queries are allowed")
 
         def _fetch_rp() -> list[Any]:
-            return self._cx.execute(sql, parameters).fetchall()
+            with self._db_lock:
+                return self._cx.execute(sql, parameters).fetchall()
 
         try:
             rows = await asyncio.to_thread(_fetch_rp)
@@ -663,7 +673,8 @@ class MessageStore:
             raise DatabaseQueryError(f"{self}: Only SELECT queries are allowed")
 
         def _fetch_field() -> list[Any]:
-            return self._cx.execute(sql, parameters).fetchall()
+            with self._db_lock:
+                return self._cx.execute(sql, parameters).fetchall()
 
         try:
             return await asyncio.to_thread(_fetch_field)
@@ -674,7 +685,8 @@ class MessageStore:
         """Get all messages from the index."""
 
         def _fetch_all() -> list[Any]:
-            return self._cx.execute("SELECT * FROM messages").fetchall()
+            with self._db_lock:
+                return self._cx.execute("SELECT * FROM messages").fetchall()
 
         rows = await asyncio.to_thread(_fetch_all)
         lst: list[Message] = []
@@ -691,8 +703,9 @@ class MessageStore:
         """Clear the message index (remove indexes of all messages)."""
 
         def _clear_db() -> None:
-            self._cx.execute("DELETE FROM messages")
-            self._cx.commit()
+            with self._db_lock:
+                self._cx.execute("DELETE FROM messages")
+                self._cx.commit()
 
         await asyncio.to_thread(_clear_db)
         self._msgs.clear()

--- a/src/ramses_rf/database.py
+++ b/src/ramses_rf/database.py
@@ -17,8 +17,7 @@ RAMSES RF - Message database and index.
    i7     get_rp_codes  src, dst     list(Code)        Discovery-supported_cmds
    =====  ============  ===========  ==========  ====  ========================
 
-[#fn1] A word of explanation.
-[^1]: ex = entity_base.py query methods
+[#fn1] A word of explanation.[^1]: ex = entity_base.py query methods
 """
 
 from __future__ import annotations
@@ -97,12 +96,19 @@ class MessageStore:
     (example of a hdr: ``000C|RP|01:223036|0208``)."""
 
     _housekeeping_task: asyncio.Task[None]
+    _hydration_task: asyncio.Task[None]
 
-    def __init__(self, maintain: bool = True, db_path: str = ":memory:") -> None:
+    def __init__(
+        self,
+        maintain: bool = True,
+        db_path: str = ":memory:",
+        disk_path: str | None = "ramses.db",
+    ) -> None:
         """Instantiate a message database/index."""
 
         self.maintain = maintain
         self._msgs: MsgDdT = OrderedDict()  # stores all messages for retrieval.
+        self._msgz_: dict[str, Message] = {}  # Phase 2.4: hdr-based retrieval.
         # Filled & cleaned up in housekeeping_loop.
 
         # For :memory: databases with multiple connections (Reader vs Worker)
@@ -113,7 +119,7 @@ class MessageStore:
 
         # Start the Storage Worker (Write Connection)
         # This thread handles all blocking INSERT/UPDATE operations
-        self._worker = StorageWorker(db_path)
+        self._worker = StorageWorker(db_path, disk_path=disk_path)
 
         # Wait for the worker to create the tables.
         # This prevents "no such table" errors on immediate reads.
@@ -164,6 +170,10 @@ class MessageStore:
             ):
                 return
 
+            self._hydration_task = asyncio.create_task(
+                self._hydrate_ram(), name=f"{self.__class__.__name__}.hydrator"
+            )
+
             self._housekeeping_task = asyncio.create_task(
                 self._housekeeping_loop(), name=f"{self.__class__.__name__}.housekeeper"
             )
@@ -177,6 +187,13 @@ class MessageStore:
             and not self._housekeeping_task.done()
         ):
             self._housekeeping_task.cancel()  # stop the housekeeper
+
+        if getattr(self, "_hydration_task", None) and not self._hydration_task.done():
+            self._hydration_task.cancel()
+
+        # Trigger a final snapshot to ensure no data is lost on shutdown
+        self._worker.submit_snapshot()
+        self._worker.flush(timeout=5.0)
 
         self._worker.stop()  # Stop the background thread
 
@@ -197,6 +214,54 @@ class MessageStore:
         This is primarily for testing to ensure data persistence before querying.
         """
         self._worker.flush()
+
+    async def _hydrate_ram(self) -> None:
+        """Hydrate RAM cache from the in-memory database.
+
+        This routine runs as a non-blocking background task.
+        """
+
+        def _fetch_all() -> list[Any]:
+            return self._cx.execute(
+                "SELECT * FROM messages ORDER BY dtm ASC"
+            ).fetchall()
+
+        try:
+            rows = await asyncio.to_thread(_fetch_all)
+        except sqlite3.Error as err:
+            _LOGGER.error("Failed to fetch messages for hydration: %s", err)
+            return
+
+        has_lock = getattr(self, "_lock", None)
+        if has_lock:
+            await self._lock.acquire()
+
+        try:
+            for row in rows:
+                dtm_val = row[0]
+                verb = row[1]
+                src = row[2]
+                dst = row[3]
+                code = row[4]
+                hdr = row[6]
+                payload_blob = row[8]
+                dtm_str = cast(DtmStrT, dtm_val.isoformat(timespec="microseconds"))
+
+                pkt_line = f"... {verb} --- {src} {dst} --:------ {code} 001 00"
+                try:
+                    pkt = Packet(dtm_val, pkt_line)
+                    msg = Message._from_pkt(pkt)
+                    msg._payload = orjson.loads(payload_blob)
+
+                    self._msgs[dtm_str] = msg
+                    self._msgz_[hdr] = msg
+                except Exception as err:
+                    _LOGGER.debug("Failed to reconstruct message for %s: %s", hdr, err)
+        finally:
+            if has_lock:
+                self._lock.release()
+
+        _LOGGER.info("Hydrated %d messages into RAM cache", len(rows))
 
     async def _housekeeping_loop(self) -> None:
         """Periodically remove stale messages from the index,
@@ -223,6 +288,14 @@ class MessageStore:
                     (k, v) for k, v in self._msgs.items() if k >= dtm_iso
                 )
 
+                valid_dtms = set(self._msgs.keys())
+                self._msgz_ = {
+                    hdr: m
+                    for hdr, m in self._msgz_.items()
+                    if cast(DtmStrT, m.dtm.isoformat(timespec="microseconds"))
+                    in valid_dtms
+                }
+
             except Exception as err:
                 _LOGGER.warning("MessageStore housekeeping error: %s", err)
             else:
@@ -235,9 +308,11 @@ class MessageStore:
 
         while True:
             self._last_housekeeping = dt.now()
-            await asyncio.sleep(3600)
+            await asyncio.sleep(900)
             _LOGGER.info("Starting next MessageStore housekeeping")
             await housekeeping(self._last_housekeeping)
+
+            self._worker.submit_snapshot()
 
     def add(self, msg: Message) -> Message | None:
         """
@@ -269,6 +344,8 @@ class MessageStore:
             # _msgs dict requires a timestamp reformat
             # add msg to self._msgs dict
             self._msgs[dtm_str] = msg
+            if msg._pkt._hdr is not None:
+                self._msgz_[msg._pkt._hdr] = msg
 
         finally:
             pass  # self._lock.release()
@@ -329,6 +406,7 @@ class MessageStore:
             Packet(_now, f"... {verb} --- {src} --:------ {src} {code} 005 0000000000")
         )
         self._msgs[dtm] = msg
+        self._msgz_[hdr] = msg
 
     def _insert_into(self, msg: Message) -> Message | None:
         """
@@ -401,7 +479,9 @@ class MessageStore:
             if msgs is not None:
                 for m in msgs:
                     dtm = cast(DtmStrT, m.dtm.isoformat(timespec="microseconds"))
-                    self._msgs.pop(dtm)
+                    self._msgs.pop(dtm, None)
+                    if m._pkt._hdr is not None:
+                        self._msgz_.pop(m._pkt._hdr, None)
 
         finally:
             pass  # self._lock.release()
@@ -616,6 +696,7 @@ class MessageStore:
 
         await asyncio.to_thread(_clear_db)
         self._msgs.clear()
+        self._msgz_.clear()
 
 
 # Alias for backwards compatibility during Phase 2 migration

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -131,6 +131,8 @@ class GatewayConfig:
     :type evofw_flag: str | None
     :param gateway_timeout: Custom timeout threshold in minutes for gateway availability.
     :type gateway_timeout: int | None
+    :param database_path: Target disk path for the persistent SQLite MessageStore DB.
+    :type database_path: str | None
     """
 
     disable_discovery: bool = False
@@ -158,6 +160,7 @@ class GatewayConfig:
     evofw_flag: str | None = None
 
     gateway_timeout: int | None = None
+    database_path: str | None = "ramses.db"
 
 
 class Gateway(GatewayInterface):
@@ -419,7 +422,9 @@ class Gateway(GatewayInterface):
         :returns: None
         :rtype: None
         """
-        self._msg_db = MessageStore()  # start the index
+        self._msg_db = MessageStore(
+            disk_path=self.config.database_path
+        )  # start the index
 
     async def stop(self) -> None:
         """Stop the Gateway and tidy up.

--- a/src/ramses_rf/storage.py
+++ b/src/ramses_rf/storage.py
@@ -7,6 +7,7 @@ import logging
 import queue
 import sqlite3
 import threading
+from pathlib import Path
 from typing import Any, NamedTuple
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,15 +33,22 @@ class PruneRequest(NamedTuple):
     dtm_limit: Any
 
 
-QueueItem = PacketLogEntry | PruneRequest | tuple[str, Any] | None
+class SnapshotRequest(NamedTuple):
+    """Represents a request to snapshot the in-memory DB to disk."""
+
+    pass
+
+
+QueueItem = PacketLogEntry | PruneRequest | SnapshotRequest | tuple[str, Any] | None
 
 
 class StorageWorker:
     """A background worker thread to handle blocking storage I/O asynchronously."""
 
-    def __init__(self, db_path: str = ":memory:") -> None:
+    def __init__(self, db_path: str = ":memory:", disk_path: str | None = None) -> None:
         """Initialize the storage worker thread."""
         self._db_path = db_path
+        self._disk_path = disk_path
         self._queue: queue.SimpleQueue[QueueItem] = queue.SimpleQueue()
         self._ready_event = threading.Event()
 
@@ -63,6 +71,10 @@ class StorageWorker:
     def submit_prune(self, dtm_limit: Any) -> None:
         """Submit a prune request for SQL deletion (Non-blocking)."""
         self._queue.put(PruneRequest(dtm_limit))
+
+    def submit_snapshot(self) -> None:
+        """Submit a disk snapshot request (Non-blocking)."""
+        self._queue.put(SnapshotRequest())
 
     def flush(self, timeout: float = 10.0) -> None:
         """Block until all currently pending tasks are processed."""
@@ -127,6 +139,22 @@ class StorageWorker:
                 with contextlib.suppress(sqlite3.Error):
                     conn.execute("PRAGMA read_uncommitted = true")
 
+            # Phase 2.4: Startup Hydration
+            if self._disk_path and (
+                self._db_path == ":memory:" or "mode=memory" in self._db_path
+            ):
+                disk_path_obj = Path(self._disk_path)
+                if disk_path_obj.exists():
+                    try:
+                        disk_conn = sqlite3.connect(self._disk_path)
+                        disk_conn.backup(conn)
+                        disk_conn.close()
+                        _LOGGER.info(
+                            "Hydrated memory DB from disk: %s", self._disk_path
+                        )
+                    except sqlite3.Error as err:
+                        _LOGGER.error("Failed to hydrate from disk: %s", err)
+
             self._init_db(conn)
             self._ready_event.set()  # Signal that tables exist
         except sqlite3.Error as err:
@@ -185,6 +213,16 @@ class StorageWorker:
                         _LOGGER.debug("Pruned records older than %s", item.dtm_limit)
                     except sqlite3.Error as err:
                         _LOGGER.error("SQL Prune Failed: %s", err)
+
+                elif isinstance(item, SnapshotRequest):
+                    if self._disk_path:
+                        try:
+                            disk_conn = sqlite3.connect(self._disk_path)
+                            conn.backup(disk_conn)
+                            disk_conn.close()
+                            _LOGGER.debug("Snapshot written to %s", self._disk_path)
+                        except sqlite3.Error as err:
+                            _LOGGER.error("SQL Snapshot Failed: %s", err)
 
                 elif isinstance(item, tuple) and item[0] == "MARKER":
                     # Flush requested

--- a/tests/tests/test_storage.py
+++ b/tests/tests/test_storage.py
@@ -45,10 +45,11 @@ async def test_storage_worker_persistence(tmp_path: Path) -> None:
 
     # 1. Setup: Use pytest's temp path for the DB file
     db_path = tmp_path / "test_async_persistence.sqlite"
+    disk_path = tmp_path / "ramses.db"
 
     # 2. Initialize MessageIndex (starts the background StorageWorker)
     # We pass the path as a string, as expected by the class
-    idx = MessageIndex(db_path=str(db_path))
+    idx = MessageIndex(db_path=str(db_path), disk_path=str(disk_path))
 
     # Allow a tiny moment for the worker thread to initialize tables
     # using a deterministic polling loop instead of a flaky hardcoded sleep
@@ -134,5 +135,20 @@ async def test_storage_worker_persistence(tmp_path: Path) -> None:
         f"after waiting {wait_time}s."
     )
 
-    # 6. Cleanup
+    # Trigger and wait for disk snapshot explicitly
+    idx._worker.submit_snapshot()
+    idx.flush()
+
+    assert disk_path.exists(), "Snapshot file was not created on disk!"
+
+    # 6. Hydration Verification
+    idx2 = MessageIndex(db_path=":memory:", disk_path=str(disk_path))
+    await asyncio.sleep(0.5)
+
+    assert len(idx2.msgs) == MSG_COUNT, (
+        f"Hydration failed! Expected {MSG_COUNT} cached items, got {len(idx2.msgs)}."
+    )
+
+    # 7. Cleanup
     idx.stop()
+    idx2.stop()

--- a/tests/tests/test_systems.py
+++ b/tests/tests/test_systems.py
@@ -6,10 +6,12 @@ Includes gwy dicts (schema, traits, params, status).
 
 import asyncio
 from pathlib import Path, PurePath
+from unittest.mock import patch
 
 import pytest
 
 from ramses_rf import Gateway
+from ramses_rf.database import MessageStore
 from ramses_tx import exceptions as exc
 from ramses_tx.message import Message
 from ramses_tx.packet import Packet
@@ -34,8 +36,9 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
 
 
 def test_payload_from_log_file(dir_name: Path) -> None:
-    """Assert that each message payload is as expected (different to other tests)."""
-    # RP --- 02:044328 18:200214 --:------ 2309 003 0007D0       # {'ufh_idx': '00', 'setpoint': 20.0}
+    """Assert that each message payload is as expected."""
+    # RP --- 02:044328 18:200214 --:------ 2309 003 0007D0
+    # {'ufh_idx': '00', 'setpoint': 20.0}
 
     def proc_log_line(log_line: str) -> None:
         if "#" not in log_line:
@@ -80,7 +83,14 @@ async def test_restore_from_log_file_sql(dir_name: Path) -> None:
     """Compare the system built from a log file with the expected results."""
 
     expected: dict = load_expected_results(dir_name) or {}
-    gwy: Gateway = await load_test_gwy(dir_name, _sqlite_index=True)
+
+    with patch(
+        "ramses_rf.gateway.MessageStore",
+        side_effect=lambda *args, **kwargs: MessageStore(
+            *args, **{**kwargs, "disk_path": None}
+        ),
+    ):
+        gwy: Gateway = await load_test_gwy(dir_name, _sqlite_index=True)
 
     await assert_expected_set(gwy, expected)
 
@@ -88,7 +98,7 @@ async def test_restore_from_log_file_sql(dir_name: Path) -> None:
 
 
 async def test_shuffle_from_log_file(dir_name: Path) -> None:
-    """Compare the system built from a shuffled log file with the expected results."""
+    """Compare the system built from a shuffled log file with results."""
 
     expected: dict = load_expected_results(dir_name) or {}
     gwy: Gateway = await load_test_gwy(dir_name)
@@ -104,10 +114,17 @@ async def test_shuffle_from_log_file(dir_name: Path) -> None:
 
 
 async def test_shuffle_from_log_file_sql(dir_name: Path) -> None:
-    """Compare the system built from a shuffled log file with the expected results."""
+    """Compare the system built from a shuffled log file with results."""
 
     expected: dict = load_expected_results(dir_name) or {}
-    gwy: Gateway = await load_test_gwy(dir_name, _sqlite_index=True)
+
+    with patch(
+        "ramses_rf.gateway.MessageStore",
+        side_effect=lambda *args, **kwargs: MessageStore(
+            *args, **{**kwargs, "disk_path": None}
+        ),
+    ):
+        gwy: Gateway = await load_test_gwy(dir_name, _sqlite_index=True)
 
     schema, packets = await gwy.get_state(include_expired=True)
     packets = shuffle_dict(packets)
@@ -123,7 +140,7 @@ async def test_shuffle_from_log_file_sql(dir_name: Path) -> None:
 
 
 async def test_fuzz_from_log_file(dir_name: Path) -> None:
-    """Compare the system built from a fuzzed log file with the expected results."""
+    """Compare the system built from a fuzzed log file with results."""
 
     expected: dict = load_expected_results(dir_name) or {}
     gwy: Gateway = await load_test_gwy(dir_name)
@@ -137,8 +154,8 @@ async def test_fuzz_from_log_file(dir_name: Path) -> None:
     schema, packets = await gwy.get_state(include_expired=True)
 
     # This loop is non-deterministic, but should be stable (fails rarely)
-    # The logic is that the system state should be consistent regardless of the order
-    # of the packets (within reason)
+    # The logic is that the system state should be consistent regardless
+    # of the order of the packets (within reason)
     for _ in range(3):
         packets = shuffle_dict(packets)
         await gwy._restore_cached_packets(packets)
@@ -154,10 +171,17 @@ async def test_fuzz_from_log_file(dir_name: Path) -> None:
 
 
 async def test_fuzz_from_log_file_sql(dir_name: Path) -> None:
-    """Compare the system built from a fuzzed log file with the expected results, using SQLite msg_db."""
+    """Compare system built from fuzzed log file, using SQLite msg_db."""
 
     expected: dict = load_expected_results(dir_name) or {}
-    gwy: Gateway = await load_test_gwy(dir_name, _sqlite_index=True)
+
+    with patch(
+        "ramses_rf.gateway.MessageStore",
+        side_effect=lambda *args, **kwargs: MessageStore(
+            *args, **{**kwargs, "disk_path": None}
+        ),
+    ):
+        gwy: Gateway = await load_test_gwy(dir_name, _sqlite_index=True)
 
     # for dev in gwy.device_registry.devices:
     #     if dev._msgs:
@@ -168,8 +192,8 @@ async def test_fuzz_from_log_file_sql(dir_name: Path) -> None:
     schema, packets = await gwy.get_state(include_expired=True)
 
     # This loop is non-deterministic, but should be stable (fails rarely)
-    # The logic is that the system state should be consistent regardless of the order
-    # of the packets (within reason)
+    # The logic is that the system state should be consistent regardless
+    # of the order of the packets (within reason)
     for _ in range(3):
         packets = shuffle_dict(packets)
         await gwy._restore_cached_packets(packets)

--- a/tests/tests_rf/test_database.py
+++ b/tests/tests_rf/test_database.py
@@ -20,7 +20,10 @@ class TestMessageIndex:
     _NOW = dt.now().replace(microsecond=0)
 
     msg1: Message = Message._from_pkt(
-        Packet(_NOW, "...  I --- 32:166025 --:------ 32:166025 1298 003 007FFF")
+        Packet(
+            _NOW,
+            "...  I --- 32:166025 --:------ 32:166025 1298 003 007FFF",
+        )
     )
     msg2: Message = Message._from_pkt(
         Packet(
@@ -31,13 +34,16 @@ class TestMessageIndex:
     msg3: Message = Message._from_pkt(
         Packet(
             _NOW + td(seconds=20),
-            "060  I --- 01:087939 --:------ 01:087939 2309 021 0007D00106400201F40301F40401F40501F40601F4",
+            "060  I --- 01:087939 --:------ 01:087939 2309 021 "
+            "0007D00106400201F40301F40401F40501F40601F4",
         )
     )
     msg4: Message = Message._from_pkt(
         Packet(
             _NOW + td(seconds=30),
-            "060  I --- 32:166025 --:------ 32:166025 31DA 030 00EF00019E00EF06E17FFF08020766BE09001F0000000000008500850000",
+            "060  I --- 32:166025 --:------ 32:166025 31DA 030 "
+            "00EF00019E00EF06E17FFF08020766BE09001F000000000000"
+            "8500850000",
         )
     )
     msg5: Message = Message._from_pkt(
@@ -63,7 +69,7 @@ class TestMessageIndex:
 
     async def test_add_msg(self) -> None:
         """Add a message to the MessageIndex."""
-        msg_db = MessageIndex()
+        msg_db = MessageIndex(disk_path=None)
         ret: Message | None
 
         # add a message
@@ -76,18 +82,18 @@ class TestMessageIndex:
         assert ret is None
         assert await msg_db.contains(code="1298")
         assert len(await msg_db.all()) == 1
-        assert (
-            str((await msg_db.all())[0])
-            == "||  32:166025 |            |  I | co2_level        |      || {'co2_level': None}"
+        assert str((await msg_db.all())[0]) == (
+            "||  32:166025 |            |  I | co2_level        "
+            "|      || {'co2_level': None}"
         )
 
         # add another message with same code
         ret = msg_db.add(self.msg2)  # replaced message
 
         assert ret is None  # Async add returns None, not the old msg
-        # assert (
-        #     str(ret)
-        #     == "||  32:166025 |            |  I | co2_level        |      || {'co2_level': None}"
+        # assert str(ret) == (
+        #     "||  32:166025 |            |  I | co2_level        "
+        #     "|      || {'co2_level': None}"
         # )
         assert len(await msg_db.all()) == 1
 
@@ -111,7 +117,7 @@ class TestMessageIndex:
 
     async def test_qry_msg(self) -> None:
         """Query the MessageIndex."""
-        msg_db = MessageIndex()
+        msg_db = MessageIndex(disk_path=None)
         msg_db.add(self.msg1)
         msg_db.add(self.msg2)
         msg_db.add(self.msg3)
@@ -167,7 +173,11 @@ class TestMessageIndex:
             ("1298", "|co2_level|"),
             (
                 "31DA",
-                "|hvac_id|exhaust_fan_speed|fan_info|_unknown_fan_info_flags|co2_level|indoor_humidity|exhaust_temp|indoor_temp|outdoor_temp|speed_capabilities|bypass_position|supply_fan_speed|remaining_mins|post_heat|pre_heat|supply_flow_fault|exhaust_flow_fault|_extra|",
+                "|hvac_id|exhaust_fan_speed|fan_info|_unknown_fan_info_flags"
+                "|co2_level|indoor_humidity|exhaust_temp|indoor_temp"
+                "|outdoor_temp|speed_capabilities|bypass_position"
+                "|supply_fan_speed|remaining_mins|post_heat|pre_heat"
+                "|supply_flow_fault|exhaust_flow_fault|_extra|",
             ),
         ]
         assert await msg_db.contains(plk="|co2_level|"), "payload keys missing"
@@ -220,28 +230,30 @@ class TestMessageIndex:
 
         # run maintenance loop
         # assert len(await msg_db.all()) == 5
-        # await msg_db._housekeeping_loop.housekeeping(self._NOW, _cutoff=dt(second=10))
+        # await msg_db._housekeeping_loop.housekeeping(
+        #     self._NOW, _cutoff=dt(second=10)
+        # )
         # assert len(await msg_db.all()) == 5
 
         msg_db.stop()  # close sqlite3 connection
 
     async def test_fat_database_payload_serialization(self) -> None:
         """Phase 2.1: Verify orjson payload serialization directly in SQLite."""
-        msg_db = MessageIndex(maintain=False)
+        msg_db = MessageIndex(maintain=False, disk_path=None)
         msg_db.add(self.msg4)  # Contains a highly complex dictionary payload
 
         # Force the StorageWorker to complete the SQL insert before we read it
         msg_db.flush()
 
-        # Query the raw blob directly out of the database, bypassing the RAM cache
+        # Query the raw blob directly out of the database, bypassing RAM cache
         sql = "SELECT payload_blob FROM messages WHERE code = '31DA'"
         res = await msg_db.qry_field(sql, ())
         assert len(res) == 1
 
-        # Deserialize using orjson and assert it perfectly matches the parsed payload
+        # Deserialize using orjson and assert it perfectly matches the payload
         raw_bytes = res[0][0]
         decoded_payload = orjson.loads(raw_bytes)
 
-        assert decoded_payload == self.msg4.payload, "orjson serialization failed"
+        assert decoded_payload == self.msg4.payload, "orjson payload failed"
 
         msg_db.stop()


### PR DESCRIPTION
### The Problem:

Issue #530 outlined the need to move away from purely volatile in-memory message storage. While earlier phases added a fast dictionary cache and a background SQLite worker, the system lacked physical persistence across reboots. All packet history, schemas, and device states were lost whenever Home Assistant restarted. _(after implimenting phase 2.1 and 2.3 - this does not take account of the existing setup, but refers to the state of the proposal in issue #530)_

### Consequences:

Without persistence, every restart of Home Assistant results in a completely amnesiac `ramses_rf` gateway. Devices have to be re-discovered, schemas rebuilt from scratch over the air, and historical packet logs are permanently destroyed. This leads to degraded system performance, delayed availability, and a poor user experience.

### The Fix:

Implemented Phase 2.4 to introduce background disk snapshotting and startup hydration. The RAM-first cache is now periodically backed up to a physical file (`ramses.db`) and seamlessly reloaded into memory upon system boot, ensuring complete continuity of the gateway state.

### Technical Implementation:
- Updated `StorageWorker` in `storage.py` to accept a `disk_path`. Uses SQLite's native `backup()` API to asynchronously dump the in-memory DB to disk when a `SnapshotRequest` is queued.
- During initialization, if `disk_path` exists, `StorageWorker` reverse-hydrates the in-memory SQLite DB from the disk file natively.
- Added a `_hydrate_ram()` async background task in `database.py` to safely reconstruct the `_msgs` and `_msgz_` fast-access dictionaries from the newly loaded SQLite backend.
- Added a final snapshot and queue flush hook in `MessageStore.stop()` to guarantee 100% data retention on graceful shutdowns.
- Modified `GatewayConfig` in `gateway.py` to include a configurable `database_path` (defaulting to `ramses.db`), allowing `ramses_cc` to eventually control file placement (e.g., inside `.storage/`).
- Updated `.gitignore` to prevent committing local `ramses.db` files.

### Testing Performed:
- Extended `test_storage.py` to verify full disk-hydration lifecycles (writing 500 messages, snapshotting, and proving instant recovery in a fresh `MessageStore`).
- Mocked `disk_path=None` across `test_systems.py` and `test_database.py` using `unittest.mock.patch` to ensure `pytest-xdist` parallel runners do not cross-contaminate a shared physical disk file.
- Passed strict Mypy checks (`mypy --strict`) across all 133 files.
- Ran and passed the full `ramses_rf` Pytest suite (833 tests).
- Ran and passed the full `ramses_cc` downstream integration Pytest suite to confirm zero public API breakages.

### Risks of NOT Implementing:

Leaving the code as-is keeps `ramses_rf` entirely volatile. Users will continue to experience data loss and slow schema/device rebuilds on every Home Assistant restart, directly violating the core acceptance criteria for Issue #530.

### Risks of Implementing:

Heavy disk I/O could potentially block the HA event loop if not handled correctly. Parallel tests running via `xdist` could fail due to shared file locking if the disk path isn't strictly mocked out during CI workflows.

### Mitigation Steps:
- All disk I/O (SQLite `backup()`) is strictly isolated to the background `StorageWorker` thread, entirely decoupled from the asyncio event loop.
- Database writes are batched, and automated snapshots run on a 15-minute timer rather than continuously.
- Applied `disk_path=None` via context managers in testing to guarantee test isolation and prevent file lock contention in CI environments.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.  