### PR TITLE
fix ramses_cc 254

### DIFF
--- a/src/ramses_tx/protocol/fsm.py
+++ b/src/ramses_tx/protocol/fsm.py
@@ -488,7 +488,13 @@ class WantEcho(ProtocolStateBase):
 
     def pkt_rcvd(self, pkt: Packet) -> None:
         """If the pkt is the expected Echo, transition to IsInIdle, or WantRply."""
-        assert self._sent_cmd is not None
+        if self._sent_cmd is None:
+            _LOGGER.debug(
+                "%s: received packet while _sent_cmd is None "
+                "(unsolicited broadcast?), ignoring",
+                self._context,
+            )
+            return
 
         try:
             pkt_hdr = pkt._hdr
@@ -555,8 +561,13 @@ class WantRply(ProtocolStateBase):
 
     def pkt_rcvd(self, pkt: Packet) -> None:
         """If the pkt is the expected reply, transition to IsInIdle."""
-        assert self._sent_cmd is not None
-        assert self._echo_pkt is not None
+        if self._sent_cmd is None or self._echo_pkt is None:
+            _LOGGER.debug(
+                "%s: received packet while _sent_cmd/_echo_pkt is None "
+                "(unsolicited broadcast?), ignoring",
+                self._context,
+            )
+            return
 
         try:
             pkt_hdr = pkt._hdr


### PR DESCRIPTION

fix(tx): gracefully handle _sent_cmd is None in WantEcho/WantRply pkt_rcvd

The assert self._sent_cmd is not None in WantEcho.pkt_rcvd and WantRply.pkt_rcvd crashes with AssertionError when an unsolicited broadcast packet arrives while the FSM state has been reset (e.g. after a timeout transition to IsInIdle, a late packet arrives before the state fully settles).

This is particularly common with HVAC devices (FANs) that broadcast unsolicited I packets (31D9, 31DA) every ~200ms. Each crash produces a full traceback and disrupts the HA event loop, causing significant slowdown under heavy packet traffic.

The fix replaces the asserts with a debug log + early return, matching the existing pattern in IsInIdle.pkt_rcvd which silently ignores unsolicited packets. This is the correct behaviour: if there is no sent command, there is nothing to match the packet against, so it should be ignored.

## Summary
- Replace `assert self._sent_cmd is not None` in `WantEcho.pkt_rcvd` and `WantRply.pkt_rcvd` with a debug log + early return
- Prevents AssertionError crashes when unsolicited broadcast packets arrive while the FSM state has been reset (e.g. after a timeout transition)
- Matches the existing pattern in `IsInIdle.pkt_rcvd` which silently ignores unsolicited packets
- Particularly impacts HVAC devices (FANs) that broadcast `I` packets (31D9, 31DA) every ~200ms, causing hundreds of tracebacks per minute and slowing down Home Assistant
 
Related issue: https://github.com/zxdavb/ramses_cc/issues/254

Error log:
2026-06-25 13:31:03.050 DEBUG (MainThread) [custom_components.ramses_extras.framework.helpers.transport_monitor] Message FROM 37:168270 not in tracked devices: {'32:153289'}
2026-06-25 13:31:03.051 DEBUG (MainThread) [custom_components.ramses_extras.framework.helpers.ramses_message_stream] Fired ramses_cc_message event: code=22F1 src=37:168270 verb= I
2026-06-25 13:31:03.054 DEBUG (SyncWorker_11) [custom_components.ramses_extras.framework.helpers.transport_monitor] _ensure_msg_handler: client unchanged, skipping
2026-06-25 13:31:03.052 ERROR (MainThread) [homeassistant] Error doing job: Exception in callback _BaseProtocol.pkt_received() (task: None)
Traceback (most recent call last):
File "/usr/local/lib/python3.14/asyncio/events.py", line 94, in _run
self._context.run(self._callback, *self._args)
~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.14/site-packages/ramses_tx/protocol/base.py", line 406, in pkt_received
self._pkt_received(pkt)
~~~~~~~~~~~~~~~~~~^^^^^
File "/usr/local/lib/python3.14/site-packages/ramses_tx/protocol/core.py", line 207, in _pkt_received
self._context.pkt_received(pkt)
~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
File "/usr/local/lib/python3.14/site-packages/ramses_tx/protocol/fsm.py", line 271, in pkt_received
self._state.pkt_rcvd(pkt)
~~~~~~~~~~~~~~~~~~~~^^^^^
File "/usr/local/lib/python3.14/site-packages/ramses_tx/protocol/fsm.py", line 491, in pkt_rcvd
assert self._sent_cmd is not None
^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
2026-06-25 13:31:03.212 DEBUG (MainThread) [custom_components.ramses_extras.framework.helpers.transport_monitor] _ensure_msg_handler: client unchanged, skipping
2026-06-25 13:31:03.212 DEBUG (MainThread) [custom_components.ramses_extras.framework.helpers.transport_monitor] Transport monitor received message: src=32:153289 dst=--:------ code=31D9
2026-06-25 13:31:03.213 DEBUG (MainThread) [custom_components.ramses_extras.framework.helpers.transport_monitor] Message FROM 32:153289 (TO --:------) - processing
2026-06-25 13:31:03.213 DEBUG (MainThread) [custom_components.ramses_extras.framework.helpers.transport_monitor] _ensure_msg_handler: client unchanged, skipping
2026-06-25 13:31:03.213 DEBUG (MainThread) [custom_components.ramses_extras.framework.helpers.transport_monitor] Device reply received from 32:153289, cancelled timeout and marked online
2026-06-25 13:31:03.213 DEBUG (MainThread) [custom_components.ramses_extras.framework.helpers.ramses_message_stream] Fired ramses_cc_message event: code=31D9 src=32:153289 verb= I
2026-06-25 13:31:03.216 DEBUG (SyncWorker_13) [custom_components.ramses_extras.framework.helpers.transport_monitor] _ensure_msg_handler: client unchanged, skipping
2026-06-25 13:31:03.216 DEBUG (SyncWorker_13) [custom_components.ramses_extras.framework.helpers.transport_monitor] Message FROM 32:153289 (TO --:------) - processing
2026-06-25 13:31:03.216 DEBUG (SyncWorker_13) [custom_components.ramses_extras.framework.helpers.transport_monitor] _ensure_msg_handler: client unchanged, skipping
2026-06-25 13:31:03.216 DEBUG (SyncWorker_13) [custom_components.ramses_extras.framework.helpers.transport_monitor] Device reply received from 32:153289, cancelled timeout and marked online
2026-06-25 13:31:03.214 ERROR (MainThread) [homeassistant] Error doing job: Exception in callback _BaseProtocol.pkt_received() (task: None)
Traceback (most recent call last):
File "/usr/local/lib/python3.14/asyncio/events.py", line 94, in _run
self._context.run(self._callback, *self._args)
~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.14/site-packages/ramses_tx/protocol/base.py", line 406, in pkt_received
self._pkt_received(pkt)
~~~~~~~~~~~~~~~~~~^^^^^
File "/usr/local/lib/python3.14/site-packages/ramses_tx/protocol/core.py", line 207, in _pkt_received
self._context.pkt_received(pkt)
~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
File "/usr/local/lib/python3.14/site-packages/ramses_tx/protocol/fsm.py", line 271, in pkt_received
self._state.pkt_rcvd(pkt)
~~~~~~~~~~~~~~~~~~~~^^^^^
File "/usr/local/lib/python3.14/site-packages/ramses_tx/protocol/fsm.py", line 491, in pkt_rcvd
assert self._sent_cmd is not None
^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
2026-06-25 13:31:03.328 DEBUG (MainThread)
