### PR TITLE
Refactor: Priority 2 Configuration Consolidation and SRP Extraction

### DIFF
--- a/src/ramses_cli/client.py
+++ b/src/ramses_cli/client.py
@@ -27,6 +27,7 @@ from ramses_rf.schemas import (
     SZ_REDUCE_PROCESSING,
 )
 from ramses_tx import is_valid_dev_id
+from ramses_tx.config import EngineConfig
 from ramses_tx.logger import CONSOLE_COLS, DEFAULT_DATEFMT, DEFAULT_FMT
 from ramses_tx.schemas import (
     SZ_DISABLE_QOS,
@@ -662,7 +663,15 @@ async def async_main(command: str, lib_kwargs: dict[str, Any], **kwargs: Any) ->
     if lib_kwargs:
         gwy_config_kwargs["schema"] = lib_kwargs
 
-    gwy_config = GatewayConfig(**gwy_config_kwargs)
+    # Separate the kwargs for the engine vs the gateway
+    engine_kwargs = {
+        k: v for k, v in gwy_config_kwargs.items() if hasattr(EngineConfig, k)
+    }
+    gwy_kwargs = {
+        k: v for k, v in gwy_config_kwargs.items() if hasattr(GatewayConfig, k)
+    }
+
+    gwy_config = GatewayConfig(engine=EngineConfig(**engine_kwargs), **gwy_kwargs)
 
     # Instantiate Gateway
     gwy = Gateway(

--- a/src/ramses_rf/device/heat.py
+++ b/src/ramses_rf/device/heat.py
@@ -109,7 +109,7 @@ if TYPE_CHECKING:
     from ramses_rf.models import DeviceTraits
     from ramses_rf.system import Evohome, Zone
     from ramses_tx import Address, Message, Packet
-    from ramses_tx.gateway import ApplicationMessage
+    from ramses_tx.application_message import ApplicationMessage
     from ramses_tx.opentherm import OtDataId
 
 

--- a/src/ramses_rf/entity_state.py
+++ b/src/ramses_rf/entity_state.py
@@ -29,7 +29,7 @@ from . import exceptions as exc
 from .const import SZ_DOMAIN_ID, SZ_NAME, SZ_ZONE_IDX
 
 if TYPE_CHECKING:
-    from ramses_tx.gateway import ApplicationMessage
+    from ramses_tx.application_message import ApplicationMessage
     from ramses_tx.typing import HeaderT
 
     from .interfaces import DeviceInterface, GatewayInterface

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 
 # TODO:
-# - sort out gwy.config...
 # - sort out reduced processing
-
 
 """RAMSES RF -the gateway (i.e. HGI80 / evofw3, not RFG100)."""
 
@@ -29,6 +27,7 @@ from ramses_tx import (
     set_pkt_logging_config,
 )
 from ramses_tx.application_message import ApplicationMessage
+from ramses_tx.config import EngineConfig
 from ramses_tx.const import (
     DEFAULT_GAP_DURATION,
     DEFAULT_MAX_RETRIES,
@@ -39,7 +38,6 @@ from ramses_tx.const import (
 )
 from ramses_tx.logger import flush_packet_log
 from ramses_tx.schemas import SZ_BLOCK_LIST, SZ_ENFORCE_KNOWN_LIST, SZ_KNOWN_LIST
-from ramses_tx.typing import PktLogConfigT, PortConfigT
 
 from .const import DONT_CREATE_MESSAGES, HIGH_VOLUME_STATUS_CODES
 
@@ -92,79 +90,39 @@ class GatewayConfig:
     :type reduce_processing: int
     :param max_zones: Maximum number of zones allowed, defaults to 12.
     :type max_zones: int
-    :param use_regex: Regex patterns for matching devices, defaults to
-        empty dict.
-    :type use_regex: dict[str, dict[str, str]]
-    :param use_aliases: Mapping of aliases for device IDs, defaults to
-        empty dict.
+    :param use_aliases: Mapping of aliases for device IDs.
     :type use_aliases: dict[str, str]
-    :param enforce_strict_handling: Enforce strict handling of packets,
-        defaults to False.
+    :param enforce_strict_handling: Enforce strict handling of packets.
     :type enforce_strict_handling: bool
     :param use_native_ot: Preference for using native OpenTherm.
     :type use_native_ot: Literal["always", "prefer", "avoid", "never"] | None
-    :param app_context: Optional application context object.
-    :type app_context: Any | None
     :param schema: Dictionary representing the schema.
     :type schema: dict[str, Any]
-    :param input_file: Path to a packet log file for playback/parsing.
-    :type input_file: str | None
-    :param port_config: Configuration dictionary for the serial port.
-    :type port_config: PortConfigT | None
-    :param packet_log: Configuration for packet logging.
-    :type packet_log: PktLogConfigT | None
-    :param block_list: A list of device IDs to block/ignore.
-    :type block_list: DeviceListT | None
-    :param known_list: A list of known device IDs and their traits.
-    :type known_list: DeviceListT | None
-    :param hgi_id: The Device ID to use for the HGI (gateway), overriding
-        defaults.
-    :type hgi_id: str | None
     :param debug_mode: If True, set the logger to debug mode.
     :type debug_mode: bool
-    :param disable_sending: Prevent sending any packets from the protocol.
-    :type disable_sending: bool
-    :param disable_qos: Disable the Quality of Service mechanism.
-    :type disable_qos: bool | None
-    :param enforce_known_list: Enforce that only known devices can be
-        created.
-    :type enforce_known_list: bool
-    :param evofw_flag: Specific flag for evofw3 usage.
-    :type evofw_flag: str | None
-    :param gateway_timeout: Custom timeout threshold in minutes for
-        gateway availability.
+    :param gateway_timeout: Custom timeout threshold in minutes.
     :type gateway_timeout: int | None
-    :param database_path: Target disk path for the persistent SQLite
-        MessageStore DB.
+    :param database_path: Target disk path for the SQLite DB.
     :type database_path: str | None
+    :param engine: Typed configuration object for the Transport layer.
+    :type engine: EngineConfig
     """
 
     disable_discovery: bool = False
     enable_eavesdrop: bool = False
     reduce_processing: int = 0
     max_zones: int = 12
-    use_regex: dict[str, dict[str, str]] = field(default_factory=dict)
     use_aliases: dict[str, str] = field(default_factory=dict)
     enforce_strict_handling: bool = False
     use_native_ot: Literal["always", "prefer", "avoid", "never"] | None = None
-    app_context: Any | None = None
 
-    # Legacy configuration parameters absorbed into the config DTO
     schema: dict[str, Any] = field(default_factory=dict)
-    input_file: str | None = None
-    port_config: PortConfigT | None = None
-    packet_log: PktLogConfigT | None = None
-    block_list: DeviceListT | None = None
-    known_list: DeviceListT | None = None
-    hgi_id: str | None = None
     debug_mode: bool = False
-    disable_sending: bool = False
-    disable_qos: bool | None = None
-    enforce_known_list: bool = False
-    evofw_flag: str | None = None
-
     gateway_timeout: int | None = None
     database_path: str | None = "ramses.db"
+
+    # Transport layer configuration encapsulated perfectly
+    engine: EngineConfig = field(default_factory=EngineConfig)
 
 
 class Gateway(GatewayInterface):
@@ -189,25 +147,25 @@ class Gateway(GatewayInterface):
         :param port_name: The serial port name (e.g., '/dev/ttyUSB0')
             or None if using a file.
         :type port_name: str | None
-        :param config: The typed configuration parameters for the
-            Gateway.
+        :param config: The typed configuration parameters.
         :type config: GatewayConfig | None, optional
-        :param loop: The asyncio event loop to use, defaults to None.
+        :param loop: The asyncio event loop to use.
         :type loop: asyncio.AbstractEventLoop | None, optional
-        :param transport_constructor: A factory for creating the
-            transport layer, defaults to None.
-        :type transport_constructor: Callable[...,
-            Awaitable[RamsesTransportT]] | None, optional
-        :param kwargs: Catch-all for legacy keyword arguments, managed
-            gracefully.
+        :param transport_constructor: A factory for creating transport.
+        :type transport_constructor: Callable | None, optional
+        :param kwargs: Catch-all for legacy keyword arguments.
         :type kwargs: Any
         """
+        self._gwy_config = config or GatewayConfig()
+
+        if port_name is not None:
+            self._gwy_config.engine.port_name = port_name
+
         if kwargs:
             keys = list(kwargs.keys())
-            _LOGGER.error(
-                "Gateway received unsupported kwargs: %s. These arguments "
-                "are ignored. Please migrate them to the GatewayConfig "
-                "object.",
+            _LOGGER.warning(
+                "Gateway received legacy kwargs: %s. Please migrate "
+                "ramses_cc to use the GatewayConfig object.",
                 keys,
             )
             warnings.warn(
@@ -218,27 +176,25 @@ class Gateway(GatewayInterface):
                 stacklevel=2,
             )
 
-        self._gwy_config = config or GatewayConfig()
+            for key, value in kwargs.items():
+                if hasattr(self._gwy_config.engine, key):
+                    setattr(self._gwy_config.engine, key, value)
+                elif hasattr(self._gwy_config, key):
+                    setattr(self._gwy_config, key, value)
+                else:
+                    _LOGGER.error(
+                        "Gateway received unsupported kwarg: %s. "
+                        "This argument is ignored.",
+                        key,
+                    )
 
         if self._gwy_config.debug_mode:
             _LOGGER.setLevel(logging.DEBUG)
 
         self._engine = Engine(
-            port_name,
-            input_file=self._gwy_config.input_file,
-            port_config=self._gwy_config.port_config,
-            packet_log=self._gwy_config.packet_log,
-            block_list=cast("Any", self._gwy_config.block_list),
-            known_list=cast("Any", self._gwy_config.known_list),
+            self._gwy_config.engine,
             loop=loop,
-            hgi_id=self._gwy_config.hgi_id,
             transport_constructor=transport_constructor,
-            disable_sending=self._gwy_config.disable_sending,
-            disable_qos=self._gwy_config.disable_qos,
-            enforce_known_list=self._gwy_config.enforce_known_list,
-            evofw_flag=self._gwy_config.evofw_flag,
-            use_regex=self._gwy_config.use_regex,
-            app_context=self._gwy_config.app_context,
         )
 
         # Force the engine's protocol to use Gateway's message handler
@@ -413,9 +369,12 @@ class Gateway(GatewayInterface):
             self, known_list=self._engine._include, **self._schema
         )  # create faked too
 
-        await self._engine.start()  # TODO: do this *after* restore cache
+        # Restored cache *before* starting the engine to ensure historic
+        # state is reconstructed correctly before live RF packets arrive.
         if cached_packets:
             await self._restore_cached_packets(cached_packets)
+
+        await self._engine.start()
 
         # reset discovery to original state
         self.config.disable_discovery = disable_discovery
@@ -505,30 +464,22 @@ class Gateway(GatewayInterface):
 
         _LOGGER.debug("Gateway: Resuming engine...")
 
-        # args_tuple = await super()._resume()
-        # self.config.disable_discovery, *args = (
-        #     args_tuple  # type: ignore[assignment]
-        # )
-
         self.config.disable_discovery, *args = (
             await self._engine._resume()  # type: ignore[assignment]
         )
 
-        return args
+        return tuple(args)
 
     async def get_state(
         self, include_expired: bool = False
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Return the current schema & state (may include expired packets).
 
-        :param include_expired: If True, include expired packets in the
-            state, defaults to False.
+        :param include_expired: If True, include expired packets.
         :type include_expired: bool, optional
-        :returns: A tuple containing the schema dictionary and the packet
-            log dictionary.
+        :returns: A tuple containing the schema dict and packet log dict.
         :rtype: tuple[dict[str, Any], dict[str, Any]]
         """
-
         await self._pause()
 
         def wanted_msg(msg: Message, include_expired: bool = False) -> bool:
@@ -690,9 +641,11 @@ class Gateway(GatewayInterface):
         return {
             "_gateway_id": self.hgi.id if self.hgi else None,
             SZ_MAIN_TCS: self.tcs.id if self.tcs else None,
-            SZ_CONFIG: {SZ_ENFORCE_KNOWN_LIST: self._engine._enforce_known_list},
+            SZ_CONFIG: {SZ_ENFORCE_KNOWN_LIST: self.config.engine.enforce_known_list},
             SZ_KNOWN_LIST: await self.device_registry.known_list(),
-            SZ_BLOCK_LIST: [{k: v} for k, v in self._engine._exclude.items()],
+            SZ_BLOCK_LIST: [
+                {k: v} for k, v in (self.config.engine.block_list or {}).items()
+            ],
             "_unwanted": sorted(self._engine._unwanted),
         }
 
@@ -880,7 +833,7 @@ class Gateway(GatewayInterface):
         )
 
         task = self._engine._loop.create_task(coro)
-        self.add_task(task)  # wait for these during stop()
+        self.add_task(task)
         return task
 
     async def async_send_cmd(
@@ -939,4 +892,4 @@ class Gateway(GatewayInterface):
             max_retries=max_retries,
             timeout=timeout,
             wait_for_reply=wait_for_reply,
-        )  # may: raise ProtocolError/ProtocolSendFailed
+        )

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -176,17 +176,23 @@ class Gateway(GatewayInterface):
                 stacklevel=2,
             )
 
-            for key, value in kwargs.items():
-                if hasattr(self._gwy_config.engine, key):
-                    setattr(self._gwy_config.engine, key, value)
-                elif hasattr(self._gwy_config, key):
-                    setattr(self._gwy_config, key, value)
-                else:
-                    _LOGGER.error(
-                        "Gateway received unsupported kwarg: %s. "
-                        "This argument is ignored.",
-                        key,
-                    )
+            def _apply_kwargs(cfg_dict: dict[str, Any]) -> None:
+                """Recursively unpack nested dictionaries to apply configs."""
+                for key, value in cfg_dict.items():
+                    if hasattr(self._gwy_config.engine, key):
+                        setattr(self._gwy_config.engine, key, value)
+                    elif hasattr(self._gwy_config, key):
+                        setattr(self._gwy_config, key, value)
+                    elif isinstance(value, dict):
+                        _apply_kwargs(value)
+                    else:
+                        _LOGGER.error(
+                            "Gateway received unsupported kwarg: %s. "
+                            "This argument is ignored.",
+                            key,
+                        )
+
+            _apply_kwargs(kwargs)
 
         if self._gwy_config.debug_mode:
             _LOGGER.setLevel(logging.DEBUG)

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -28,6 +28,7 @@ from ramses_tx import (
     protocol_factory,
     set_pkt_logging_config,
 )
+from ramses_tx.application_message import ApplicationMessage
 from ramses_tx.const import (
     DEFAULT_GAP_DURATION,
     DEFAULT_MAX_RETRIES,
@@ -36,7 +37,6 @@ from ramses_tx.const import (
     DEFAULT_WAIT_FOR_REPLY,
     SZ_ACTIVE_HGI,
 )
-from ramses_tx.gateway import ApplicationMessage
 from ramses_tx.logger import flush_packet_log
 from ramses_tx.schemas import SZ_BLOCK_LIST, SZ_ENFORCE_KNOWN_LIST, SZ_KNOWN_LIST
 from ramses_tx.typing import PktLogConfigT, PortConfigT

--- a/src/ramses_tx/__init__.py
+++ b/src/ramses_tx/__init__.py
@@ -18,6 +18,7 @@ from .address import (
     Address,
     is_valid_dev_id,
 )
+from .application_message import ApplicationMessage
 from .command import CODE_API_MAP, Command
 from .const import (
     DEV_ROLE_MAP,
@@ -42,7 +43,7 @@ from .const import (
     ZoneRole,
 )
 from .discovery import is_hgi80
-from .gateway import Engine
+from .engine import Engine
 from .logger import set_pkt_logging
 from .message import Message
 from .packet import PKT_LOGGER, Packet
@@ -144,6 +145,8 @@ __all__ = [
     #
     "is_valid_dev_id",
     "set_pkt_logging_config",
+    "ApplicationMessage",
+    "Engine",
 ]
 
 

--- a/src/ramses_tx/application_message.py
+++ b/src/ramses_tx/application_message.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+
+"""RAMSES RF - The Application Message module."""
+
+from __future__ import annotations
+
+from datetime import timedelta as td
+from typing import TYPE_CHECKING, Any
+
+from .const import RQ, Code
+from .message import Message
+
+if TYPE_CHECKING:
+    from .engine import Engine
+
+
+class ApplicationMessage(Message):
+    """Application-level message extended with gateway context and
+    expiration.
+    """
+
+    CANT_EXPIRE: float = -1.0  # sentinel value for fraction_expired
+    HAS_EXPIRED: float = 2.0  # fraction_expired >= HAS_EXPIRED
+    IS_EXPIRING: float = 0.8  # fraction_expired >= 0.8 (and < HAS_EXPIRED)
+
+    _engine: Engine | None = None
+    _fraction_expired: float | None = None
+    _gwy: Any | None = None
+
+    @classmethod
+    def from_message(cls, msg: Message) -> ApplicationMessage:
+        """Factory to safely promote a transport Message to an
+        ApplicationMessage.
+        """
+        # Initialize the subclass identically to how the base class initializes
+        return cls(msg._pkt)
+
+    def bind_context(self, gwy: Any) -> None:
+        """Explicitly assign the application context (gateway).
+
+        :param gwy: The application context (gateway) to associate.
+        :type gwy: Any
+        """
+        self._gwy = gwy
+
+    def set_gateway(self, gwy: Engine) -> None:
+        """Set the gateway (engine) instance for this message.
+
+        :param gwy: The gateway (engine) instance to associate.
+        :type gwy: Engine
+        """
+        self._engine = gwy
+
+    @property
+    def _expired(self) -> bool:
+        """Return True if the message is dated, False otherwise.
+
+        :return: True if the message is dated, False otherwise.
+        :rtype: bool
+        """
+        # Safest fallback for unit tests without an engine
+        now = self._engine._dt_now() if self._engine else self.dtm
+
+        # 1. Enforce the hard 7-day expiration limit
+        if now - self.dtm > td(days=7):
+            return True
+
+        def fraction_expired(lifespan: td) -> float:
+            """Calculate the fraction of expired normal lifespan.
+
+            :param lifespan: The lifespan of the message.
+            :type lifespan: td
+            :return: The expired fraction.
+            :rtype: float
+            """
+            return float((now - self.dtm - td(seconds=3)) / lifespan)
+
+        # 1. Look for easy win...
+        if self._fraction_expired is not None:
+            if self._fraction_expired == self.CANT_EXPIRE:
+                return False
+            if self._fraction_expired >= self.HAS_EXPIRED:
+                return True
+
+        # 2. Need to update the fraction_expired...
+        # sync_cycle is a special case
+        if self.code == Code._1F09 and self.verb != RQ:
+            # RQs won't have remaining_seconds, RP/Ws have only partial
+            # cycle times
+            rem_secs = getattr(self.payload, "remaining_seconds", None)
+            if rem_secs is None and isinstance(self.payload, dict):
+                rem_secs = self.payload.get("remaining_seconds", 0)
+
+            self._fraction_expired = fraction_expired(
+                td(seconds=float(rem_secs or 0)),
+            )
+
+        # Can't expire
+        elif getattr(self._pkt, "_lifespan", None) is False:
+            self._fraction_expired = self.CANT_EXPIRE
+
+        # Can't expire
+        elif getattr(self._pkt, "_lifespan", None) is True:
+            raise NotImplementedError("Lifespan True not implemented")
+
+        else:
+            lifespan = getattr(self._pkt, "_lifespan", None)
+            assert isinstance(lifespan, td)
+            self._fraction_expired = fraction_expired(lifespan)
+
+        return self._fraction_expired >= self.HAS_EXPIRED

--- a/src/ramses_tx/config.py
+++ b/src/ramses_tx/config.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+"""RAMSES RF - Transport layer configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .typing import DeviceListT, PktLogConfigT, PortConfigT
+
+
+@dataclass
+class EngineConfig:
+    """Configuration parameters for the Ramses Engine.
+
+    :param port_name: The serial port name (e.g., '/dev/ttyUSB0').
+    :type port_name: str | None
+    :param input_file: Path to a packet log file for playback/parsing.
+    :type input_file: str | None
+    :param port_config: Configuration dictionary for the serial port.
+    :type port_config: PortConfigT | None
+    :param packet_log: Configuration for packet logging.
+    :type packet_log: PktLogConfigT | None
+    :param block_list: A list of device IDs to block/ignore.
+    :type block_list: DeviceListT | None
+    :param known_list: A list of known device IDs and their traits.
+    :type known_list: DeviceListT | None
+    :param hgi_id: The Device ID to use for the HGI, overriding defaults.
+    :type hgi_id: str | None
+    :param disable_sending: Prevent sending any packets.
+    :type disable_sending: bool
+    :param disable_qos: Disable the Quality of Service mechanism.
+    :type disable_qos: bool | None
+    :param enforce_known_list: Enforce that only known devices are used.
+    :type enforce_known_list: bool
+    :param log_all_mqtt: Enable logging all MQTT messages.
+    :type log_all_mqtt: bool
+    :param evofw_flag: Specific flag for evofw3 usage.
+    :type evofw_flag: str | None
+    :param use_regex: Regex patterns for matching devices.
+    :type use_regex: dict[str, dict[str, str]]
+    :param app_context: Optional application context object.
+    :type app_context: Any | None
+    """
+
+    port_name: str | None = None
+    input_file: str | None = None
+    port_config: PortConfigT | None = None
+    packet_log: PktLogConfigT | None = None
+    block_list: DeviceListT | None = None
+    known_list: DeviceListT | None = None
+    hgi_id: str | None = None
+    disable_sending: bool = False
+    disable_qos: bool | None = None
+    enforce_known_list: bool = False
+    log_all_mqtt: bool = False
+    evofw_flag: str | None = None
+    use_regex: dict[str, dict[str, str]] = field(default_factory=dict)
+    app_context: Any | None = None

--- a/src/ramses_tx/engine.py
+++ b/src/ramses_tx/engine.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-"""RAMSES RF - The serial to RF gateway (HGI80, not RFG100)."""
+"""RAMSES RF - The serial to RF engine."""
 
 from __future__ import annotations
 
@@ -8,10 +8,11 @@ import asyncio
 import logging
 import threading
 from collections.abc import Awaitable, Callable
-from datetime import datetime as dt, timedelta as td
+from datetime import datetime as dt
 from typing import TYPE_CHECKING, Any, Never
 
 from .address import ALL_DEV_ADDR, HGI_DEV_ADDR, NON_DEV_ADDR
+from .application_message import ApplicationMessage
 from .command import Command
 from .const import (
     DEFAULT_DISABLE_QOS,
@@ -21,6 +22,7 @@ from .const import (
     DEFAULT_SEND_TIMEOUT,
     DEFAULT_WAIT_FOR_REPLY,
     SZ_ACTIVE_HGI,
+    Code,
     Priority,
 )
 from .message import Message
@@ -35,14 +37,6 @@ from .schemas import (
 from .transport import TransportConfig, transport_factory
 from .typing import PktLogConfigT, PortConfigT, QosParams
 
-from .const import (  # noqa: F401, isort: skip, pylint: disable=unused-import
-    Code,
-    I_,
-    RP,
-    RQ,
-    W_,
-)
-
 if TYPE_CHECKING:
     from .const import VerbT
     from .protocol import RamsesProtocolT
@@ -55,101 +49,12 @@ DEV_MODE = False
 _LOGGER = logging.getLogger(__name__)
 
 
-class ApplicationMessage(Message):
-    """Application-level message extended with gateway context and expiration."""
-
-    CANT_EXPIRE: float = -1.0  # sentinel value for fraction_expired
-    HAS_EXPIRED: float = 2.0  # fraction_expired >= HAS_EXPIRED
-    IS_EXPIRING: float = 0.8  # fraction_expired >= 0.8 (and < HAS_EXPIRED)
-
-    _engine: Engine | None = None
-    _fraction_expired: float | None = None
-    _gwy: Any | None = None
-
-    @classmethod
-    def from_message(cls, msg: Message) -> ApplicationMessage:
-        """Factory to safely promote a transport Message to an ApplicationMessage."""
-        # Initialize the subclass identically to how the base class initializes
-        return cls(msg._pkt)
-
-    def bind_context(self, gwy: Any) -> None:
-        """Explicitly assign the application context (gateway).
-
-        :param gwy: The application context (gateway) to associate.
-        :type gwy: Any
-        """
-        self._gwy = gwy
-
-    def set_gateway(self, gwy: Engine) -> None:
-        """Set the gateway (engine) instance for this message.
-
-        :param gwy: The gateway (engine) instance to associate.
-        :type gwy: Engine
-        """
-        self._engine = gwy
-
-    @property
-    def _expired(self) -> bool:
-        """Return True if the message is dated, False otherwise.
-
-        :return: True if the message is dated, False otherwise.
-        :rtype: bool
-        """
-        # Safest fallback for unit tests without an engine
-        now = self._engine._dt_now() if self._engine else self.dtm
-
-        # 1. Enforce the hard 7-day expiration limit
-        if now - self.dtm > td(days=7):
-            return True
-
-        def fraction_expired(lifespan: td) -> float:
-            """Calculate the fraction of expired normal lifespan.
-
-            :param lifespan: The lifespan of the message.
-            :type lifespan: td
-            :return: The expired fraction.
-            :rtype: float
-            """
-            return float((now - self.dtm - td(seconds=3)) / lifespan)
-
-        # 1. Look for easy win...
-        if self._fraction_expired is not None:
-            if self._fraction_expired == self.CANT_EXPIRE:
-                return False
-            if self._fraction_expired >= self.HAS_EXPIRED:
-                return True
-
-        # 2. Need to update the fraction_expired...
-        # sync_cycle is a special case
-        if self.code == Code._1F09 and self.verb != RQ:
-            # RQs won't have remaining_seconds, RP/Ws have only partial
-            # cycle times
-            rem_secs = getattr(self.payload, "remaining_seconds", None)
-            if rem_secs is None and isinstance(self.payload, dict):
-                rem_secs = self.payload.get("remaining_seconds", 0)
-
-            self._fraction_expired = fraction_expired(
-                td(seconds=float(rem_secs or 0)),
-            )
-
-        # Can't expire
-        elif getattr(self._pkt, "_lifespan", None) is False:
-            self._fraction_expired = self.CANT_EXPIRE
-
-        # Can't expire
-        elif getattr(self._pkt, "_lifespan", None) is True:
-            raise NotImplementedError("Lifespan True not implemented")
-
-        else:
-            lifespan = getattr(self._pkt, "_lifespan", None)
-            assert isinstance(lifespan, td)
-            self._fraction_expired = fraction_expired(lifespan)
-
-        return self._fraction_expired >= self.HAS_EXPIRED
-
-
 class Engine:
-    """The engine class."""
+    """The engine class.
+
+    Manages the transport layer, protocol binding, task registry, and
+    asynchronous command dispatching for the RF network.
+    """
 
     def __init__(
         self,
@@ -173,7 +78,9 @@ class Engine:
     ) -> None:
         if port_name and input_file:
             _LOGGER.warning(
-                "Port (%s) specified, so file (%s) ignored", port_name, input_file
+                "Port (%s) specified, so file (%s) ignored",
+                port_name,
+                input_file,
             )
             input_file = None
 
@@ -220,7 +127,7 @@ class Engine:
         ) = None
 
         self._protocol: RamsesProtocolT = None  # type: ignore[assignment]
-        self._transport: RamsesTransportT | None = None  # None until self.start()
+        self._transport: RamsesTransportT | None = None  # None until start()
 
         self._prev_msg: ApplicationMessage | None = None
         self._this_msg: ApplicationMessage | None = None
@@ -229,7 +136,7 @@ class Engine:
 
         # Thread-safe lock for task registry modifications
         self._tasks_lock = threading.Lock()
-        self._tasks: list[asyncio.Task] = []  # type: ignore[type-arg]
+        self._tasks: list[asyncio.Task[Any]] = []
 
         self._set_msg_handler(self._msg_handler)  # sets self._protocol
 
@@ -270,7 +177,6 @@ class Engine:
 
         The corresponding transport will be created later.
         """
-
         self._protocol = protocol_factory(
             msg_handler,
             disable_sending=self._disable_sending,
@@ -300,7 +206,6 @@ class Engine:
 
         Initiate receiving (Messages) and sending (Commands).
         """
-
         pkt_source: dict[str, Any] = {}  # [str, dict | str | TextIO]
         if self.ser_name:
             pkt_source[SZ_PORT_NAME] = self.ser_name
@@ -339,7 +244,6 @@ class Engine:
 
     async def stop(self) -> None:
         """Close the transport (will stop the protocol)."""
-
         # Shutdown Safety - securely lock the task registry to clean up
         with self._tasks_lock:
             tasks = [t for t in self._tasks if not t.done()]
@@ -355,7 +259,9 @@ class Engine:
                 if task.done() and not task.cancelled():
                     if exc := task.exception():
                         _LOGGER.debug(
-                            "Background task %s failed: %s", task.get_name(), exc
+                            "Background task %s failed: %s",
+                            task.get_name(),
+                            exc,
                         )
 
         if self._transport:
@@ -394,7 +300,8 @@ class Engine:
             if pause_reading:
                 self._loop.call_soon(pause_reading)
 
-        # Implement No-Op pattern instead of None to prevent 'NoneType callable' crashes
+        # Implement No-Op pattern instead of None to prevent 'NoneType
+        # callable' crashes
         self._protocol._msg_handler, handler = (
             self._drop_msg,
             self._protocol._msg_handler,
@@ -404,9 +311,9 @@ class Engine:
 
         self._engine_state = (handler, read_only, *args)
 
-    async def _resume(self) -> tuple[Any]:
+    async def _resume(self) -> tuple[Any, ...]:
         """Resume the (paused) engine or raise a RuntimeError."""
-        args: tuple[Any]
+        args: tuple[Any, ...]
 
         try:
             await asyncio.wait_for(self._engine_lock.acquire(), timeout=0.1)
@@ -435,7 +342,7 @@ class Engine:
         if not self._disable_sending:
             self._loop.call_soon(self._protocol.resume_writing)
 
-        return args
+        return tuple(args)
 
     def add_task(self, task: asyncio.Task[Any]) -> None:
         """Keep a track of tasks securely, so we can tidy-up."""
@@ -454,7 +361,6 @@ class Engine:
         seqn: str | None = None,
     ) -> Command:
         """Make a command addressed to device_id."""
-
         kwargs = {}
         if from_id is not None:
             kwargs["from_id"] = from_id
@@ -484,7 +390,6 @@ class Engine:
             ProtocolSendFailed: tried to Tx Command, but didn't get echo/reply
             ProtocolError:      didn't attempt to Tx Command for some reason
         """
-
         qos = QosParams(
             max_retries=max_retries,
             timeout=timeout,

--- a/src/ramses_tx/engine.py
+++ b/src/ramses_tx/engine.py
@@ -38,6 +38,7 @@ from .transport import TransportConfig, transport_factory
 from .typing import PktLogConfigT, PortConfigT, QosParams
 
 if TYPE_CHECKING:
+    from .config import EngineConfig
     from .const import VerbT
     from .protocol import RamsesProtocolT
     from .transport import RamsesTransportT
@@ -58,68 +59,63 @@ class Engine:
 
     def __init__(
         self,
-        port_name: str | None,
-        input_file: str | None = None,
-        port_config: PortConfigT | None = None,
-        packet_log: PktLogConfigT | None = None,
-        block_list: DeviceListT | None = None,
-        known_list: DeviceListT | None = None,
-        hgi_id: str | None = None,
+        config: EngineConfig,
         loop: asyncio.AbstractEventLoop | None = None,
         *,
-        disable_sending: bool = False,
-        disable_qos: bool | None = None,
-        enforce_known_list: bool = False,
-        log_all_mqtt: bool = False,
-        evofw_flag: str | None = None,
-        use_regex: dict[str, dict[str, str]] | None = None,
         transport_constructor: Callable[..., Awaitable[RamsesTransportT]] | None = None,
-        app_context: Any | None = None,
     ) -> None:
-        if port_name and input_file:
+        self.config = config
+
+        if self.config.port_name and self.config.input_file:
             _LOGGER.warning(
                 "Port (%s) specified, so file (%s) ignored",
-                port_name,
-                input_file,
+                self.config.port_name,
+                self.config.input_file,
             )
-            input_file = None
+            self.config.input_file = None
 
-        self._disable_sending = disable_sending
-        if input_file:
+        self._disable_sending = self.config.disable_sending
+        if self.config.input_file:
             self._disable_sending = True
-        elif not port_name:
+        elif not self.config.port_name:
             raise TypeError("Either a port_name or an input_file must be specified")
 
-        self.ser_name = port_name
-        self._input_file = input_file
+        self.ser_name = self.config.port_name
+        self._input_file = self.config.input_file
 
-        self._port_config: PortConfigT | dict[Never, Never] = port_config or {}
-        self._packet_log: PktLogConfigT | dict[Never, Never] = packet_log or {}
+        self._port_config: PortConfigT | dict[Never, Never] = (
+            self.config.port_config or {}
+        )
+        self._packet_log: PktLogConfigT | dict[Never, Never] = (
+            self.config.packet_log or {}
+        )
         self._loop = loop or asyncio.get_running_loop()
 
-        self._exclude: DeviceListT = block_list or {}
-        self._include: DeviceListT = known_list or {}
+        self._exclude: DeviceListT = self.config.block_list or {}
+        self._include: DeviceListT = self.config.known_list or {}
         self._unwanted: list[DeviceIdT] = [
             NON_DEV_ADDR.id,
             ALL_DEV_ADDR.id,
             "01:000001",  # type: ignore[list-item]  # why this one?
         ]
         self._enforce_known_list = select_device_filter_mode(
-            enforce_known_list,
+            self.config.enforce_known_list,
             self._include,
             self._exclude,
         )
-        self._log_all_mqtt = log_all_mqtt
-        self._evofw_flag = evofw_flag
-        self._use_regex = use_regex or {}
+        self._log_all_mqtt = self.config.log_all_mqtt
+        self._evofw_flag = self.config.evofw_flag
+        self._use_regex = self.config.use_regex or {}
         self._disable_qos = (
-            disable_qos if disable_qos is not None else DEFAULT_DISABLE_QOS
+            self.config.disable_qos
+            if self.config.disable_qos is not None
+            else DEFAULT_DISABLE_QOS
         )
 
         self._transport_constructor = transport_constructor
-        self._app_context = app_context
+        self._app_context = self.config.app_context
 
-        self._hgi_id = hgi_id
+        self._hgi_id = self.config.hgi_id
 
         self._engine_lock = asyncio.Lock()
         self._engine_state: (

--- a/tests/tests/helpers.py
+++ b/tests/tests/helpers.py
@@ -18,6 +18,7 @@ from ramses_rf.gateway import GatewayConfig
 from ramses_rf.helpers import shrink
 from ramses_rf.message_store import MessageStore
 from ramses_rf.schemas import SCH_GLOBAL_CONFIG, SCH_GLOBAL_SCHEMAS
+from ramses_tx.config import EngineConfig
 from ramses_tx.schemas import SCH_GLOBAL_TRAITS_DICT
 
 SCH_GLOBAL_TRAITS = vol.Schema(SCH_GLOBAL_TRAITS_DICT, extra=vol.PREVENT_EXTRA)
@@ -27,10 +28,13 @@ SCH_GLOBAL_TRAITS = vol.Schema(SCH_GLOBAL_TRAITS_DICT, extra=vol.PREVENT_EXTRA)
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-# logging.disable(logging.WARNING)  # usu. WARNING  # TODO: Verify original intent. Commented out as it breaks isolated logging logic in PR #413.
+# usu. WARNING  # TODO: Verify original intent. Commented out as it breaks
+# isolated logging logic in PR #413.
+# logging.disable(logging.WARNING)
 
 
-TEST_DIR = Path(__file__).resolve().parent  # TEST_DIR = f"{os.path.dirname(__file__)}"
+# TEST_DIR = f"{os.path.dirname(__file__)}"
+TEST_DIR = Path(__file__).resolve().parent
 
 
 def shuffle_dict(old_dict: dict[str, Any]) -> dict[str, Any]:
@@ -50,7 +54,8 @@ def shuffle_dict(old_dict: dict[str, Any]) -> dict[str, Any]:
 
 
 @pytest.fixture
-async def gwy() -> AsyncGenerator[Gateway, None]:  # NOTE: async to get running loop
+# NOTE: async to get running loop
+async def gwy() -> AsyncGenerator[Gateway, None]:
     """Return a vanilla system (with a known, minimal state)."""
     gwy = Gateway("/dev/null", config=GatewayConfig())
     gwy._engine._disable_sending = True
@@ -64,7 +69,8 @@ async def gwy() -> AsyncGenerator[Gateway, None]:  # NOTE: async to get running 
 def assert_expected(
     actual: dict[str, Any], expected: dict[str, Any] | None = None
 ) -> None:
-    """Compare an actual system state dict against the corresponding expected state.
+    """Compare an actual system state dict against the corresponding
+    expected state.
 
     :param actual: The actual state dictionary.
     :type actual: dict[str, Any]
@@ -82,7 +88,8 @@ def assert_expected(
 
 
 async def assert_expected_set(gwy: Gateway, expected: dict[str, Any]) -> None:
-    """Compare the actual system state against the expected system state.
+    """Compare the actual system state against the expected system
+    state.
 
     :param gwy: The gateway instance to check.
     :type gwy: Gateway
@@ -175,7 +182,8 @@ def find_test_tcs(gwy: Gateway | tuple[Gateway, ...]) -> Any:
 
 
 async def load_test_gwy(dir_name: Path, **kwargs: Any) -> Gateway:
-    """Create a system state from a packet log (using an optional configuration).
+    """Create a system state from a packet log (using an optional
+    configuration).
 
     :param dir_name: The directory containing config.json and packet.log.
     :type dir_name: Path
@@ -199,15 +207,20 @@ async def load_test_gwy(dir_name: Path, **kwargs: Any) -> Gateway:
     config_kwargs = {**config_dict, **kwargs}
     config_kwargs["input_file"] = f"{dir_name}/packet.log"
 
-    valid_keys = {f.name for f in fields(GatewayConfig)}
-    safe_kwargs: dict[str, Any] = {}
+    valid_gwy_keys = {f.name for f in fields(GatewayConfig)}
+    valid_eng_keys = {f.name for f in fields(EngineConfig)}
+
+    gwy_kwargs: dict[str, Any] = {}
+    eng_kwargs: dict[str, Any] = {}
     schema_kwargs = config_kwargs.pop("schema", {})
 
     for k, v in config_kwargs.items():
         if k.startswith("_"):
             continue
-        if k in valid_keys:
-            safe_kwargs[k] = v
+        if k in valid_gwy_keys:
+            gwy_kwargs[k] = v
+        elif k in valid_eng_keys:
+            eng_kwargs[k] = v
         elif k in (
             "main_tcs",
             "orphans",
@@ -218,15 +231,20 @@ async def load_test_gwy(dir_name: Path, **kwargs: Any) -> Gateway:
             schema_kwargs[k] = v
 
     if schema_kwargs:
-        safe_kwargs["schema"] = schema_kwargs
+        gwy_kwargs["schema"] = schema_kwargs
 
-    gwy = Gateway(None, config=GatewayConfig(**safe_kwargs))
+    if eng_kwargs:
+        gwy_kwargs["engine"] = EngineConfig(**eng_kwargs)
+
+    gwy = Gateway(None, config=GatewayConfig(**gwy_kwargs))
     await gwy.start()
 
-    # The Gateway with input_file uses a Transport that processes the file automatically.
-    # We simply need to wait for the transport to finish reading the file.
+    # The Gateway with input_file uses a Transport that processes the file
+    # automatically. We simply need to wait for the transport to finish
+    # reading the file.
     # We pause discovery/sending during replay to avoid side effects.
-    await gwy._engine._protocol.wait_for_connection_lost()  # until packet log is EOF
+    # until packet log is EOF
+    await gwy._engine._protocol.wait_for_connection_lost()
 
     # Ensure all packets from the log are written to the DB before returning
     # This is critical for tests using the StorageWorker
@@ -237,7 +255,8 @@ async def load_test_gwy(dir_name: Path, **kwargs: Any) -> Gateway:
 
 
 def load_expected_results(dir_name: Path) -> dict[str, Any]:
-    """Return the expected (global) schema/params/status & traits (aka known_list).
+    """Return the expected (global) schema/params/status & traits
+    (aka known_list).
 
     :param dir_name: The directory containing the JSON result files.
     :type dir_name: Path
@@ -257,6 +276,7 @@ def load_expected_results(dir_name: Path) -> dict[str, Any]:
             known_list = json.load(f)["known_list"]
     except FileNotFoundError:
         known_list = {}
+
     known_list = SCH_GLOBAL_TRAITS({"known_list": shrink(known_list)})["known_list"]
 
     try:

--- a/tests/tests/test_cli_transport_factory.py
+++ b/tests/tests/test_cli_transport_factory.py
@@ -23,7 +23,6 @@ async def test_cli_uses_transport_factory(mock_gateway: MagicMock) -> None:
     Verifies that when a non-standard port (like an MQTT URL) is passed,
     the Gateway is initialized correctly.
     """
-
     runner = CliRunner()
 
     # We use a valid-looking MQTT URL
@@ -52,12 +51,8 @@ async def test_cli_uses_transport_factory(mock_gateway: MagicMock) -> None:
     await async_main(command, lib_kwargs, **kwargs)
 
     # 4. Assert Gateway was initialized with our URL
-    args, kwargs = mock_gateway.call_args
+    args, kwargs_call = mock_gateway.call_args
     assert args[0] == mqtt_url
-
-    # FIX: We no longer expect transport_constructor to be passed explicitly
-    # because it causes recursion issues in ramses_tx.transport_factory
-    # assert "transport_constructor" in kwargs
 
 
 @pytest.mark.asyncio
@@ -68,7 +63,6 @@ async def test_cli_serial_backward_compatibility(mock_gateway: MagicMock) -> Non
     Verifies that standard serial port paths are still accepted and handled
     correctly by the Gateway initialization logic.
     """
-
     runner = CliRunner()
     serial_port = "/dev/ttyUSB0"
 
@@ -90,5 +84,5 @@ async def test_cli_serial_backward_compatibility(mock_gateway: MagicMock) -> Non
     await async_main(command, lib_kwargs, **kwargs)
 
     # 4. Assert Gateway was instantiated
-    args, kwargs = mock_gateway.call_args
+    args, kwargs_call = mock_gateway.call_args
     assert args[0] == serial_port

--- a/tests/tests/test_eavesdrop_dev_class.py
+++ b/tests/tests/test_eavesdrop_dev_class.py
@@ -8,6 +8,7 @@ import pytest
 
 from ramses_rf import Gateway, Message
 from ramses_rf.gateway import GatewayConfig
+from ramses_tx.config import EngineConfig
 
 from .helpers import TEST_DIR, assert_expected
 
@@ -32,7 +33,13 @@ async def test_packets_from_log_file(dir_name: Path) -> None:
 
     path = f"{dir_name}/packet.log"
 
-    gwy = Gateway(None, config=GatewayConfig(input_file=path, enable_eavesdrop=False))
+    gwy = Gateway(
+        None,
+        config=GatewayConfig(
+            enable_eavesdrop=False,
+            engine=EngineConfig(input_file=path),
+        ),
+    )
     gwy.config.enable_eavesdrop = True  # Test setting this config attr
 
     gwy.add_msg_handler(proc_log_line)
@@ -48,12 +55,19 @@ async def test_dev_eavesdrop_on_(dir_name: Path) -> None:
     """Check discovery of schema and known_list *with* eavesdropping."""
 
     path = f"{dir_name}/packet.log"
-    gwy = Gateway(None, config=GatewayConfig(input_file=path, enable_eavesdrop=True))
+    gwy = Gateway(
+        None,
+        config=GatewayConfig(
+            enable_eavesdrop=True,
+            engine=EngineConfig(input_file=path),
+        ),
+    )
     await gwy.start()
 
     with open(f"{dir_name}/known_list_eavesdrop_on.json") as f:
         assert_expected(
-            await gwy.device_registry.known_list(), json.load(f).get("known_list")
+            await gwy.device_registry.known_list(),
+            json.load(f).get("known_list"),
         )
 
     try:
@@ -70,13 +84,20 @@ async def test_dev_eavesdrop_off(dir_name: Path) -> None:
     """Check discovery of schema and known_list *without* eavesdropping."""
 
     path = f"{dir_name}/packet.log"
-    gwy = Gateway(None, config=GatewayConfig(input_file=path, enable_eavesdrop=False))
+    gwy = Gateway(
+        None,
+        config=GatewayConfig(
+            enable_eavesdrop=False,
+            engine=EngineConfig(input_file=path),
+        ),
+    )
     await gwy.start()
 
     try:
         with open(f"{dir_name}/known_list_eavesdrop_off.json") as f:
             assert_expected(
-                await gwy.device_registry.known_list(), json.load(f).get("known_list")
+                await gwy.device_registry.known_list(),
+                json.load(f).get("known_list"),
             )
     except FileNotFoundError:
         pass

--- a/tests/tests/test_eavesdrop_schema.py
+++ b/tests/tests/test_eavesdrop_schema.py
@@ -10,6 +10,7 @@ import pytest
 from ramses_rf import Gateway
 from ramses_rf.gateway import GatewayConfig
 from ramses_rf.helpers import shrink
+from ramses_tx.config import EngineConfig
 
 from .helpers import TEST_DIR, assert_expected
 
@@ -46,7 +47,8 @@ async def assert_schemas_equal(gwy: Gateway, expected_schema: dict[str, Any]) ->
     :type gwy: Gateway
     :param expected_schema: The schema dictionary expected to match.
     :type expected_schema: dict[str, Any]
-    :raises AssertionError: If the actual schema does not match the expected schema.
+    :raises AssertionError: If the actual schema does not match the
+        expected schema.
     :rtype: None
     """
     schema, packets = await gwy.get_state(include_expired=True)
@@ -69,15 +71,23 @@ async def assert_schemas_equal(gwy: Gateway, expected_schema: dict[str, Any]) ->
 
 # duplicate in test_eavesdrop_dev_class
 async def test_eavesdrop_off(dir_name: Path) -> None:
-    """Check discovery of schema and known_list *without* eavesdropping.
+    """Check discovery of schema and known_list *without*
+    eavesdropping.
 
-    :param dir_name: The directory containing the test packet log and schemas.
+    :param dir_name: The directory containing the test packet log and
+        schemas.
     :type dir_name: Path
     :rtype: None
     """
 
     path = f"{dir_name}/packet.log"
-    gwy = Gateway(None, config=GatewayConfig(input_file=path, enable_eavesdrop=False))
+    gwy = Gateway(
+        None,
+        config=GatewayConfig(
+            enable_eavesdrop=False,
+            engine=EngineConfig(input_file=path),
+        ),
+    )
     await gwy.start()
 
     with open(f"{dir_name}/schema_eavesdrop_off.json") as f:
@@ -99,13 +109,20 @@ async def test_eavesdrop_off(dir_name: Path) -> None:
 async def test_eavesdrop_on_(dir_name: Path) -> None:
     """Check discovery of schema and known_list *with* eavesdropping.
 
-    :param dir_name: The directory containing the test packet log and schemas.
+    :param dir_name: The directory containing the test packet log and
+        schemas.
     :type dir_name: Path
     :rtype: None
     """
 
     path = f"{dir_name}/packet.log"
-    gwy = Gateway(None, config=GatewayConfig(input_file=path, enable_eavesdrop=True))
+    gwy = Gateway(
+        None,
+        config=GatewayConfig(
+            enable_eavesdrop=True,
+            engine=EngineConfig(input_file=path),
+        ),
+    )
     await gwy.start()
 
     with open(f"{dir_name}/schema_eavesdrop_on.json") as f:

--- a/tests/tests/test_hgi_id.py
+++ b/tests/tests/test_hgi_id.py
@@ -26,7 +26,7 @@ async def test_hgi_id_injection() -> None:
     # Mock the transport factory to avoid creating a real connection/transport
     # We want to inspect the kwargs passed to it.
     with (
-        patch("ramses_tx.gateway.transport_factory") as mock_transport_factory,
+        patch("ramses_tx.engine.transport_factory") as mock_transport_factory,
         patch.object(
             gwy._engine._protocol, "wait_for_connection_made", new_callable=AsyncMock
         ),
@@ -68,7 +68,7 @@ async def test_hgi_id_default_behavior() -> None:
     gwy = Gateway("/dev/ttyMOCK", config=GatewayConfig(input_file=None))
 
     with (
-        patch("ramses_tx.gateway.transport_factory") as mock_transport_factory,
+        patch("ramses_tx.engine.transport_factory") as mock_transport_factory,
         patch.object(
             gwy._engine._protocol, "wait_for_connection_made", new_callable=AsyncMock
         ),

--- a/tests/tests/test_hgi_id.py
+++ b/tests/tests/test_hgi_id.py
@@ -7,6 +7,7 @@ import pytest
 
 from ramses_rf.gateway import Gateway, GatewayConfig
 from ramses_tx.address import HGI_DEV_ADDR
+from ramses_tx.config import EngineConfig
 from ramses_tx.const import SZ_ACTIVE_HGI
 
 TEST_HGI_ID = "18:005960"
@@ -20,7 +21,7 @@ async def test_hgi_id_injection() -> None:
     # We must provide a dummy port_name to satisfy Engine.__init__ validation
     gwy = Gateway(
         "/dev/ttyMOCK",
-        config=GatewayConfig(input_file=None, hgi_id=TEST_HGI_ID),
+        config=GatewayConfig(engine=EngineConfig(input_file=None, hgi_id=TEST_HGI_ID)),
     )
 
     # Mock the transport factory to avoid creating a real connection/transport
@@ -65,7 +66,9 @@ async def test_hgi_id_default_behavior() -> None:
     """Check that the Gateway defaults to the hardcoded ID when no custom ID is provided."""
 
     # 1. Instantiate Gateway WITHOUT the custom hgi_id using GatewayConfig
-    gwy = Gateway("/dev/ttyMOCK", config=GatewayConfig(input_file=None))
+    gwy = Gateway(
+        "/dev/ttyMOCK", config=GatewayConfig(engine=EngineConfig(input_file=None))
+    )
 
     with (
         patch("ramses_tx.engine.transport_factory") as mock_transport_factory,

--- a/tests/tests/test_schemas.py
+++ b/tests/tests/test_schemas.py
@@ -9,6 +9,7 @@ import pytest
 from ramses_rf import Gateway
 from ramses_rf.gateway import GatewayConfig
 from ramses_rf.helpers import shrink
+from ramses_tx.config import EngineConfig
 
 from .helpers import (
     TEST_DIR,
@@ -28,7 +29,7 @@ async def test_schema_discover_from_log(f_name: str) -> None:
     :param f_name: The stem of the log file to be tested
     """
     path = f"{WORK_DIR}/log_files/{f_name}.log"
-    gwy = Gateway(None, config=GatewayConfig(input_file=path))  # noqa: F811
+    gwy = Gateway(None, config=GatewayConfig(engine=EngineConfig(input_file=path)))  # noqa: F811
     await gwy.start()  # this is what we're testing
 
     with open(f"{WORK_DIR}/log_files/{f_name}.json") as f:

--- a/tests/tests_rf/conftest.py
+++ b/tests/tests_rf/conftest.py
@@ -4,6 +4,7 @@
 import logging
 import os
 from collections.abc import AsyncGenerator
+from dataclasses import fields
 from pathlib import Path
 from typing import Any, Final, NoReturn, TypeAlias, TypedDict, cast
 from unittest.mock import patch
@@ -17,6 +18,7 @@ from ramses_rf.device import HgiGateway
 from ramses_rf.gateway import GatewayConfig
 from ramses_tx import exceptions as exc
 from ramses_tx.address import HGI_DEVICE_ID
+from ramses_tx.config import EngineConfig
 from ramses_tx.transport.port import PortTransport
 from ramses_tx.typing import DeviceIdT
 from tests_rf.virtual_rf import HgiFwTypes, VirtualRf
@@ -24,7 +26,8 @@ from tests_rf.virtual_rf import HgiFwTypes, VirtualRf
 #
 PortStrT: TypeAlias = str
 
-TEST_DIR = Path(__file__).resolve().parent  # TEST_DIR = f"{os.path.dirname(__file__)}"
+# TEST_DIR = f"{os.path.dirname(__file__)}"
+TEST_DIR = Path(__file__).resolve().parent
 
 SZ_GWY_CONFIG: Final = "gwy_config"
 SZ_GWY_DEV_ID: Final = "gwy_dev_id"
@@ -51,7 +54,7 @@ IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 _global_failed_ports: list[str] = []
 
 
-#######################################################################################
+###############################################################################
 
 # pytestmark = pytest.mark.asyncio(scope="function")  # needed?
 
@@ -82,7 +85,7 @@ def patches_for_tests(monkeypatch: pytest.MonkeyPatch) -> None:
 #     request.addfinalizer(finalize)
 
 
-#######################################################################################
+###############################################################################
 
 
 @pytest.fixture()
@@ -174,7 +177,7 @@ async def real_ti3410_port() -> PortStrT | NoReturn:
     pytest.skip("No ti3410-based gateway device found")
 
 
-#######################################################################################
+###############################################################################
 
 
 async def _gateway(gwy_port: PortStrT, gwy_config: _GwyConfigDictT) -> Gateway:
@@ -182,14 +185,32 @@ async def _gateway(gwy_port: PortStrT, gwy_config: _GwyConfigDictT) -> Gateway:
 
     kwargs = cast(dict[str, Any], dict(gwy_config))
 
-    # Flatten gwy_config to handle nested 'config' dicts or GatewayConfig objects
+    # Flatten gwy_config to handle nested 'config' dicts or GatewayConfig
+    # objects
     if "config" in kwargs:
         cfg = kwargs.pop("config")
         cfg_dict = cast(dict[str, Any], cfg if isinstance(cfg, dict) else vars(cfg))
         # Outer kwargs take precedence over nested config values
         kwargs = {**cfg_dict, **kwargs}
 
-    config = GatewayConfig(**kwargs)
+    valid_gwy_keys = {f.name for f in fields(GatewayConfig)}
+    valid_eng_keys = {f.name for f in fields(EngineConfig)}
+
+    gwy_kwargs: dict[str, Any] = {}
+    eng_kwargs: dict[str, Any] = {}
+
+    for k, v in kwargs.items():
+        if k in valid_gwy_keys:
+            gwy_kwargs[k] = v
+        elif k in valid_eng_keys:
+            eng_kwargs[k] = v
+        else:
+            gwy_kwargs[k] = v
+
+    if eng_kwargs:
+        gwy_kwargs["engine"] = EngineConfig(**eng_kwargs)
+
+    config = GatewayConfig(**gwy_kwargs)
 
     gwy = Gateway(gwy_port, config=config)
 
@@ -227,16 +248,19 @@ async def _real_gateway(gwy_port: PortStrT, gwy_config: _GwyConfigDictT) -> Gate
         return await _gateway(gwy_port, gwy_config)
     except (ser.SerialException, exc.TransportError) as err:
         _global_failed_ports.append(gwy_port)
-        pytest.xfail(str(err))  # not skip, as we had determined port exists elsewhere
+        # not skip, as we had determined port exists elsewhere
+        pytest.xfail(str(err))
 
 
 @pytest.fixture()
 async def fake_evofw3(
     fake_evofw3_port: PortStrT, request: pytest.FixtureRequest, rf: VirtualRf
 ) -> AsyncGenerator[Gateway, None]:
-    """Utilize a virtual evofw3-compatible gateway (discovered by fake_evofw3_port).
+    """Utilize a virtual evofw3-compatible gateway (discovered by
+    fake_evofw3_port).
 
-    Requires test to supply gwy_config & gwy_dev_id (used by fake_evofw3_port) fixtures.
+    Requires test to supply gwy_config & gwy_dev_id (used by fake_evofw3_port)
+    fixtures.
     """
 
     gwy_config: _GwyConfigDictT = request.getfixturevalue(SZ_GWY_CONFIG)
@@ -257,9 +281,11 @@ async def fake_evofw3(
 async def fake_ti3410(
     fake_ti3410_port: PortStrT, request: pytest.FixtureRequest, rf: VirtualRf
 ) -> AsyncGenerator[Gateway, None]:
-    """Utilize a virtual HGI80-compatible gateway (discovered by fake_ti3410_port).
+    """Utilize a virtual HGI80-compatible gateway (discovered by
+    fake_ti3410_port).
 
-    Requires test to supply gwy_config & gwy_dev_id (used by fake_ti3410_port) fixtures.
+    Requires test to supply gwy_config & gwy_dev_id (used by fake_ti3410_port)
+    fixtures.
     """
 
     gwy_config: _GwyConfigDictT = request.getfixturevalue(SZ_GWY_CONFIG)
@@ -280,7 +306,8 @@ async def fake_ti3410(
 async def mqtt_evofw3(
     mqtt_evofw3_port: PortStrT, request: pytest.FixtureRequest
 ) -> AsyncGenerator[Gateway, None]:
-    """Utilize an actual evofw3-compatible gateway (discovered by mqtt_evofw3_port).
+    """Utilize an actual evofw3-compatible gateway (discovered by
+    mqtt_evofw3_port).
 
     Requires test to supply corresponding gwy_config fixture.
     """
@@ -289,11 +316,13 @@ async def mqtt_evofw3(
     gwy_config: _GwyConfigDictT = request.getfixturevalue(SZ_GWY_CONFIG)
     gwy = await _gateway(mqtt_evofw3_port, gwy_config)
 
-    gwy.device_registry.get_device(
-        gwy._engine._protocol.hgi_id
-    )  # HACK: not instantiated: no puzzle pkts sent
+    # HACK: not instantiated: no puzzle pkts sent
+    gwy.device_registry.get_device(gwy._engine._protocol.hgi_id)
 
-    assert isinstance(gwy.hgi, HgiGateway) and gwy.hgi.id not in (None, HGI_DEVICE_ID)
+    assert isinstance(gwy.hgi, HgiGateway) and gwy.hgi.id not in (
+        None,
+        HGI_DEVICE_ID,
+    )
     assert gwy._engine._protocol._is_evofw3 is True
 
     try:
@@ -306,7 +335,8 @@ async def mqtt_evofw3(
 async def real_evofw3(
     real_evofw3_port: PortStrT, request: pytest.FixtureRequest
 ) -> AsyncGenerator[Gateway, None]:
-    """Utilize an actual evofw3-compatible gateway (discovered by real_evofw3_port).
+    """Utilize an actual evofw3-compatible gateway (discovered by
+    real_evofw3_port).
 
     Requires test to supply corresponding gwy_config fixture.
     """
@@ -315,7 +345,10 @@ async def real_evofw3(
 
     gwy = await _real_gateway(real_evofw3_port, gwy_config)
 
-    assert isinstance(gwy.hgi, HgiGateway) and gwy.hgi.id not in (None, HGI_DEVICE_ID)
+    assert isinstance(gwy.hgi, HgiGateway) and gwy.hgi.id not in (
+        None,
+        HGI_DEVICE_ID,
+    )
     assert gwy._engine._protocol._is_evofw3 is True
 
     try:
@@ -328,7 +361,8 @@ async def real_evofw3(
 async def real_ti3410(
     real_ti3410_port: PortStrT, request: pytest.FixtureRequest
 ) -> AsyncGenerator[Gateway, None]:
-    """Utilize an actual HGI80-compatible gateway (discovered by real_ti3410_port).
+    """Utilize an actual HGI80-compatible gateway (discovered by
+    real_ti3410_port).
 
     Requires test to supply corresponding gwy_config fixture.
     """
@@ -337,7 +371,10 @@ async def real_ti3410(
 
     gwy = await _real_gateway(real_ti3410_port, gwy_config)
 
-    assert isinstance(gwy.hgi, HgiGateway) and gwy.hgi.id not in (None, HGI_DEVICE_ID)
+    assert isinstance(gwy.hgi, HgiGateway) and gwy.hgi.id not in (
+        None,
+        HGI_DEVICE_ID,
+    )
     assert gwy._engine._protocol._is_evofw3 is False
 
     try:

--- a/tests/tests_rf/test_gateway.py
+++ b/tests/tests_rf/test_gateway.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from ramses_rf.gateway import Gateway, GatewayConfig
+from ramses_tx.config import EngineConfig
 
 
 @pytest.mark.asyncio
@@ -71,13 +72,16 @@ async def test_gateway_with_config() -> None:
     :returns: None
     """
     # Added gateway_timeout=15 to the initialization
-    config = GatewayConfig(enforce_known_list=True, gateway_timeout=15)
+    config = GatewayConfig(
+        gateway_timeout=15,
+        engine=EngineConfig(enforce_known_list=True),
+    )
 
     with warnings.catch_warnings(record=True) as recorded_warnings:
         warnings.simplefilter("always")
         gwy = Gateway("/dev/null", config=config)
 
-    assert gwy.config.enforce_known_list is True
+    assert gwy.config.engine.enforce_known_list is True
     # Assert that the gateway config retained the custom timeout
     assert gwy.config.gateway_timeout == 15
 
@@ -150,7 +154,9 @@ async def test_gateway_start_initiates_periodic_flush(
     # Configure a flush interval to trigger the task creation
     config = GatewayConfig(
         disable_discovery=True,
-        packet_log={"flush_interval": 60},
+        engine=EngineConfig(
+            packet_log={"flush_interval": 60},
+        ),
     )
     gwy = Gateway("/dev/null", config=config)
 
@@ -209,3 +215,32 @@ async def test_gateway_restore_cached_packets_dto() -> None:
 
         # Verify the protocol layer was handed the parsed Packet object directly
         mock_protocol.pkt_received.assert_called_once_with(mock_pkt)
+
+
+@pytest.mark.asyncio
+async def test_gateway_legacy_kwargs_deprecation() -> None:
+    """Test that legacy kwargs are gracefully mapped to config objects.
+
+    This ensures backward compatibility for ramses_cc while it transitions
+    to using the strict GatewayConfig/EngineConfig DTOs.
+    """
+    with pytest.warns(
+        DeprecationWarning, match=r"Initializing Gateway with \*\*kwargs.*is deprecated"
+    ):
+        gwy = Gateway(
+            port_name="/dev/null",
+            disable_sending=True,  # Transport-level (EngineConfig) kwarg
+            disable_discovery=True,  # RF-level (GatewayConfig) kwarg
+            invalid_fake_arg="ignore",  # Unsupported kwarg
+        )
+
+    # 1. Verify EngineConfig absorbed the transport kwarg
+    assert gwy.config.engine.disable_sending is True
+    assert gwy.config.engine.port_name == "/dev/null"
+
+    # 2. Verify GatewayConfig absorbed the RF kwarg
+    assert gwy.config.disable_discovery is True
+
+    # 3. Verify unsupported arguments were safely ignored
+    assert not hasattr(gwy.config, "invalid_fake_arg")
+    assert not hasattr(gwy.config.engine, "invalid_fake_arg")

--- a/tests/tests_rf/test_gateway.py
+++ b/tests/tests_rf/test_gateway.py
@@ -1,12 +1,14 @@
 """Tests for the Gateway backward compatibility, deprecation shims, and lifecycle."""
 
 import warnings
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from ramses_rf.gateway import Gateway, GatewayConfig
 from ramses_tx.config import EngineConfig
+from ramses_tx.typing import PktLogConfigT
 
 
 @pytest.mark.asyncio
@@ -225,7 +227,8 @@ async def test_gateway_legacy_kwargs_deprecation() -> None:
     to using the strict GatewayConfig/EngineConfig DTOs.
     """
     with pytest.warns(
-        DeprecationWarning, match=r"Initializing Gateway with \*\*kwargs.*is deprecated"
+        DeprecationWarning,
+        match=r"Initializing Gateway with \*\*kwargs.*is deprecated",
     ):
         gwy = Gateway(
             port_name="/dev/null",
@@ -244,3 +247,37 @@ async def test_gateway_legacy_kwargs_deprecation() -> None:
     # 3. Verify unsupported arguments were safely ignored
     assert not hasattr(gwy.config, "invalid_fake_arg")
     assert not hasattr(gwy.config.engine, "invalid_fake_arg")
+
+
+@pytest.mark.asyncio
+async def test_gateway_nested_kwargs_unpacking() -> None:
+    """Test that nested kwargs from Home Assistant are correctly unpacked.
+
+    This ensures that the recursive adapter can reach into nested dictionaries
+    passed by ramses_cc to extract DTO-level configuration variables.
+    """
+    nested_kwargs = {
+        "ramses_rf": {
+            "enforce_known_list": True,
+            "nested_unsupported": "ignore",
+        },
+        "packet_log": {
+            "packet_log_retention_days": 7,
+        },
+    }
+
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        gwy = Gateway(port_name="/dev/null", **nested_kwargs)
+
+    # 1. Verify EngineConfig absorbed the nested transport/filtering kwarg
+    assert gwy.config.engine.enforce_known_list is True
+
+    # 2. Verify EngineConfig absorbed the nested dictionary kwarg directly
+    # Use PktLogConfigT to satisfy Mypy strict comparison check
+    assert gwy.config.engine.packet_log == cast(
+        PktLogConfigT, {"packet_log_retention_days": 7}
+    )
+
+    # 3. Verify nesting logic did not create phantom attributes
+    assert not hasattr(gwy.config, "ramses_rf")
+    assert not hasattr(gwy.config.engine, "nested_unsupported")

--- a/tests/tests_rf/test_regression_rf.py
+++ b/tests/tests_rf/test_regression_rf.py
@@ -13,6 +13,7 @@ import pytest
 from ramses_rf import Gateway
 from ramses_rf.device import DeviceHeat, DeviceHvac
 from ramses_rf.gateway import GatewayConfig
+from ramses_tx.config import EngineConfig
 from ramses_tx.const import SZ_READER_TASK
 from ramses_tx.exceptions import TransportError
 
@@ -183,9 +184,11 @@ async def test_gateway_replay_regression(snapshot: SnapshotAssertion) -> None:
         None,  # port_name is required (positional arg)
         config=GatewayConfig(
             disable_discovery=True,
-            disable_sending=True,
-            input_file=str(FIXTURE_FILE),
             reduce_processing=0,
+            engine=EngineConfig(
+                disable_sending=True,
+                input_file=str(FIXTURE_FILE),
+            ),
         ),
     )
 

--- a/tests/tests_rf/test_use_regex.py
+++ b/tests/tests_rf/test_use_regex.py
@@ -9,6 +9,7 @@ import serial
 
 from ramses_rf import Command, Gateway, Packet
 from ramses_rf.gateway import GatewayConfig
+from ramses_tx.config import EngineConfig
 from ramses_tx.protocol import PortProtocol
 from ramses_tx.schemas import SZ_INBOUND, SZ_OUTBOUND
 from ramses_tx.transport.helpers import _str
@@ -95,9 +96,11 @@ async def test_regex_inbound_() -> None:
         rf.ports[0],
         config=GatewayConfig(
             disable_discovery=True,
-            disable_qos=False,
-            enforce_known_list=False,
-            use_regex={SZ_INBOUND: RULES_INBOUND},
+            engine=EngineConfig(
+                disable_qos=False,
+                enforce_known_list=False,
+                use_regex={SZ_INBOUND: RULES_INBOUND},
+            ),
         ),
     )
     ser_1 = serial.Serial(rf.ports[1])
@@ -126,9 +129,11 @@ async def test_regex_with_qos() -> None:
         rf.ports[0],
         config=GatewayConfig(
             disable_discovery=True,
-            disable_qos=False,
-            enforce_known_list=False,
-            use_regex=RULES_COMBINED,
+            engine=EngineConfig(
+                disable_qos=False,
+                enforce_known_list=False,
+                use_regex=RULES_COMBINED,
+            ),
         ),
     )
     ser_1 = serial.Serial(rf.ports[1])

--- a/tests/tests_rf/test_virt_network.py
+++ b/tests/tests_rf/test_virt_network.py
@@ -12,12 +12,14 @@ import serial
 
 from ramses_rf import Address, Code, Command, Gateway
 from ramses_rf.gateway import GatewayConfig
+from ramses_tx.config import EngineConfig
 from ramses_tx.transport.port import PortTransport
 from ramses_tx.typing import DeviceIdT
 from tests_rf.virtual_rf import VirtualRf, rf_factory
 
 # other constants
-ASSERT_CYCLE_TIME = 0.001  # max_cycles_per_assert = max_sleep / ASSERT_CYCLE_TIME
+# max_cycles_per_assert = max_sleep / ASSERT_CYCLE_TIME
+ASSERT_CYCLE_TIME = 0.001
 DEFAULT_MAX_SLEEP = 1
 
 
@@ -38,7 +40,7 @@ SCHEMA_1: dict[str, Any] = {
 }
 
 
-# ######################################################################################
+# #############################################################################
 
 
 async def assert_code_in_device_msgindex(
@@ -48,7 +50,9 @@ async def assert_code_in_device_msgindex(
     max_sleep: int = DEFAULT_MAX_SLEEP,
     test_not: bool = False,
 ) -> None:
-    """Fail if the device doesn't exist, or if it doesn't have the code in its msg_db."""
+    """Fail if the device doesn't exist, or if it doesn't have the code
+    in its msg_db.
+    """
 
     async def _has_code() -> bool:
         dev = gwy.device_registry.device_by_id.get(dev_id)
@@ -93,7 +97,9 @@ async def assert_devices(
 async def assert_this_pkt(
     transport: PortTransport, cmd: Command, max_sleep: int = DEFAULT_MAX_SLEEP
 ) -> None:
-    """Check, at the transport layer, that the current packet is as expected."""
+    """Check, at the transport layer, that the current packet is as
+    expected.
+    """
     for _ in range(int(max_sleep / ASSERT_CYCLE_TIME)):
         await asyncio.sleep(ASSERT_CYCLE_TIME)
         if transport._this_pkt and transport._this_pkt._frame == cmd._frame:
@@ -101,7 +107,7 @@ async def assert_this_pkt(
     assert transport._this_pkt and transport._this_pkt._frame == cmd._frame
 
 
-# ### TESTS ############################################################################
+# ### TESTS ###################################################################
 
 
 async def _test_virtual_rf_dev_disc(
@@ -121,7 +127,8 @@ async def _test_virtual_rf_dev_disc(
     await gwy_1.start()
     assert gwy_1._engine._protocol._transport
 
-    # NOTE: will pick up gwy 18:111111, since Foreign gwy detect has been removed
+    # NOTE: will pick up gwy 18:111111, since Foreign gwy detect has
+    # been removed
     await assert_devices(gwy_0, ["18:000000", "18:111111"])
     await assert_devices(gwy_1, ["18:111111"])
 
@@ -143,7 +150,8 @@ async def _test_virtual_rf_dev_disc(
     cmd = Command(" I --- 01:022222 --:------ 01:022222 1F09 003 0004B5")
     list(rf._port_to_object.values())[1].write(bytes(f"000 {cmd}\r\n".encode("ascii")))
 
-    # Fix: Reverted gwy_0 expected list to have 18:000000 since it is not receiving the injected packet
+    # Fix: Reverted gwy_0 expected list to have 18:000000 since it is
+    # not receiving the injected packet
     await assert_devices(gwy_0, ["01:010000", "01:011111", "18:000000", "18:111111"])
     await assert_devices(gwy_1, ["01:010000", "01:011111", "01:022222", "18:111111"])
 
@@ -175,7 +183,7 @@ async def _test_virtual_rf_pkt_flow(
     cmd = Command(" I --- 40:000000 --:------ 40:000000 22F1 003 000507")
     gwy_0.send_cmd(cmd, num_repeats=1)
 
-    # await assert_code_in_device_msgindex(gwy_0, "40:000000", Code._22F1)  # ?needs QoS
+    # await assert_code_in_device_msgindex(gwy_0, "40:000000", Code._22F1)
 
     await assert_this_pkt(gwy_0._engine._transport, cmd)
     await assert_this_pkt(gwy_1._engine._transport, cmd)
@@ -187,7 +195,9 @@ async def _test_virtual_rf_pkt_flow(
 # NOTE: does not use factory
 @pytest.mark.xdist_group(name="virt_serial")
 async def test_virtual_rf_dev_disc() -> None:
-    """Check the virtual RF network behaves as expected (device discovery)."""
+    """Check the virtual RF network behaves as expected (device
+    discovery).
+    """
 
     rf = VirtualRf(3)
 
@@ -195,12 +205,17 @@ async def test_virtual_rf_dev_disc() -> None:
     gwy_1: Gateway = None  # type: ignore[assignment]
 
     try:
+        gwy_config = GatewayConfig(
+            disable_discovery=GWY_CONFIG["disable_discovery"],
+            engine=EngineConfig(enforce_known_list=GWY_CONFIG["enforce_known_list"]),
+        )
+
         rf.set_gateway(rf.ports[0], "18:000000")
-        gwy_0 = Gateway(rf.ports[0], config=GatewayConfig(**GWY_CONFIG))
+        gwy_0 = Gateway(rf.ports[0], config=gwy_config)
         await assert_devices(gwy_0, [])
 
         rf.set_gateway(rf.ports[1], "18:111111")
-        gwy_1 = Gateway(rf.ports[1], config=GatewayConfig(**GWY_CONFIG))
+        gwy_1 = Gateway(rf.ports[1], config=gwy_config)
         await assert_devices(gwy_1, [])
 
         await _test_virtual_rf_dev_disc(rf, gwy_0, gwy_1)
@@ -229,7 +244,8 @@ async def test_virtual_rf_pkt_flow() -> None:
         )
 
         assert gwy_0._engine._protocol._transport
-        # NOTE: will pick up gwy 18:111111, since Foreign gwy detect has been removed
+        # NOTE: will pick up gwy 18:111111, since Foreign gwy detect has
+        # been removed
         await assert_devices(gwy_0, ["18:000000", "18:111111", "40:000000"])
 
         assert gwy_1._engine._protocol._transport

--- a/tests/tests_rf/virtual_rf/__init__.py
+++ b/tests/tests_rf/virtual_rf/__init__.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from ramses_rf import Gateway
 from ramses_rf.gateway import GatewayConfig
 from ramses_rf.schemas import SZ_CLASS, SZ_KNOWN_LIST
+from ramses_tx.config import EngineConfig
 
 from .const import MAX_NUM_PORTS, HgiFwTypes
 from .virtual_rf import VirtualRf
@@ -34,12 +35,13 @@ _DEFAULT_GWY_CONFIG = {
 def _get_hgi_id_for_schema(
     schema: dict[str, Any] | GatewayConfig, port_idx: int
 ) -> tuple[str, HgiFwTypes]:
-    """Return the Gateway's device_id for a schema (if required, construct an id).
+    """Return the Gateway's device_id for a schema (if required, construct
+    an id).
 
     Does not modify the schema.
 
-    Checks that only one Gateway is defined and ensures all 18: type devices
-    have an explicit HGI class trait.
+    Checks that only one Gateway is defined and ensures all 18: type
+    devices have an explicit HGI class trait.
     """
 
     if isinstance(schema, GatewayConfig):
@@ -72,13 +74,15 @@ def _get_hgi_id_for_schema(
 
 @patch("ramses_tx.transport.port.MIN_INTER_WRITE_GAP", MIN_INTER_WRITE_GAP)
 async def rf_factory(
-    schemas: list[dict[str, Any] | GatewayConfig | None], start_gwys: bool = True
+    schemas: list[dict[str, Any] | GatewayConfig | None],
+    start_gwys: bool = True,
 ) -> tuple[VirtualRf, list[Gateway]]:
-    """Return the virtual network corresponding to a list of gateway schema/configs.
+    """Return the virtual network corresponding to a list of gateway
+    schema/configs.
 
-    Each dict entry will consist of a standard gateway config/schema (or None). Any
-    serial port configs are ignored, and are instead allocated sequentially from the
-    virtual RF pool.
+    Each dict entry will consist of a standard gateway config/schema (or
+    None). Any serial port configs are ignored, and are instead allocated
+    sequentially from the virtual RF pool.
     """
 
     if len(schemas) > MAX_NUM_PORTS:
@@ -98,7 +102,7 @@ async def rf_factory(
 
         with patch("ramses_tx.discovery.comports", rf.comports):
             if isinstance(schema, GatewayConfig):
-                schema.hgi_id = hgi_id
+                schema.engine.hgi_id = hgi_id
                 gwy_config = schema
             else:
                 config_kwargs: dict[str, Any] = {}
@@ -117,21 +121,31 @@ async def rf_factory(
 
                 config_kwargs.update(schema_copy)
 
-                valid_keys = {f.name for f in fields(GatewayConfig)}
-                safe_kwargs = {
-                    k: v for k, v in config_kwargs.items() if k in valid_keys
-                }
-                safe_kwargs["hgi_id"] = hgi_id
+                valid_gwy_keys = {f.name for f in fields(GatewayConfig)}
+                valid_eng_keys = {f.name for f in fields(EngineConfig)}
 
-                gwy_config = GatewayConfig(**safe_kwargs)
+                gwy_kwargs: dict[str, Any] = {}
+                eng_kwargs: dict[str, Any] = {}
+
+                for k, v in config_kwargs.items():
+                    if k in valid_gwy_keys:
+                        gwy_kwargs[k] = v
+                    elif k in valid_eng_keys:
+                        eng_kwargs[k] = v
+
+                eng_kwargs["hgi_id"] = hgi_id
+
+                if eng_kwargs:
+                    gwy_kwargs["engine"] = EngineConfig(**eng_kwargs)
+
+                gwy_config = GatewayConfig(**gwy_kwargs)
 
             gwy = Gateway(rf.ports[idx], config=gwy_config)
 
             if start_gwys:
                 await gwy.start()
-                gwy._engine._disable_sending = (
-                    False  # allows Virtual RF to capture/reply
-                )
+                # allows Virtual RF to capture/reply
+                gwy._engine._disable_sending = False
 
             gwys.append(gwy)
 

--- a/tests/tests_tx/test_engine.py
+++ b/tests/tests_tx/test_engine.py
@@ -9,9 +9,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from ramses_tx.address import HGI_DEV_ADDR
+from ramses_tx.application_message import ApplicationMessage
 from ramses_tx.command import Command
 from ramses_tx.const import Code, Priority
-from ramses_tx.gateway import ApplicationMessage, Engine
+from ramses_tx.engine import Engine
 from ramses_tx.message import Message
 from ramses_tx.packet import Packet
 
@@ -97,7 +98,7 @@ async def test_engine_message_history_encapsulation(
 
 
 @pytest.mark.asyncio
-@patch("ramses_tx.gateway.transport_factory", new_callable=AsyncMock)
+@patch("ramses_tx.engine.transport_factory", new_callable=AsyncMock)
 async def test_engine_start_serial(
     mock_factory: AsyncMock, dummy_engine: Engine
 ) -> None:
@@ -113,7 +114,7 @@ async def test_engine_start_serial(
 
 
 @pytest.mark.asyncio
-@patch("ramses_tx.gateway.transport_factory", new_callable=AsyncMock)
+@patch("ramses_tx.engine.transport_factory", new_callable=AsyncMock)
 async def test_engine_start_file(mock_factory: AsyncMock) -> None:
     # Starting via file forces wait_for_connection_lost up to 86400 seconds
     engine = Engine(port_name=None, input_file="test.log")

--- a/tests/tests_tx/test_engine.py
+++ b/tests/tests_tx/test_engine.py
@@ -11,6 +11,7 @@ import pytest
 from ramses_tx.address import HGI_DEV_ADDR
 from ramses_tx.application_message import ApplicationMessage
 from ramses_tx.command import Command
+from ramses_tx.config import EngineConfig
 from ramses_tx.const import Code, Priority
 from ramses_tx.engine import Engine
 from ramses_tx.message import Message
@@ -27,14 +28,19 @@ def mock_packet() -> Packet:
 async def dummy_engine() -> Engine:
     # Create an async dummy engine instance configured to disable sending.
     # Being an async fixture ensures it binds to the current test's event loop.
-    return Engine(port_name="/dev/null", disable_sending=True)
+    return Engine(
+        config=EngineConfig(port_name="/dev/null", disable_sending=True),
+    )
 
 
 @pytest.mark.asyncio
 async def test_engine_init_missing_source_raises() -> None:
     # Initializing without port_name or input_file must raise TypeError
-    with pytest.raises(TypeError, match="Either a port_name or an input_file"):
-        Engine(port_name=None, input_file=None)
+    with pytest.raises(
+        TypeError,
+        match="Either a port_name or an input_file",
+    ):
+        Engine(config=EngineConfig(port_name=None, disable_sending=True))
 
 
 @pytest.mark.asyncio
@@ -42,7 +48,9 @@ async def test_engine_init_port_and_file_ignores_file(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     # Providing both should log a warning and ignore the file
-    engine = Engine(port_name="/dev/null", input_file="test.log")
+    engine = Engine(
+        config=EngineConfig(port_name="/dev/null", input_file="test.log"),
+    )
     assert "Port (/dev/null) specified, so file (test.log) ignored" in caplog.text
     assert engine._input_file is None
     assert engine.ser_name == "/dev/null"
@@ -51,10 +59,12 @@ async def test_engine_init_port_and_file_ignores_file(
 @pytest.mark.asyncio
 async def test_engine_str_representations() -> None:
     # Test __str__ correctly identifies the active HGI ID
-    engine_hgi = Engine(port_name="/dev/null", hgi_id="18:123456")
+    engine_hgi = Engine(
+        config=EngineConfig(port_name="/dev/null", hgi_id="18:123456"),
+    )
     assert str(engine_hgi) == "18:123456 (/dev/null)"
 
-    engine_no_hgi = Engine(port_name="/dev/null")
+    engine_no_hgi = Engine(config=EngineConfig(port_name="/dev/null"))
     assert str(engine_no_hgi) == f"{HGI_DEV_ADDR.id} (/dev/null)"
 
     engine_no_hgi._transport = MagicMock()
@@ -117,7 +127,9 @@ async def test_engine_start_serial(
 @patch("ramses_tx.engine.transport_factory", new_callable=AsyncMock)
 async def test_engine_start_file(mock_factory: AsyncMock) -> None:
     # Starting via file forces wait_for_connection_lost up to 86400 seconds
-    engine = Engine(port_name=None, input_file="test.log")
+    engine = Engine(
+        config=EngineConfig(port_name=None, input_file="test.log"),
+    )
     mock_transport = MagicMock()
     mock_factory.return_value = mock_transport
 
@@ -129,8 +141,10 @@ async def test_engine_start_file(mock_factory: AsyncMock) -> None:
 
 
 @pytest.mark.asyncio
-async def test_engine_stop_cleans_tasks_and_transport(dummy_engine: Engine) -> None:
-    # Tasks are correctly cancelled, transport is closed, and exceptions logged
+async def test_engine_stop_cleans_tasks_and_transport(
+    dummy_engine: Engine,
+) -> None:
+    # Tasks are correctly cancelled, transport is closed, exceptions logged
     async def dummy_coro() -> None:
         await asyncio.sleep(0.1)
 
@@ -169,7 +183,8 @@ async def test_engine_pause_resume(dummy_engine: Engine) -> None:
     await dummy_engine._pause("custom_arg")
     await asyncio.sleep(0)  # Yield to flush loop.call_soon callbacks
 
-    # Use cast to bypass Mypy's strict attribute narrowing across method calls
+    # Use cast to bypass Mypy's strict attribute narrowing across method
+    # calls
     assert cast(Any, dummy_engine._engine_state) is not None
     assert cast(Any, dummy_engine._disable_sending) is True
     dummy_engine._protocol.pause_writing.assert_called_once()
@@ -181,7 +196,8 @@ async def test_engine_pause_resume(dummy_engine: Engine) -> None:
     assert cast(Any, dummy_engine._engine_state) is None
     assert cast(Any, dummy_engine._disable_sending) is False
 
-    # Cast to list prevents Mypy comparison-overlap with `args` tuple type hint
+    # Cast to list prevents Mypy comparison-overlap with `args` tuple type
+    # hint
     assert list(args) == ["custom_arg"]
 
     dummy_engine._protocol.resume_writing.assert_called_once()
@@ -286,8 +302,11 @@ def test_application_message_expired_1f09_logic(mock_packet: Packet) -> None:
     assert app_msg._fraction_expired == 1.0
 
 
-def test_application_message_expired_lifespan_false(mock_packet: Packet) -> None:
-    # Packets specifically stating False for lifespan evaluate identically to CANT_EXPIRE
+def test_application_message_expired_lifespan_false(
+    mock_packet: Packet,
+) -> None:
+    # Packets specifically stating False for lifespan evaluate identically to
+    # CANT_EXPIRE
     mock_packet._lifespan = False
     app_msg = ApplicationMessage(mock_packet)
     app_msg.set_gateway(MagicMock())
@@ -297,7 +316,9 @@ def test_application_message_expired_lifespan_false(mock_packet: Packet) -> None
     assert app_msg._fraction_expired == ApplicationMessage.CANT_EXPIRE
 
 
-def test_application_message_expired_lifespan_true_raises(mock_packet: Packet) -> None:
+def test_application_message_expired_lifespan_true_raises(
+    mock_packet: Packet,
+) -> None:
     # Packets stating True for lifespan are not implemented yet
     mock_packet._lifespan = True
     app_msg = ApplicationMessage(mock_packet)
@@ -308,7 +329,9 @@ def test_application_message_expired_lifespan_true_raises(mock_packet: Packet) -
         _ = app_msg._expired
 
 
-def test_application_message_expired_standard_lifespan(mock_packet: Packet) -> None:
+def test_application_message_expired_standard_lifespan(
+    mock_packet: Packet,
+) -> None:
     # Lifespan durations are resolved based on standard td offsets
     mock_packet._lifespan = td(seconds=10)
     app_msg = ApplicationMessage(mock_packet)

--- a/tests/tests_tx/test_logger.py
+++ b/tests/tests_tx/test_logger.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from ramses_rf import Gateway, GatewayConfig
+from ramses_tx.config import EngineConfig
 from ramses_tx.logger import flush_packet_log
 from ramses_tx.packet import PKT_LOGGER
 
@@ -41,11 +42,13 @@ async def test_logging_lifecycle(tmp_path: Path) -> None:
     gwy = Gateway(
         None,
         config=GatewayConfig(
-            input_file=str(input_file),
-            packet_log={
-                "packet_log_path": str(tmp_path),
-                "packet_log_prefix": "packet",
-            },
+            engine=EngineConfig(
+                input_file=str(input_file),
+                packet_log={
+                    "packet_log_path": str(tmp_path),
+                    "packet_log_prefix": "packet",
+                },
+            ),
         ),
     )
     await gwy.start()
@@ -107,13 +110,15 @@ async def test_flight_recorder_auto_flush(tmp_path: Path) -> None:
     gwy = Gateway(
         None,
         config=GatewayConfig(
-            input_file=str(input_file),
-            packet_log={
-                "packet_log_path": str(tmp_path),
-                "packet_log_prefix": "flight_recorder_auto",
-                "buffer_capacity": 10,
-                "flush_level": logging.WARNING,  # Adjusted to pass PktLogFilter
-            },
+            engine=EngineConfig(
+                input_file=str(input_file),
+                packet_log={
+                    "packet_log_path": str(tmp_path),
+                    "packet_log_prefix": "flight_recorder_auto",
+                    "buffer_capacity": 10,
+                    "flush_level": logging.WARNING,  # Adjusted to pass PktLogFilter
+                },
+            ),
         ),
     )
     await gwy.start()
@@ -183,13 +188,15 @@ async def test_flight_recorder_manual_flush(tmp_path: Path) -> None:
     gwy = Gateway(
         None,
         config=GatewayConfig(
-            input_file=str(input_file),
-            packet_log={
-                "packet_log_path": str(tmp_path),
-                "packet_log_prefix": "flight_recorder_manual",
-                "buffer_capacity": 10,
-                "flush_level": logging.ERROR,
-            },
+            engine=EngineConfig(
+                input_file=str(input_file),
+                packet_log={
+                    "packet_log_path": str(tmp_path),
+                    "packet_log_prefix": "flight_recorder_manual",
+                    "buffer_capacity": 10,
+                    "flush_level": logging.ERROR,
+                },
+            ),
         ),
     )
     await gwy.start()
@@ -248,14 +255,16 @@ async def test_flight_recorder_time_flush(tmp_path: Path) -> None:
     gwy = Gateway(
         None,
         config=GatewayConfig(
-            input_file=str(input_file),
-            packet_log={
-                "packet_log_path": str(tmp_path),
-                "packet_log_prefix": "flight_recorder_time",
-                "buffer_capacity": 10,
-                "flush_level": logging.ERROR,
-                "flush_interval": 0.2,  # Flush every 200ms
-            },
+            engine=EngineConfig(
+                input_file=str(input_file),
+                packet_log={
+                    "packet_log_path": str(tmp_path),
+                    "packet_log_prefix": "flight_recorder_time",
+                    "buffer_capacity": 10,
+                    "flush_level": logging.ERROR,
+                    "flush_interval": 0.2,  # Flush every 200ms
+                },
+            ),
         ),
     )
     await gwy.start()

--- a/tests/tests_tx/test_message.py
+++ b/tests/tests_tx/test_message.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from ramses_tx.gateway import ApplicationMessage
+from ramses_tx.application_message import ApplicationMessage
 from ramses_tx.message import Message
 from ramses_tx.packet import Packet
 


### PR DESCRIPTION
### The Problem:
1. `src/ramses_tx/gateway.py` violated the Single Responsibility Principle by housing both the core `Engine` IO manager and the `ApplicationMessage` data structure.
2. Configuration was handled via a flat, untyped list of `**kwargs` passed into `Gateway.__init__`. This leaked Transport-layer concepts into the RF layer, broke encapsulation (e.g., `_config()` reaching into protected engine variables), and bypassed strict type-checking.
3. The engine boot sequence was out of order, starting the live RF engine before the historic cache was fully restored.

### Consequences:

If left unaddressed, this architectural debt would severely hinder future roadmap phases. The lack of strict configuration boundaries makes the codebase brittle, difficult to maintain, and prone to downstream `TypeError` crashes.

### The Fix:

Extracted the `Engine` and `ApplicationMessage` into dedicated files. Created a strict `EngineConfig` Data Transfer Object (DTO) in the Transport layer, which is now composed inside the `GatewayConfig` DTO in the RF layer. Reordered the gateway boot sequence and implemented a backward-compatibility shim for downstream consumers.

### Technical Implementation:
- **SRP Split:** Created `src/ramses_tx/engine.py` and `src/ramses_tx/application_message.py`, safely routing type hints with `TYPE_CHECKING` to prevent circular imports.
- **DTO Composition:** Created `src/ramses_tx/config.py`. Modified `ramses_rf.GatewayConfig` to accept `engine=EngineConfig(...)`.
- **Deprecation Adapter:** Updated `Gateway.__init__` to catch legacy `**kwargs` (used by Home Assistant / `ramses_cc`), map them natively into the new `EngineConfig` hierarchy, and emit a `DeprecationWarning` instead of crashing.
- **Boot Sequence:** Swapped `await self._engine.start()` to run *after* `await self._restore_cached_packets()` in `Gateway.start()`.
- **Test Alignment:** Refactored `helpers.py` and `conftest.py` to use `dataclasses.fields` to dynamically intercept flat test configuration variables and nest them into the correct DTOs.

### Testing Performed:
- Full local `pytest` suite execution (100% pass rate).
- Full `mypy --strict` validation (Zero errors across all modified files).
- Added `test_gateway_legacy_kwargs_deprecation` to explicitly test that legacy `**kwargs` from `ramses_cc` are successfully intercepted, mapped to the correct DTOs, and trigger the appropriate warning without failing.

### Risks of NOT Implementing:

Leaving the code as-is perpetuates the mixing of Transport and Application layers, making strict type safety impossible and acting as a structural blocker for subsequent refactoring phases (such as the Dispatcher/Parser overhauls).

### Risks of Implementing:

Downstream integrations (`ramses_cc`) utilizing deeply obscure or entirely unsupported kwargs during initialization might experience unexpected drops of those variables if they do not map to the known legacy keys.

### Mitigation Steps:

Implemented a highly robust Graceful Deprecation Pattern in `Gateway.__init__`. Known legacy kwargs (`disable_sending`, `hgi_id`, `packet_log`, etc.) are actively caught and re-routed to the new config objects. A clear log warning is emitted to instruct downstream maintainers on how to upgrade their initialization calls in future releases.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.
