### PR TITLE
Fix: Suppress `ProtocolSendFailed` in background tasks during gateway init

### DIFF
--- a/src/ramses_rf/system/schedule.py
+++ b/src/ramses_rf/system/schedule.py
@@ -25,6 +25,7 @@ from ramses_rf.const import (
 )
 from ramses_tx.command import Command
 from ramses_tx.const import SZ_CHANGE_COUNTER, Priority
+from ramses_tx.exceptions import ProtocolSendFailed
 from ramses_tx.message import Message
 from ramses_tx.packet import Packet
 
@@ -289,6 +290,14 @@ class Schedule:  # 0404
             raise exc.ScheduleFlowError(
                 f"Failed to obtain schedule within {timeout} secs"
             ) from err
+        except ProtocolSendFailed:
+            # Silently drop the background request if the transport is
+            # inactive (e.g., during cache restoration prior to gateway
+            # startup).
+            _LOGGER.debug(
+                f"{self}: Dropped request: gateway transport is inactive.",
+            )
+            return None
 
         return self.schedule
 

--- a/src/ramses_rf/system/zones.py
+++ b/src/ramses_rf/system/zones.py
@@ -49,7 +49,7 @@ from ramses_rf.schemas import (
 )
 from ramses_rf.topology import Child, Parent
 from ramses_tx import Address, Command, Message, Priority
-from ramses_tx.exceptions import ProtocolTimeoutError
+from ramses_tx.exceptions import ProtocolSendFailed, ProtocolTimeoutError
 from ramses_tx.typing import HeaderT, PayDictT, PayloadT
 
 from .schedule import InnerScheduleT, OuterScheduleT, Schedule
@@ -899,6 +899,13 @@ class Zone(ZoneSchedule):
             )
         except ProtocolTimeoutError as err:
             _LOGGER.warning(f"{self}: _get_temp timed out: {err}")
+            return None
+        except ProtocolSendFailed:
+            # Silently drop the request if the transport is inactive
+            # (e.g., during cache restoration prior to gateway startup).
+            _LOGGER.debug(
+                f"{self}: Dropped request: gateway transport is inactive.",
+            )
             return None
 
     async def reset_config(self) -> Packet:  # 000A


### PR DESCRIPTION
### The Problem:

During system startup, cached packets (like `30C9` syncs) are now loaded before the gateway transport is fully active. This triggers unawaited background tasks (`_get_temp` in `zones.py` and `get_schedule` in `schedule.py`) that attempt to transmit commands over an inactive radio, resulting in unhandled `ProtocolSendFailed` exceptions (References Issue #583).

### Consequences:

Because these background tasks are unawaited, the exceptions bubble all the way up to the Home Assistant event loop as "Task exception was never retrieved." This heavily spams the logs, stalls the event loop, and halts the zone setup process, leaving entities permanently "Unavailable" after a restart.

### The Fix:

Added targeted exception handling to the vulnerable background tasks to safely drop the requests if the radio transport is down.

### Technical Implementation:

Wrapped the `self._gwy.async_send_cmd` calls in `_get_temp` (`ramses_rf/system/zones.py`) and `get_schedule` (`ramses_rf/system/schedule.py`) with a `try/except ProtocolSendFailed` block. When caught, the task returns `None` and safely exits. A `_LOGGER.debug` call was added to track the dropped requests without spamming the user's primary HA logs.

### Testing Performed:
- Passed `mypy --strict`.
- Passed the full `pytest` suite.
- Logic verified against the asynchronous event-loop architecture to ensure safe background task termination.

### Risks of NOT Implementing:

Leaving this code as-is guarantees that users will continue to experience severe event loop saturation and broken zone initialization on every Home Assistant restart.

### Risks of Implementing:

If a persistent, non-transient `ProtocolSendFailed` error occurs later in the system's lifecycle, it will be caught by this block and dropped silently from the main logs, potentially masking a deeper hardware or connection issue from the user.

### Mitigation Steps:
- Added a `_LOGGER.debug` statement to ensure developers still have a paper trail to diagnose transport failures if a user submits a debug log.
- Relied on the naturally stateful, broadcast-heavy nature of the Evohome protocol; dropped syncs will automatically heal on the next periodic broadcast when the transport is active.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.