### PR TITLE
Fix race condition in fan_device class promotion

### DIFF
--- a/src/ramses_rf/devices/dev_registry.py
+++ b/src/ramses_rf/devices/dev_registry.py
@@ -58,6 +58,7 @@ class DeviceRegistry:
         self._device_factory_cb = device_factory_cb
         self.devices: list[Device] = []
         self.device_by_id: dict[DeviceIdT, Device] = {}
+        self._pending_promotions: dict[str, str] = {}
 
         # Temporal Process Manager Cache for Eavesdropping
         self._orphan_telemetry: dict[str, dict[str, Any]] = {}
@@ -242,10 +243,6 @@ class DeviceRegistry:
         if not event.device_id or not event.metadata:
             return
 
-        old_dev = self.device_by_id.get(event.device_id)
-        if not old_dev:
-            return
-
         new_class_slug_raw = str(event.metadata.get("device_class"))
         slug_map = {
             "HUM": "rh_sensor",
@@ -255,6 +252,15 @@ class DeviceRegistry:
         }
         dict_key = new_class_slug_raw.split(".")[-1]
         new_class_slug = slug_map.get(dict_key, new_class_slug_raw)
+
+        old_dev = self.device_by_id.get(event.device_id)
+        if not old_dev:
+            # Device doesn't exist yet — store the pending promotion so
+            # it can be applied when the device is created by instantiate_devices.
+            if not new_class_slug:
+                return
+            self._pending_promotions[event.device_id] = new_class_slug
+            return
 
         if not new_class_slug or getattr(old_dev, "_SLUG", None) == new_class_slug:
             return
@@ -479,9 +485,18 @@ class DeviceRegistry:
             )
             _traits_raw.pop("commands", None)
 
+            # Check for pending promotion from TopologyBuilder (the builder
+            # may emit a PROMOTE_CLASS event before the device is created)
+            pending_slug = self._pending_promotions.pop(device_id, None)
+            if pending_slug:
+                _traits_raw["class"] = pending_slug
+
             traits_dict: dict[str, Any] = SCH_TRAITS(
                 self._config.known_list.get(device_id, {})
             )
+            # Override with pending promotion if any
+            if pending_slug:
+                traits_dict["class"] = pending_slug
             traits = DeviceTraits.from_dict(traits_dict)
 
             try:


### PR DESCRIPTION
# Fix: Race condition in FAN device class promotion

## Problem

FAN devices (ventilation units) are not promoted to `HvacVentilator` on
their first observed packet, even when eavesdropping is enabled. This
prevents ramses_cc from creating sensor entities (CO2 level, fan speed,
humidity, temperatures, filter status, etc.) for the device — resulting
in "no values" for the user.

Reported in: https://github.com/wimpie70/ramses_extras/issues/88

## Root Cause

Race condition in the message processing flow in `gateway.py`:

1. `await self._topology_builder.consume(core_msg)` — TopologyBuilder
   evaluates rules and emits `PROMOTE_CLASS` events
2. `await process_msg(self, app_msg)` — calls `instantiate_devices()` which
   creates the device in the registry

The TopologyBuilder runs **before** the device is created. When
`_handle_promote_class` in `device/registry.py` processes the promotion
event:

```python
old_dev = self.device_by_id.get(event.device_id)
if not old_dev:
    return  # <-- silently skips, device doesn't exist yet
```

The promotion is silently dropped because the device hasn't been created yet.
On subsequent packets the device exists and promotion works — but FAN devices
that send `31DA` as their first observed packet (common for ventilation units
that broadcast status periodically) never get promoted on that first packet,
and ramses_cc's sensor setup may have already evaluated the device by then.

## Flow

```
31DA packet arrives
       |
       v
gateway.py: _topology_builder.consume(core_msg)          [1]
       |
       v
TopologyBuilder._evaluate_hvac_rules(msg)
       |
       v
_emit(PROMOTE_CLASS, device_id, FAN)
       |
       v
registry._handle_promote_class(event)
       |
       +-- device not in registry yet? --> return (BUG: silently dropped)
       |
       v
   (only works on 2nd+ packet when device already exists)
       |
       v
gateway.py: process_msg(app_msg)                          [2]
       |
       v
instantiate_devices(gwy, msg)
       |
       v
device created as DeviceHvac (base class, not promoted)
       |
       v
ramses_cc sensor setup
       |
       +-- DeviceHvac? --> hasattr(device, "co2_level") = False --> NO SENSORS
       |
       +-- HvacVentilator? --> hasattr(device, "co2_level") = True --> sensors created
```

`DeviceHvac` (base class) does not have `co2_level`, `exhaust_fan_speed`,
`indoor_humidity`, etc. as properties — only `HvacVentilator` does. So no
sensor entities are created.

## Fix

In `device/registry.py`, store pending promotions when the device doesn't
exist yet, and apply them when the device is created in `get_device()`:

```python
def _handle_promote_class(self, event):
    old_dev = self.device_by_id.get(event.device_id)
    if not old_dev:
        # Store for later application
        self._pending_promotions[event.device_id] = new_class_slug
        return
    # ... existing promotion logic

def get_device(self, device_id, ...):
    if not dev:
        # Check for pending promotion
        pending_slug = self._pending_promotions.pop(device_id, None)
        if pending_slug:
            traits_dict["class"] = pending_slug
        # ... create device with correct class
```

## User Workaround (confirms analysis)

Adding the FAN device to the ramses_cc known_list with
`{"class": "ventilator"}` manually creates it as `HvacVentilator`,
bypassing the race. Sensor values then appear correctly.

## Note on eavesdropping

This fix only addresses the race condition. Users with eavesdrop **disabled**
still need to add FAN devices to the known_list manually — eavesdrop-off
deliberately prevents automatic class promotion, and that boundary is
respected.
