### PR TITLE
Fix `10DO` RP regex 

### DIFF
--- a/src/ramses_rf/protocol/ramses.py
+++ b/src/ramses_rf/protocol/ramses.py
@@ -227,6 +227,7 @@ CODES_SCHEMA: dict[Code, CodeSchemaEntry] = {  # rf_unknown
         "name": "filter_change",
         " I": r"^00[0-9A-F]{6}(0000|FFFF)?$",
         "RQ": r"^00(00)?$",
+        "RP": r"^00[0-9A-F]{6}(0000|FFFF)?$",  # same structure as I_
         " W": r"^00FF$",
     },
     Code._10E0: {  # device_info


### PR DESCRIPTION
# Fix: 10D0 RP regex mismatch for fans with padding bytes

## Problem

The `10D0` (filter_change) RP regex was missing entirely, and the `I_` regex
allowed optional `0000|FFFF` padding that some fans also include in RP
responses. This caused strict validation to reject valid RP payloads from
certain ventilation units.

Reported by a user in: https://github.com/wimpie70/ramses_extras/issues/88

## User Payload Examples

The user's FAN device (`32:136723`, configured as `ventilator` in known_list)
sends the following `10D0` RP response:

```
RP --- 32:136723 29:123456 --:------ 10D0 006 005BB4650000
```

Payload breakdown:
```
00        = zone_idx
5B        = days_remaining (91)
B4        = days_lifetime (180)
65        = percent_remaining (101 -> 50.5%)
0000      = trailing padding
```

ramses_rf parses this correctly:
```
{'days_remaining': 91, 'days_lifetime': 180, 'percent_remaining': 0.505}
```

But the regex schema had no `"RP"` entry for `Code._10D0`, and the existing
`I_` pattern (`^00[0-9A-F]{6}(0000|FFFF)?$`) was the only one that matched.

## Fix

Added an `"RP"` pattern to `Code._10D0` matching the same structure as `I_`:

```python
Code._10D0: {  # filter_change
    "name": "filter_change",
    " I": r"^00[0-9A-F]{6}(0000|FFFF)?$",
    "RQ": r"^00(00)?$",
    "RP": r"^00[0-9A-F]{6}(0000|FFFF)?$",  # same structure as I_
    " W": r"^00FF$",
},
```

This accepts both 4-byte payloads (`005BB465`) and 6-byte payloads with
padding (`005BB4650000`).

## Verification

- User's payload `005BB4650000` matches the new RP pattern
- Short payload `005BB465` also matches
- All existing tests pass (4 pre-existing failures unrelated to this change)
