### PR TITLE
fix: sliding-window reassembly buffer (#669)

### DIFF
--- a/src/ramses_rf/pipeline/reassembly.py
+++ b/src/ramses_rf/pipeline/reassembly.py
@@ -10,8 +10,42 @@ from ramses_tx.dtos import PacketDTO
 
 _LOGGER = logging.getLogger(__name__)
 
-_ARRAY_CODES: Final[tuple[str, ...]] = ("000A", "22C9")
+# Codes whose ``I`` packets are *always* array fragments at the L3 layer and
+# can therefore be safely buffered for reassembly using only (code, verb)
+# inspection -- the only metadata available to this module via PacketDTO.
+#
+# Audit of ramses_rf.protocol.ramses.CODES_WITH_ARRAYS (the authoritative
+# schema, which lists 0005/0009/000A/2309/30C9/2249/22C9/3150 plus the
+# special-cased 000C/1FC9) for issue #669:
+#
+#   - 000A, 22C9: safe.  Their ``I`` packets from a controller/UFC are arrays
+#     (a lone single-element ``I`` is an acceptable false negative, as noted
+#     in ramses_tx.frame.Frame._has_array).
+#   - 2309, 30C9: NOT safe to add here.  These routinely emit *single* zone
+#     packets (one zone's temperature) that must pass straight through.  The
+#     frame layer distinguishes array vs single via a payload-length multiple
+#     heuristic (Frame._has_array) that this module does not have access to.
+#   - 3150: NOT safe here for the same reason -- a single heat-demand packet
+#     is indistinguishable from a fragment without the length/domain check
+#     (and the UFC-only src.type guard) that lives in the frame layer.
+#   - 1FC9, 000C, 0005, 0009, 2249: special-cased or non-fragmenting here.
+#
+# Expanding this set to 2309/30C9/3150 correctly requires migrating the
+# Frame._has_array length heuristic into (or exposing it to) the reassembly
+# pipeline, which is part of the broader #608 schema migration.  Until then,
+# the conservative set below matches the legacy detect_array_fragment()
+# behaviour in dispatcher.py without introducing false buffering of routine
+# single-zone packets.  See issue #669.
+_ARRAY_CODES: Final[tuple[str, ...]] = (
+    "000A",
+    "22C9",
+)
 _VERB_I: Final[str] = " I"
+
+# A pending array is keyed by (src_id, code) so that an intervening packet
+# from a different source (or a different code) does not abort an in-flight
+# reassembly.  See issue #669 (sliding window buffer).
+_PendingKey = tuple[str, str]
 
 
 class ReassemblyBuffer:
@@ -19,6 +53,12 @@ class ReassemblyBuffer:
 
     Consumes raw PacketDTOs from the transport layer, buffers potential
     array fragments, and outputs unified PacketDTOs.
+
+    Unlike a single-slot buffer, this implementation maintains a *sliding
+    window* of pending arrays keyed by ``(src_id, code)``.  An unrelated
+    packet (RF noise, or a broadcast from a different device) that arrives
+    between two fragments of an array therefore passes straight through
+    without aborting the in-progress reassembly.
     """
 
     def __init__(
@@ -41,7 +81,7 @@ class ReassemblyBuffer:
         self._array_timeout = array_timeout
         self._task: asyncio.Task[None] | None = None
 
-        self._pending_dto: PacketDTO | None = None
+        self._pending: dict[_PendingKey, PacketDTO] = {}
 
     async def start(self) -> None:
         """Start the background consumer task."""
@@ -60,53 +100,76 @@ class ReassemblyBuffer:
         """Main asynchronous loop consuming the input queue."""
         while True:
             try:
-                # Wait for a packet, or timeout if we have a pending array
-                timeout = self._array_timeout if self._pending_dto else None
+                # Wait for a packet, or timeout if we have any pending arrays
+                timeout = self._array_timeout if self._pending else None
                 dto = await asyncio.wait_for(self._in_queue.get(), timeout=timeout)
                 await self._process_packet(dto)
                 self._in_queue.task_done()
 
             except TimeoutError:
-                # Timeout exceeded, flush the pending packet
-                if self._pending_dto:
-                    _LOGGER.warning(
-                        "%s < Array reassembly timeout (%ss): flushing "
-                        "incomplete multi-packet message",
-                        self._pending_dto.code,
-                        self._array_timeout,
-                    )
-                    await self._out_queue.put(self._pending_dto)
-                    self._pending_dto = None
+                # One or more pending arrays have exceeded their timeout:
+                # flush every stale pending packet in arrival-key order.
+                await self._flush_stale_pending()
+
+    async def _flush_stale_pending(self) -> None:
+        """Flush every pending array whose timeout has expired.
+
+        The loop's ``wait_for`` only times out when no packet has arrived
+        for ``array_timeout`` seconds, so every pending entry (which was
+        buffered at or before the most recently received packet) is stale
+        by definition when this is called.
+        """
+        # Snapshot the keys to avoid mutating the dict while iterating.
+        for key in list(self._pending):
+            pending = self._pending.pop(key, None)
+            if pending is None:
+                continue
+            _LOGGER.warning(
+                "%s < Array reassembly timeout (%ss): flushing "
+                "incomplete multi-packet message",
+                pending.code,
+                self._array_timeout,
+            )
+            await self._out_queue.put(pending)
 
     async def _process_packet(self, dto: PacketDTO) -> None:
         """Evaluate a packet for array stitching or passthrough.
 
+        A packet is matched against a pending array for the same
+        ``(src_id, code)``.  Unrelated packets (different source or code)
+        are passed straight through without disturbing any in-flight
+        reassembly.
+
         :param dto: The inbound packet to evaluate.
         :type dto: PacketDTO
         """
-        if self._pending_dto is None:
+        key: _PendingKey = (dto.addr1, dto.code)
+        pending = self._pending.get(key)
+
+        if pending is None:
             if self._is_potential_array_start(dto):
-                self._pending_dto = dto
+                self._pending[key] = dto
             else:
                 await self._out_queue.put(dto)
             return
 
-        if self._is_array_fragment(self._pending_dto, dto):
-            stitched_dto = self._stitch_dtos(self._pending_dto, dto)
+        if self._is_array_fragment(pending, dto):
+            stitched_dto = self._stitch_dtos(pending, dto)
             await self._out_queue.put(stitched_dto)
-            self._pending_dto = None
+            del self._pending[key]
         else:
-            # Flush the old pending dto and evaluate the new one
+            # The pending fragment for this key is not continued by `dto`:
+            # flush the stale pending packet and re-evaluate `dto` itself.
             _LOGGER.warning(
-                "%s < Array reassembly interrupted by %s: flushing "
+                "%s < Array reassembly interrupted for %s: flushing "
                 "incomplete multi-packet message",
-                self._pending_dto.code,
-                dto.code,
+                pending.code,
+                key,
             )
-            await self._out_queue.put(self._pending_dto)
-            self._pending_dto = None
+            await self._out_queue.put(pending)
+            del self._pending[key]
             if self._is_potential_array_start(dto):
-                self._pending_dto = dto
+                self._pending[key] = dto
             else:
                 await self._out_queue.put(dto)
 

--- a/tests/tests_rf/pipeline/test_reassembly.py
+++ b/tests/tests_rf/pipeline/test_reassembly.py
@@ -15,16 +15,23 @@ def base_time() -> dt:
     return dt(2026, 5, 15, 12, 0, 0, tzinfo=UTC)
 
 
-def create_dto(verb: str, code: str, payload: str, timestamp: dt) -> PacketDTO:
+def create_dto(
+    verb: str,
+    code: str,
+    payload: str,
+    timestamp: dt,
+    *,
+    addr1: str = "01:158182",
+) -> PacketDTO:
     """Helper to generate mock PacketDTOs for testing."""
     return PacketDTO(
         timestamp=timestamp,
         rssi="-70",
         verb=verb,
         seq="000",
-        addr1="01:158182",
+        addr1=addr1,
         addr2="--:------",
-        addr3="01:158182",
+        addr3=addr1,
         code=code,
         length=f"{len(payload) // 2:03d}",
         payload=payload,
@@ -108,30 +115,123 @@ async def test_timeout_flush(base_time: dt) -> None:
 
 
 @pytest.mark.asyncio
-async def test_interruption_flush(base_time: dt) -> None:
-    """Test that an unrelated packet flushes the buffer."""
+async def test_unrelated_packet_does_not_abort_reassembly(base_time: dt) -> None:
+    """An unrelated packet passes through without flushing a pending array.
+
+    This is the core sliding-window behaviour from issue #669: an intervening
+    packet (RF noise, or a broadcast from a different device/code) must NOT
+    abort an in-flight array reassembly.  The unrelated packet is emitted
+    immediately and the pending fragment is preserved for its matching peer.
+    """
     in_q: asyncio.Queue[PacketDTO] = asyncio.Queue()
     out_q: asyncio.Queue[PacketDTO] = asyncio.Queue()
     buffer = ReassemblyBuffer(in_q, out_q)
 
     await buffer.start()
 
-    # Send the first fragment
+    # Send the first fragment of a 000A array
     frag1 = create_dto(" I", "000A", "001201F4", base_time)
     await in_q.put(frag1)
 
-    # Send an unrelated packet immediately
-    unrelated = create_dto(" I", "30C9", "0001C8", base_time)
+    # The pending fragment is buffered, nothing emitted yet
+    assert out_q.empty()
+
+    # An unrelated 30C9 packet arrives between the two fragments
+    unrelated = create_dto(" I", "30C9", "0001C8", base_time + td(seconds=1))
     await in_q.put(unrelated)
 
-    # First, we should receive the flushed fragment
-    out_pkt_1 = await asyncio.wait_for(out_q.get(), timeout=1.0)
-    assert out_pkt_1.code == "000A"
-    assert out_pkt_1.payload == "001201F4"
+    # The unrelated packet passes straight through immediately...
+    out_pkt_unrelated = await asyncio.wait_for(out_q.get(), timeout=1.0)
+    assert out_pkt_unrelated.code == "30C9"
+    assert out_pkt_unrelated.payload == "0001C8"
 
-    # Next, we should receive the unrelated packet
-    out_pkt_2 = await asyncio.wait_for(out_q.get(), timeout=1.0)
-    assert out_pkt_2.code == "30C9"
-    assert out_pkt_2.payload == "0001C8"
+    # ...and the 000A fragment is STILL buffered (not flushed)
+    assert out_q.empty()
+
+    # The second 000A fragment now arrives and completes the array
+    frag2 = create_dto(" I", "000A", "081001F409C4", base_time + td(seconds=2))
+    await in_q.put(frag2)
+
+    out_pkt_stitched = await asyncio.wait_for(out_q.get(), timeout=1.0)
+    assert out_pkt_stitched.code == "000A"
+    assert out_pkt_stitched.payload == "001201F4081001F409C4"
+    assert out_pkt_stitched.length == "010"
+
+    await buffer.stop()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_arrays_from_different_sources(base_time: dt) -> None:
+    """Two arrays from different sources reassemble in parallel.
+
+    The sliding window keys pending arrays by (src_id, code), so fragments
+    from two distinct devices interleaved over the radio must each stitch
+    with their own peer rather than aborting one another.
+    """
+    in_q: asyncio.Queue[PacketDTO] = asyncio.Queue()
+    out_q: asyncio.Queue[PacketDTO] = asyncio.Queue()
+    buffer = ReassemblyBuffer(in_q, out_q)
+
+    await buffer.start()
+
+    # Device A starts an array
+    frag_a1 = create_dto(" I", "000A", "001201F4", base_time, addr1="01:158182")
+    await in_q.put(frag_a1)
+
+    # Device B starts an array (same code, different src) before A completes
+    frag_b1 = create_dto(
+        " I", "000A", "00AA00BB", base_time + td(seconds=1), addr1="01:223036"
+    )
+    await in_q.put(frag_b1)
+
+    # Neither is emitted yet: both are buffered concurrently
+    assert out_q.empty()
+
+    # Device A's second fragment arrives
+    frag_a2 = create_dto(
+        " I", "000A", "081001F409C4", base_time + td(seconds=2), addr1="01:158182"
+    )
+    await in_q.put(frag_a2)
+
+    out_a = await asyncio.wait_for(out_q.get(), timeout=1.0)
+    assert out_a.addr1 == "01:158182"
+    assert out_a.payload == "001201F4081001F409C4"
+
+    # Device B's second fragment arrives
+    frag_b2 = create_dto(
+        " I", "000A", "0810AABBCC", base_time + td(seconds=3), addr1="01:223036"
+    )
+    await in_q.put(frag_b2)
+
+    out_b = await asyncio.wait_for(out_q.get(), timeout=1.0)
+    assert out_b.addr1 == "01:223036"
+    assert out_b.payload == "00AA00BB0810AABBCC"
+
+    await buffer.stop()
+
+
+@pytest.mark.asyncio
+async def test_timeout_flushes_all_pending(base_time: dt) -> None:
+    """A timeout flushes every pending array, not just a single slot."""
+    in_q: asyncio.Queue[PacketDTO] = asyncio.Queue()
+    out_q: asyncio.Queue[PacketDTO] = asyncio.Queue()
+
+    buffer = ReassemblyBuffer(in_q, out_q, array_timeout=0.1)
+
+    await buffer.start()
+
+    # Two unrelated pending arrays from different sources
+    await in_q.put(create_dto(" I", "000A", "001201F4", base_time, addr1="01:158182"))
+    await in_q.put(create_dto(" I", "000A", "00AA00BB", base_time, addr1="01:223036"))
+
+    # Both should be flushed after the timeout
+    flushed: list[PacketDTO] = []
+    for _ in range(2):
+        flushed.append(await asyncio.wait_for(out_q.get(), timeout=0.5))
+
+    flushed_codes = sorted(p.addr1 for p in flushed)
+    assert flushed_codes == ["01:158182", "01:223036"]
+    for p in flushed:
+        assert p.code == "000A"
 
     await buffer.stop()


### PR DESCRIPTION
@PWhite-Eng, @silverailscolo  My assistants were a bit bored, so I gave them some extra jobs to do. Here's another attempt to clear the list. Have a look if it suits you.
see issue #669 

Replace the single-slot _pending_dto with a dict of pending arrays keyed by (src_id, code) so that an intervening packet (RF noise or a broadcast from an unrelated device) no longer aborts an in-flight array reassembly.

Previously, any unrelated packet arriving between fragment 1 and fragment 2 of a multi-packet array (000A/22C9) caused the buffer to flush the pending fragment and drop the array.  The sliding window lets unrelated packets pass straight through while preserving the pending array for its matching peer, and supports concurrent arrays from different sources.

Also documents the _ARRAY_CODES audit: 2309/30C9/3150 are intentionally NOT added because they routinely emit single (non-array) packets that are indistinguishable from fragments at the PacketDTO level -- reliably classifying them requires the Frame._has_array length heuristic that lives in the frame layer and is part of the broader #608 migration.

Adds noise-injection tests proving the sliding window, concurrent multi-source arrays, and multi-pending timeout flush.
