### PR TITLE
Fix: Resolve DTO dictionary boundary regressions (key mismatches and Enum leaks)

### DIFF
--- a/src/ramses_rf/devices/hvac_ventilators.py
+++ b/src/ramses_rf/devices/hvac_ventilators.py
@@ -885,6 +885,8 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
             SZ_FAN_MODE: await self.fan_mode(),
             SZ_FAN_RATE: await self.fan_rate(),
             SZ_FILTER_DIRTY: await self.filter_dirty(),
+            "filter_remaining": await self.filter_remaining(),
+            "filter_remaining_percent": await self.filter_remaining_percent(),
             SZ_FROST_CYCLE: await self.frost_cycle(),
             SZ_HAS_FAULT: await self.has_fault(),
             SZ_INDOOR_HUMIDITY: await self.indoor_humidity(),

--- a/src/ramses_rf/devices/hvac_ventilators.py
+++ b/src/ramses_rf/devices/hvac_ventilators.py
@@ -147,7 +147,8 @@ class FilterChange(DeviceHvac):  # FAN: 10D0
     async def filter_remaining(self) -> int | None:
         """Return the remaining days until filter change is needed.
 
-        :return: Number of days remaining until filter change, or None if not available
+        :return: Number of days remaining until filter change, or None if
+                 not available
         :rtype: int | None
         """
         return self.hvac_state.filter_remaining_days
@@ -155,7 +156,8 @@ class FilterChange(DeviceHvac):  # FAN: 10D0
     async def filter_remaining_percent(self) -> float | None:
         """Return the remaining filter life as a percentage.
 
-        :return: Percentage of filter life remaining (0-100), or None if not available
+        :return: Percentage of filter life remaining (0-100), or None if
+                 not available
         :rtype: float | None
         """
         return self.hvac_state.filter_remaining_percent
@@ -204,7 +206,8 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
     The cardinal codes are 31D9, 31DA.  Signature is RP/31DA.
 
     Also handles 2411 parameter messages for configuration.
-    Since 2411 is not supported by all vendors, discovery is used to determine if it is supported.
+    Since 2411 is not supported by all vendors, discovery is used to
+    determine if it is supported.
     Since more than 1 different parameters can be sent on 2411 messages,
     we process these in the dedicated _handle_2411_message method.
     """
@@ -255,13 +258,16 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         self._init_fan_state()
 
     def set_initialized_callback(self, callback: Callable[[], None] | None) -> None:
-        """Set a callback to be executed when the next message (any) is received.
+        """Set a callback to be executed when the next message (any) is
+        received.
 
-        The callback will be used exactly once to indicate that the device is fully functional.
-        In ramses_cc, 2411 entities are created - on the fly - only for devices that support them.
+        The callback will be used exactly once to indicate that the device
+        is fully functional. In ramses_cc, 2411 entities are created - on
+        the fly - only for devices that support them.
 
-        :param callback: A callable that takes no arguments and returns None.
-                         If None, any existing callback will be cleared.
+        :param callback: A callable that takes no arguments and returns
+                         None. If None, any existing callback will be
+                         cleared.
         :type callback: Callable[[], None] | None
         :raises ValueError: If the callback is not callable and not None
         """
@@ -295,17 +301,19 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
     ) -> None:
         """Set a callback to be called when 2411 parameters are updated.
 
-        This method registers a callback function that will be invoked whenever
-        a 2411 parameter is updated. The callback receives the parameter ID and
-        its new value as arguments.
+        This method registers a callback function that will be invoked
+        whenever a 2411 parameter is updated. The callback receives the
+        parameter ID and its new value as arguments.
 
-        Since 2411 parameters are configuration entities, we are not polling for them
-        and we update them immediately after receiving a 2411 message. We don't wait for them,
-        we only process when we see a 2411 response for our device. The request may have come
-        from another REM or DIS, but we will update to that as well.
+        Since 2411 parameters are configuration entities, we are not
+        polling for them and we update them immediately after receiving a
+        2411 message. We don't wait for them, we only process when we see
+        a 2411 response for our device. The request may have come from
+        another REM or DIS, but we will update to that as well.
 
-        :param callback: A callable that will be invoked with (param_id, value) when a
-                         2411 parameter is updated, or None to clear the current callback
+        :param callback: A callable that will be invoked with (param_id, value)
+                         when a 2411 parameter is updated, or None to clear
+                         the current callback
         :type callback: Callable[[str, Any], None] | None
         """
         self._param_update_callback = callback
@@ -380,15 +388,17 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
     def get_fan_param(self, param_id: str) -> float | None:
         """Retrieve a fan parameter value from the device's message store.
 
-        This wrapper method gets a specific parameter value for a FAN device stored in
-        _params_2411 dict. It first makes sure we use the proper param_id format
+        This wrapper method gets a specific parameter value for a FAN device
+        stored in _params_2411 dict. It first makes sure we use the proper
+        param_id format.
 
         :param param_id: The parameter ID to retrieve.
         :type param_id: str
         :return: The parameter value if found, None otherwise
         :rtype: float | None
         """
-        # Ensure param_id is uppercase and strip leading zeros for consistency
+        # Ensure param_id is uppercase and strip leading zeros for
+        # consistency with get_fan_param
         param_id = (
             str(param_id).upper().lstrip("0") or "0"
         )  # Handle case where param_id is "0"
@@ -421,7 +431,8 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
             _LOGGER.debug("Missing parameter ID or value in 2411 message: %s", msg)
             return
 
-        # Normalize param_id: uppercase and strip leading zeros for consistency with get_fan_param
+        # Normalize param_id: uppercase and strip leading zeros for
+        # consistency with get_fan_param
         param_id = str(param_id).upper().lstrip("0") or "0"
 
         # Mark that we support 2411 parameters
@@ -458,8 +469,8 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         handling for 2411 parameter messages. It updates the device state and
         triggers any necessary callbacks.
 
-        After handling the messages, it calls the initialized callback - if set - to notify that
-        the device was fully initialized.
+        After handling the messages, it calls the initialized callback - if set
+        - to notify that the device was fully initialized.
 
         :param msg: The incoming message to process
         :type msg: Message
@@ -495,9 +506,9 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
             delay=15,
         )  # to learn scheme: orcon/itho/other (04/07/0?)
 
-        # Add a single discovery command for all parameters (3F likely to be supported if any)
-        # The handler will process the response and update the appropriate parameter and
-        # also set the supports_2411 flag
+        # Add a single discovery command for all parameters (3F likely to be
+        # supported if any). The handler will process the response and update
+        # the appropriate parameter and also set the supports_2411 flag.
         _LOGGER.debug("Adding single discovery command for all 2411 parameters")
         self.discovery.add_cmd(
             Command.from_attrs(RQ, self.id, Code._2411, PayloadT("00003F")),
@@ -528,11 +539,13 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         """Add a bound device to this FAN.
 
         This method registers a REM or DIS device as bound to this FAN device.
-        Bound devices are required for certain operations like setting parameters.
+        Bound devices are required for certain operations like setting
+        parameters.
 
-        A bound device is needed to be able to send 2411 parameter Set messages,
-        or the device will not accept and respond to them.
-        In HomeAssistant, ramses_cc, you can set a bound device in the device configuration.
+        A bound device is needed to be able to send 2411 parameter Set
+        messages, or the device will not accept and respond to them.
+        In HomeAssistant, ramses_cc, you can set a bound device in the device
+        configuration.
 
         System schema and known devices example:
 
@@ -583,10 +596,12 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
     def get_bound_rem(self) -> str | None:
         """Get the first bound REM/DIS device ID for this FAN.
 
-        This method retrieves the device ID of the first bound REM or DIS device.
-        Bound devices are required for certain operations like setting parameters.
+        This method retrieves the device ID of the first bound REM or DIS
+        device. Bound devices are required for certain operations like setting
+        parameters.
 
-        :return: The device ID of the first bound REM or DIS device, or None if none found
+        :return: The device ID of the first bound REM or DIS device, or None
+                 if none found
         :rtype: str | None
         """
         if not self._bound_devices:
@@ -614,8 +629,9 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         :return: The sent packet.
         :raises CommandInvalid: If unable to determine a valid source ID.
         """
-        # 22F1 commands to a FAN typically must originate from a bound Remote (REM)
-        # We attempt to impersonate the first bound REM. If none exists, fallback to HGI.
+        # 22F1 commands to a FAN typically must originate from a bound Remote
+        # (REM). We attempt to impersonate the first bound REM. If none
+        # exists, fallback to HGI.
         src_id = self.get_bound_rem()
 
         if not src_id:
@@ -662,8 +678,11 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
 
     async def bypass_position(self) -> float | str | None:
         """
-        Position info is found in 22F7 and in 31DA. The most recent packet is returned.
-        :return: bypass position as percentage: 0.0 (closed) or 1.0 (open), on error: "x_faulted"
+        Position info is found in 22F7 and in 31DA. The most recent packet
+        is returned.
+
+        :return: bypass position as percentage: 0.0 (closed) or 1.0 (open),
+                 on error: "x_faulted"
         """
         return self.hvac_state.bypass_position
 
@@ -686,6 +705,7 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         """
         Some fans (Vasco, Itho) use Code._31D9 for speed + mode,
         Orcon sends SZ_EXHAUST_FAN_SPEED in 31DA. See parser for details.
+
         :return: speed as percentage
         """
         return self.hvac_state.exhaust_fan_speed
@@ -708,8 +728,8 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
 
     async def fan_rate(self) -> str | None:
         """
-        Lookup fan mode description from _22F4  message payload, e.g. "low", "medium", "boost".
-        For manufacturers Orcon, Vasco, ClimaRad.
+        Lookup fan mode description from _22F4 message payload, e.g. "low",
+        "medium", "boost". For manufacturers Orcon, Vasco, ClimaRad.
 
         :return: int or str describing rate of fan
         """
@@ -717,8 +737,8 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
 
     async def fan_mode(self) -> str | None:
         """
-        Lookup fan mode description from _22F4  message payload, e.g. "auto", "manual", "off".
-        For manufacturers Orcon, Vasco, ClimaRad.
+        Lookup fan mode description from _22F4 message payload, e.g. "auto",
+        "manual", "off". For manufacturers Orcon, Vasco, ClimaRad.
 
         :return: a string describing mode
         """
@@ -729,7 +749,8 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         Extract fan info description from MessageStore _31D9 or _31DA payload,
         e.g. "speed 2, medium".
         By its name, the result is picked up by a sensor in HA Climate UI.
-        Some manufacturers (Orcon, Vasco) include the fan mode (auto, manual), others don't (Itho).
+        Some manufacturers (Orcon, Vasco) include the fan mode (auto, manual),
+        others don't (Itho).
 
         :return: string describing fan mode, speed
         """
@@ -755,9 +776,11 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
     async def outdoor_humidity(self) -> float | None:
         """Return the outdoor relative humidity.
 
-        Handles special case for Ventura devices that send humidity data in 12A0 messages.
+        Handles special case for Ventura devices that send humidity data in
+        12A0 messages.
 
-        :return: The outdoor relative humidity as a percentage (0-100), or None if not available
+        :return: The outdoor relative humidity as a percentage (0-100),
+                 or None if not available
         :rtype: float | None
         """
         return self.hvac_state.outdoor_humidity
@@ -836,9 +859,11 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
     async def supply_temp(self) -> float | None:
         """Return the supply air temperature.
 
-        Handles special case for Ventura devices that send temperature data in 12A0 messages.
+        Handles special case for Ventura devices that send temperature data
+        in 12A0 messages.
 
-        :return: The supply air temperature in Celsius, or None if not available
+        :return: The supply air temperature in Celsius, or None if not
+                 available
         :rtype: float | None
         """
         return self.hvac_state.supply_temp
@@ -879,10 +904,24 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         }
 
         # Emulate the legacy behaviour by only exposing populated payload keys
-        return {
+        merged_status = {
             **base_status,
             **{k: v for k, v in cqrs_status.items() if v is not None},
         }
+
+        shim_status: dict[str, Any] = {}
+        for key, value in merged_status.items():
+            # Ensure Enums are serialised to strings to prevent leakage
+            k_str = str(getattr(key, "value", key))
+            v_clean = getattr(value, "value", value)
+
+            # Legacy shim: remap newer CQRS keys to legacy downstream keys
+            if k_str in ("indoor_temperature", "indoor_temp"):
+                k_str = "temperature"
+
+            shim_status[k_str] = v_clean
+
+        return shim_status
 
     async def temperature(self) -> float | None:  # Celsius
         """Return the current temperature in Celsius.

--- a/src/ramses_rf/models/state_base.py
+++ b/src/ramses_rf/models/state_base.py
@@ -40,13 +40,13 @@ class DeviceTraits:
         """
         result: dict[str, Any] = {}
         if self.device_class is not None:
-            result["class"] = self.device_class
+            result["class"] = getattr(self.device_class, "value", self.device_class)
         if self.alias is not None:
             result["alias"] = self.alias
         if self.faked is not None:
             result["faked"] = self.faked
         if self.scheme is not None:
-            result["scheme"] = self.scheme
+            result["scheme"] = getattr(self.scheme, "value", self.scheme)
         return result
 
 

--- a/tests/tests_rf/device/test_hvac_ventilator.py
+++ b/tests/tests_rf/device/test_hvac_ventilator.py
@@ -2,6 +2,8 @@
 """Unittests for the HvacVentilator class."""
 
 from collections.abc import Generator
+from enum import Enum
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -10,6 +12,8 @@ from ramses_rf import exceptions as exc
 from ramses_rf.const import DevType
 from ramses_rf.devices import HvacVentilator
 from ramses_rf.gateway import Gateway
+from ramses_rf.models.state_base import DeviceTraits
+from ramses_rf.models.state_hvac import HvacState
 from ramses_rf.state import MessageStore
 from ramses_tx import Address
 from ramses_tx.const import Code, Priority
@@ -694,3 +698,53 @@ async def test_set_fan_mode_no_src_id_raises() -> None:
         exc.CommandInvalid, match="Cannot set fan mode without a bound REM or HGI"
     ):
         await HvacVentilator.set_fan_mode(dev, "auto")
+
+
+class MockEnum(Enum):
+    """Mock enum to simulate boundary leakage."""
+
+    TEST_VAL = "active_fault"
+
+
+def test_device_traits_to_dict_unboxes_enums() -> None:
+    """Ensure DeviceTraits serialises Enums to raw strings for legacy APIs."""
+
+    # Arrange
+    traits = DeviceTraits(
+        device_class=cast(str, MockEnum.TEST_VAL),
+        scheme=cast(str, MockEnum.TEST_VAL),
+    )
+
+    # Act
+    result = traits.to_dict()
+
+    # Assert
+    assert result["class"] == "active_fault"
+    assert result["scheme"] == "active_fault"
+    assert not isinstance(result["class"], Enum)
+
+
+@pytest.mark.asyncio
+async def test_hvac_ventilator_status_dictionary_shim() -> None:
+    """Ensure the status dictionary remaps keys and unboxes Enums."""
+
+    # Arrange
+    mock_gwy = MagicMock()
+    mock_gwy.config.disable_discovery = True
+
+    ventilator = HvacVentilator(mock_gwy, Address("32:123456"))
+    ventilator.hvac_state = HvacState(
+        indoor_temp=21.5,
+        fan_mode=cast(str, MockEnum.TEST_VAL),
+    )
+
+    # Act
+    status_dict = await ventilator.status()
+
+    # Assert
+    assert "temperature" in status_dict
+    assert status_dict["temperature"] == 21.5
+    assert "indoor_temp" not in status_dict
+
+    assert status_dict["fan_mode"] == "active_fault"
+    assert not isinstance(status_dict["fan_mode"], Enum)


### PR DESCRIPTION
### The Problem:

Recent DTO refactoring caused regressions at the API boundary between `ramses_rf` and the Home Assistant integration (`ramses_cc`). Specifically, Enum objects are leaking into generated dictionary shims, and the legacy `temperature` key is incorrectly exposed as `indoor_temp` (Resolves [ramses_cc Issue 727](https://github.com/ramses-rf/ramses_cc/issues/727)).

### Consequences:

These boundary regressions result in silent sensor failures within Home Assistant (sensors fail to populate for the first 10 minutes or indefinitely) and cause consistent failures in the `ramses_cc` test suite due to JSON serialisation errors when processing Enum objects.

### The Fix:

Restored the legacy dictionary shim structure by explicitly remapping mismatched keys and safely unboxing Enums into standard Python strings before they cross the API boundary.

### Technical Implementation:
- Updated the dictionary build process in `HvacVentilator.status()` to intercept `indoor_temp` / `indoor_temperature` and explicitly remap it to `temperature`.
- Implemented dynamic duck-typing (`getattr(val, "value", val)`) in `DeviceTraits.to_dict()` and `HvacVentilator.status()` to safely extract string values from Enum objects without relying on complex type checking.

### Testing Performed:

Added strict Arrange-Act-Assert (AAA) unit tests in `test_hvac_ventilator.py` to verify that `DeviceTraits.to_dict()` correctly serialises Enums, and that `HvacVentilator.status()` successfully remaps keys and unboxes Enums within the output dictionary. All existing and new tests pass perfectly.

### Risks of NOT Implementing:

The `ramses_cc` integration will remain functionally broken for HVAC devices, preventing end-users from receiving critical telemetry, and upstream test suites will continue to fail.

### Risks of Implementing:

If downstream systems or undocumented third-party consumers expect actual Python Enum objects instead of standard strings, this coercion could cause unexpected type mismatch errors.

### Mitigation Steps:

Covered the critical translation paths with comprehensive unit tests. Utilised safe duck-typing (`getattr` with a fallback to the original value) so that if a standard string or integer is passed instead of an Enum, the code simply passes the original value safely without raising an `AttributeError`.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.

---
