### PR TITLE
Log outgoing cmd

### DIFF
--- a/src/ramses_tx/logger.py
+++ b/src/ramses_tx/logger.py
@@ -170,11 +170,14 @@ class StdOutFilter(logging.Filter):  # record.levelno < logging.WARNING
 
 
 class BlockMqttFilter(logging.Filter):
-    """Block mqtt traffic"""
+    """Block mqtt and Sent traffic"""
 
     def filter(self, record: logging.LogRecord) -> bool:
         """Return True if the record is to be processed."""
-        return not record.getMessage().startswith("mq Rx: ")
+        return not (  # ignored if Config lag_all is True
+            record.getMessage().startswith("mq Rx: ")
+            or record.getMessage().startswith("Sent: ")
+        )
 
 
 class TimedRotatingFileHandler(_TimedRotatingFileHandler):
@@ -334,7 +337,7 @@ def set_pkt_logging(
 
         handler = logging.StreamHandler(stream=sys.stderr)
         handler.setFormatter(console_fmt)
-        handler.setLevel(logging.WARNING)  # musr be .WARNING or less
+        handler.setLevel(logging.WARNING)  # must be .WARNING or less
         handler.addFilter(StdErrFilter())  # record.levelno >= .WARNING
         handlers.append(handler)
 

--- a/src/ramses_tx/protocol/base.py
+++ b/src/ramses_tx/protocol/base.py
@@ -301,14 +301,6 @@ class _BaseProtocol(ProtocolInterface, asyncio.Protocol):
             _LOGGER.warning(f"{cmd} < num_repeats set to 0, as wait_for_reply is True")
             num_repeats = 0  # the lesser crime over wait_for_reply=False
 
-        # Log outgoing cmd
-        if _DBG_FORCE_LOG_PACKETS:
-            _LOGGER.warning(f"Sent: {cmd}")
-        elif _LOGGER.getEffectiveLevel() > logging.DEBUG:
-            _LOGGER.info(f"Sent: {cmd}")
-        else:
-            _LOGGER.debug(f"Sent: {cmd}")
-
         pkt = await self._send_cmd(  # may: raise ProtocolError/ProtocolSendFailed
             cmd,
             gap_duration=gap_duration,

--- a/src/ramses_tx/protocol/base.py
+++ b/src/ramses_tx/protocol/base.py
@@ -2,7 +2,7 @@
 """RAMSES RF - RAMSES-II compatible packet protocol base classes.
 
 This module provides the foundational protocol layers, handling transport
-binding, basic message dispatching, regex-based payload manipulation,
+binding, basic message dispatching, regex-based payload manipulation, logging
 and device ID filtering mechanisms.
 """
 
@@ -300,6 +300,14 @@ class _BaseProtocol(ProtocolInterface, asyncio.Protocol):
         if qos and qos.wait_for_reply and num_repeats:
             _LOGGER.warning(f"{cmd} < num_repeats set to 0, as wait_for_reply is True")
             num_repeats = 0  # the lesser crime over wait_for_reply=False
+
+        # Log outgoing cmd
+        if _DBG_FORCE_LOG_PACKETS:
+            _LOGGER.warning(f"Sent: {cmd}")
+        elif _LOGGER.getEffectiveLevel() > logging.DEBUG:
+            _LOGGER.info(f"Sent: {cmd}")
+        else:
+            _LOGGER.debug(f"Sent: {cmd}")
 
         pkt = await self._send_cmd(  # may: raise ProtocolError/ProtocolSendFailed
             cmd,

--- a/src/ramses_tx/transport/mqtt.py
+++ b/src/ramses_tx/transport/mqtt.py
@@ -448,8 +448,8 @@ class MqttTransport(_FullTransport, _MqttTransportAbstractor):
 
         if _DBG_FORCE_FRAME_LOGGING:
             _LOGGER.warning("Tx: %s", data)
-        elif _LOGGER.getEffectiveLevel() == logging.INFO:
-            _LOGGER.info("Tx: %s", data)
+        elif _LOGGER.getEffectiveLevel() == logging.INFO or self._log_all:
+            _LOGGER.info("mq Tx: %s", data)
 
         try:
             self._publish(data)

--- a/src/ramses_tx/transport/port.py
+++ b/src/ramses_tx/transport/port.py
@@ -194,6 +194,7 @@ class PortTransport(_FullTransport, _PortTransportAbstractor):  # type: ignore[m
 
         self._tx_bits_in_bucket = None
         self._tx_last_time_bit_added = None
+        self._log_all = config.log_all
 
         self._init_fut = self._loop.create_future()
 
@@ -323,10 +324,10 @@ class PortTransport(_FullTransport, _PortTransportAbstractor):  # type: ignore[m
         """Write some data bytes to the underlying transport."""
         data = bytes(frame, "ascii") + b"\r\n"
 
-        log_msg = f"Serial transport transmitting frame: {frame}"
+        log_msg = f"Serial transport Tx frame: {frame}"
         if _DBG_FORCE_FRAME_LOGGING:
             _LOGGER.warning(log_msg)
-        elif _LOGGER.getEffectiveLevel() > logging.DEBUG:
+        elif _LOGGER.getEffectiveLevel() > logging.DEBUG or self._log_all:
             _LOGGER.info(log_msg)
         else:
             _LOGGER.debug(log_msg)


### PR DESCRIPTION
**PR Summary**
Should only log outgoing send_cmd If log_all is set to True
Comment spelling fix

This PR fixes issue #607

- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: not used