### PR TITLE
Chore: added message to broadened exception handler

### DIFF
--- a/src/ramses_tx/protocol/fsm.py
+++ b/src/ramses_tx/protocol/fsm.py
@@ -374,6 +374,10 @@ class ProtocolContext(StateMachineInterface):
 
             try:
                 await self._send_fnc(cmd)
+            # NOTE this exception has been left deliberatley broad to
+            # allow any unexpected failures to correctly transition the
+            # FSM back to the IsInIdle state and injects the exception
+            # into the pending future to unblock the queue
             except Exception as err:
                 self.set_state(IsInIdle, exception=err)
 


### PR DESCRIPTION
- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: not used - I did this all by myself!

**PR Summary**
Added a note, as requested by the maintainer, about the reason why the exception handler has been broadened in the `send_fnc_wrapper` task inside `_send_cmd` from `except TransportError as err:` to `except Exception as err:`. This ensures any unexpected failure correctly transitions the FSM back to the `IsInIdle` state and injects the exception into the pending future to unblock the queue.