### PR TITLE
Fix Orcon `fan_info` sensor UI jitter by preventing `31D9` state collision

### DIFF
--- a/src/ramses_rf/parsers/hvac.py
+++ b/src/ramses_rf/parsers/hvac.py
@@ -998,10 +998,10 @@ def parser_31d9(payload: str, msg: Message) -> dict[str, Any]:
     # Orcon and Brofer long payloads provide accurate fan speed in 31DA.
     # Emitting exhaust_fan_speed here incorrectly converts mode bytes to speed.
     # Itho formats end with "00", whereas Orcon/Brofer formats end with "04" or "08".
-    _is_mode_only = (
-        len(payload) >= 34 and payload[8:32] == "20" * 12 and payload[32:34] != "00"
+    _has_exhaust_fan_speed = (
+        len(payload) < 34 or payload[8:32] != "20" * 12 or payload[32:34] == "00"
     )
-    if not _is_mode_only:
+    if _has_exhaust_fan_speed:
         result.update(parse_exhaust_fan_speed(payload[4:6]))  # for itho, nuaire
 
     # Fan Mode Lookup 1 for Vasco codes

--- a/src/ramses_rf/parsers/hvac.py
+++ b/src/ramses_rf/parsers/hvac.py
@@ -986,7 +986,6 @@ def parser_31d9(payload: str, msg: Message) -> dict[str, Any]:
 
     # NOTE: 31D9[4:6] is fan_speed (ClimaRad minibox, Itho) *or* fan_mode (Orcon, Vasco)
     result = {
-        **parse_exhaust_fan_speed(payload[4:6]),  # for itho
         SZ_FAN_MODE: payload[4:6],  # orcon, vasco/climarad
         "passive": bool(bitmap & 0x02),
         "damper_only": bool(bitmap & 0x04),  # i.e. valve only
@@ -995,6 +994,15 @@ def parser_31d9(payload: str, msg: Message) -> dict[str, Any]:
         SZ_HAS_FAULT: bool(bitmap & 0x80),
         "_flags": hex_to_flag8(payload[2:4]),
     }
+
+    # Orcon and Brofer long payloads provide accurate fan speed in 31DA.
+    # Emitting exhaust_fan_speed here incorrectly converts mode bytes to speed.
+    # Itho formats end with "00", whereas Orcon/Brofer formats end with "04" or "08".
+    _is_mode_only = (
+        len(payload) >= 34 and payload[8:32] == "20" * 12 and payload[32:34] != "00"
+    )
+    if not _is_mode_only:
+        result.update(parse_exhaust_fan_speed(payload[4:6]))  # for itho, nuaire
 
     # Fan Mode Lookup 1 for Vasco codes
     if msg.len == 3:  # usu: I -->20: (no seq#)

--- a/tests/tests/parsers/code_31d9.log
+++ b/tests/tests/parsers/code_31d9.log
@@ -62,4 +62,4 @@
 2024-12-01T00:00:00.000003 000  I --- 29:098458 --:------ 29:098458 31D9 003 000001 # {'hvac_id': '00', 'exhaust_fan_speed': 0.005, 'fan_mode': '1 (trickle)', 'passive': False, 'damper_only': False, 'filter_dirty': False, 'frost_cycle': False, 'has_fault': False, '_flags': [0, 0, 0, 0, 0, 0, 0, 0]}
 
 # Brofer HRU
-2026-04-08T02:43:50.003415 057  I 077 32:150621 --:------ 32:150621 31D9 017 000A020020202020202020202020202008  # {'hvac_id': '00', 'exhaust_fan_speed': 0.01, 'fan_mode': '02', 'passive': True, 'damper_only': False, 'filter_dirty': False, 'frost_cycle': False, 'has_fault': False, '_flags': [0, 0, 0, 0, 1, 0, 1, 0], '_unknown_3': '00', '_unknown_4': '202020202020202020202020', 'unknown_16': '08', 'seqx_num': '077'}
+2026-04-08T02:43:50.003415 057  I 077 32:150621 --:------ 32:150621 31D9 017 000A020020202020202020202020202008  # {'hvac_id': '00', 'fan_mode': '02', 'passive': True, 'damper_only': False, 'filter_dirty': False, 'frost_cycle': False, 'has_fault': False, '_flags': [0, 0, 0, 0, 1, 0, 1, 0], '_unknown_3': '00', '_unknown_4': '202020202020202020202020', 'unknown_16': '08', 'seqx_num': '077'}

--- a/tests/tests_rf/test_hvac.py
+++ b/tests/tests_rf/test_hvac.py
@@ -1,0 +1,24 @@
+"""Tests for HVAC payload parsers."""
+
+from unittest.mock import MagicMock
+
+from ramses_rf.messages import Message
+from ramses_rf.parsers.hvac import parser_31d9
+
+
+def test_parser_31d9_orcon_prevents_speed_collision() -> None:
+    # Arrange
+    # Simulated Orcon 31D9 payload with 12 bytes of space padding (0x20)
+    payload = "001A040020202020202020202020202008"
+    msg = MagicMock(spec=Message)
+    msg.len = 17
+    msg._addrs = ["32:123456", "32:123456", "32:123456"]
+
+    # Act
+    result = parser_31d9(payload, msg)
+
+    # Assert
+    # The exhaust_fan_speed key must be absent to prevent 31DA state collision
+    assert "exhaust_fan_speed" not in result
+    assert result.get("fan_mode") == "04"
+    assert result.get("unknown_16") == "08"


### PR DESCRIPTION
### The Problem:
Ramses_cc [Issue 723](https://github.com/ramses-rf/ramses_cc/issues/723) reports that the Orcon HRC-400-MaxComfort `fan_info` sensor ~rapidly~ toggles between a correct speed (e.g., 30%) and an incorrect speed (e.g., 2%), _especially when poll_interval in set below 200 seconds_.

### Consequences:
What happens if this isn't fixed is severe UI jitter, noisy Home Assistant logbooks, and unreliable state history for Orcon and Brofer HVAC units.

### The Fix:
Intercepted long-format Orcon and Brofer `31D9` packets to prevent the parser from mistakenly extracting `exhaust_fan_speed` from them, deferring to the `31DA` packet as the single source of truth for fan speed.

### Technical Implementation:
Added a strict signature check (`_is_mode_only`) to `src/ramses_rf/parsers/hvac.py`. If a `31D9` packet is >= 34 characters, is padded with exactly 12 bytes of `0x20`, and ends in a non-zero byte (like `04` or `08`), the parser safely bypasses the `parse_exhaust_fan_speed` mapping.

### Testing Performed:
Created `tests/tests_rf/test_hvac.py` with a dedicated test validating that `exhaust_fan_speed` is omitted from Orcon payloads. Updated legacy logs (`code_31d9.log`) to fix a historical false-positive on the Brofer HRU payload, and passed the full pytest suite.

### Risks of NOT Implementing:
Users with Orcon and Brofer systems will continue to experience chaotic UI behaviour, confusing dashboards, and database bloat in Home Assistant.

### Risks of Implementing:
There is a potential risk of regression in `31D9` parsing for other device types (e.g., Itho, Nuaire, and ClimaRad) if the signature detection is too broad and accidentally drops their fan speed data.

### Mitigation Steps:
The `_is_mode_only` check strictly requires a specific packet length, a 12-byte `0x20` padding signature, and a non-`00` trailing byte. This highly specific fingerprint effectively shields Itho, Nuaire, and ClimaRad packets from being affected by the bypass logic.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.