### PR TITLE
Refactor: Apply AAA testing pattern and line-length formatting to reassembly buffer

### DIFF
--- a/src/ramses_rf/pipeline/reassembly.py
+++ b/src/ramses_rf/pipeline/reassembly.py
@@ -10,41 +10,45 @@ from ramses_tx.dtos import PacketDTO
 
 _LOGGER = logging.getLogger(__name__)
 
-# Codes whose ``I`` packets are *always* array fragments at the L3 layer and
-# can therefore be safely buffered for reassembly using only (code, verb)
-# inspection -- the only metadata available to this module via PacketDTO.
+# Codes whose ``I`` packets are *always* array fragments at the L3 layer
+# and can therefore be safely buffered for reassembly using only (code,
+# verb) inspection -- the only metadata available to this module via
+# PacketDTO.
 #
-# Audit of ramses_rf.protocol.ramses.CODES_WITH_ARRAYS (the authoritative
-# schema, which lists 0005/0009/000A/2309/30C9/2249/22C9/3150 plus the
-# special-cased 000C/1FC9) for issue #669:
+# Audit of ramses_rf.protocol.ramses.CODES_WITH_ARRAYS (the
+# authoritative schema, which lists 0005/0009/000A/2309/30C9/2249/22C9/
+# 3150 plus the special-cased 000C/1FC9) for issue #669:
 #
-#   - 000A, 22C9: safe.  Their ``I`` packets from a controller/UFC are arrays
-#     (a lone single-element ``I`` is an acceptable false negative, as noted
-#     in ramses_tx.frame.Frame._has_array).
-#   - 2309, 30C9: NOT safe to add here.  These routinely emit *single* zone
-#     packets (one zone's temperature) that must pass straight through.  The
-#     frame layer distinguishes array vs single via a payload-length multiple
-#     heuristic (Frame._has_array) that this module does not have access to.
-#   - 3150: NOT safe here for the same reason -- a single heat-demand packet
-#     is indistinguishable from a fragment without the length/domain check
-#     (and the UFC-only src.type guard) that lives in the frame layer.
-#   - 1FC9, 000C, 0005, 0009, 2249: special-cased or non-fragmenting here.
+#   - 000A, 22C9: safe. Their ``I`` packets from a controller/UFC are
+#     arrays (a lone single-element ``I`` is an acceptable false
+#     negative, as noted in ramses_tx.frame.Frame._has_array).
+#   - 2309, 30C9: NOT safe to add here. These routinely emit *single*
+#     zone packets (one zone's temperature) that must pass straight
+#     through. The frame layer distinguishes array vs single via a
+#     payload-length multiple heuristic (Frame._has_array) that this
+#     module does not have access to.
+#   - 3150: NOT safe here for the same reason -- a single heat-demand
+#     packet is indistinguishable from a fragment without the
+#     length/domain check (and the UFC-only src.type guard) that lives
+#     in the frame layer.
+#   - 1FC9, 000C, 0005, 0009, 2249: special-cased or non-fragmenting
+#     here.
 #
 # Expanding this set to 2309/30C9/3150 correctly requires migrating the
-# Frame._has_array length heuristic into (or exposing it to) the reassembly
-# pipeline, which is part of the broader #608 schema migration.  Until then,
-# the conservative set below matches the legacy detect_array_fragment()
-# behaviour in dispatcher.py without introducing false buffering of routine
-# single-zone packets.  See issue #669.
+# Frame._has_array length heuristic into (or exposing it to) the
+# reassembly pipeline, which is part of the broader #608 schema
+# migration. Until then, the conservative set below matches the legacy
+# detect_array_fragment() behaviour in dispatcher.py without introducing
+# false buffering of routine single-zone packets. See issue #669.
 _ARRAY_CODES: Final[tuple[str, ...]] = (
     "000A",
     "22C9",
 )
 _VERB_I: Final[str] = " I"
 
-# A pending array is keyed by (src_id, code) so that an intervening packet
-# from a different source (or a different code) does not abort an in-flight
-# reassembly.  See issue #669 (sliding window buffer).
+# A pending array is keyed by (src_id, code) so that an intervening
+# packet from a different source (or a different code) does not abort
+# an in-flight reassembly. See issue #669 (sliding window buffer).
 _PendingKey = tuple[str, str]
 
 
@@ -54,11 +58,11 @@ class ReassemblyBuffer:
     Consumes raw PacketDTOs from the transport layer, buffers potential
     array fragments, and outputs unified PacketDTOs.
 
-    Unlike a single-slot buffer, this implementation maintains a *sliding
-    window* of pending arrays keyed by ``(src_id, code)``.  An unrelated
-    packet (RF noise, or a broadcast from a different device) that arrives
-    between two fragments of an array therefore passes straight through
-    without aborting the in-progress reassembly.
+    Unlike a single-slot buffer, this implementation maintains a
+    *sliding window* of pending arrays keyed by ``(src_id, code)``. An
+    unrelated packet (RF noise, or a broadcast from a different device)
+    that arrives between two fragments of an array therefore passes
+    straight through without aborting the in-progress reassembly.
     """
 
     def __init__(
@@ -100,7 +104,8 @@ class ReassemblyBuffer:
         """Main asynchronous loop consuming the input queue."""
         while True:
             try:
-                # Wait for a packet, or timeout if we have any pending arrays
+                # Wait for a packet, or timeout if we have any pending
+                # arrays
                 timeout = self._array_timeout if self._pending else None
                 dto = await asyncio.wait_for(self._in_queue.get(), timeout=timeout)
                 await self._process_packet(dto)
@@ -114,10 +119,10 @@ class ReassemblyBuffer:
     async def _flush_stale_pending(self) -> None:
         """Flush every pending array whose timeout has expired.
 
-        The loop's ``wait_for`` only times out when no packet has arrived
-        for ``array_timeout`` seconds, so every pending entry (which was
-        buffered at or before the most recently received packet) is stale
-        by definition when this is called.
+        The loop's ``wait_for`` only times out when no packet has
+        arrived for ``array_timeout`` seconds, so every pending entry
+        (which was buffered at or before the most recently received
+        packet) is stale by definition when this is called.
         """
         # Snapshot the keys to avoid mutating the dict while iterating.
         for key in list(self._pending):
@@ -136,7 +141,7 @@ class ReassemblyBuffer:
         """Evaluate a packet for array stitching or passthrough.
 
         A packet is matched against a pending array for the same
-        ``(src_id, code)``.  Unrelated packets (different source or code)
+        ``(src_id, code)``. Unrelated packets (different source or code)
         are passed straight through without disturbing any in-flight
         reassembly.
 
@@ -158,8 +163,9 @@ class ReassemblyBuffer:
             await self._out_queue.put(stitched_dto)
             del self._pending[key]
         else:
-            # The pending fragment for this key is not continued by `dto`:
-            # flush the stale pending packet and re-evaluate `dto` itself.
+            # The pending fragment for this key is not continued by
+            # `dto`: flush the stale pending packet and re-evaluate
+            # `dto` itself.
             _LOGGER.warning(
                 "%s < Array reassembly interrupted for %s: flushing "
                 "incomplete multi-packet message",

--- a/tests/tests_rf/pipeline/test_reassembly.py
+++ b/tests/tests_rf/pipeline/test_reassembly.py
@@ -41,18 +41,20 @@ def create_dto(
 @pytest.mark.asyncio
 async def test_passthrough_normal_packet(base_time: dt) -> None:
     """Test that a non-array packet passes through immediately."""
+    # Arrange
     in_q: asyncio.Queue[PacketDTO] = asyncio.Queue()
     out_q: asyncio.Queue[PacketDTO] = asyncio.Queue()
     buffer = ReassemblyBuffer(in_q, out_q)
-
     await buffer.start()
-
     # Send a normal temperature packet (30C9)
     normal_pkt = create_dto(" I", "30C9", "0001C8", base_time)
-    await in_q.put(normal_pkt)
 
-    # It should appear in the output queue immediately
+    # Act
+    await in_q.put(normal_pkt)
     out_pkt = await asyncio.wait_for(out_q.get(), timeout=1.0)
+
+    # Assert
+    # It should appear in the output queue immediately
     assert out_pkt.code == "30C9"
     assert out_pkt.payload == "0001C8"
 
@@ -62,26 +64,29 @@ async def test_passthrough_normal_packet(base_time: dt) -> None:
 @pytest.mark.asyncio
 async def test_successful_stitching(base_time: dt) -> None:
     """Test that two valid fragments are stitched into one."""
+    # Arrange
     in_q: asyncio.Queue[PacketDTO] = asyncio.Queue()
     out_q: asyncio.Queue[PacketDTO] = asyncio.Queue()
     buffer = ReassemblyBuffer(in_q, out_q)
-
     await buffer.start()
 
     # Send the first fragment (000A)
     frag1 = create_dto(" I", "000A", "001201F409C4", base_time)
-    await in_q.put(frag1)
-
-    # Assert it is buffered (queue remains empty)
-    assert out_q.empty()
-
     # Send the second fragment 1 second later
     time_2 = base_time + td(seconds=1)
     frag2 = create_dto(" I", "000A", "081001F409C4", time_2)
-    await in_q.put(frag2)
 
+    # Act
+    await in_q.put(frag1)
+    # Assert it is buffered (queue remains empty)
+    is_empty_after_frag1 = out_q.empty()
+
+    await in_q.put(frag2)
     # Receive the stitched packet
     out_pkt = await asyncio.wait_for(out_q.get(), timeout=1.0)
+
+    # Assert
+    assert is_empty_after_frag1 is True
     assert out_pkt.code == "000A"
     assert out_pkt.payload == "001201F409C4081001F409C4"
     assert out_pkt.length == "012"
@@ -93,21 +98,21 @@ async def test_successful_stitching(base_time: dt) -> None:
 @pytest.mark.asyncio
 async def test_timeout_flush(base_time: dt) -> None:
     """Test that a buffered packet is flushed if no fragment arrives."""
+    # Arrange
     in_q: asyncio.Queue[PacketDTO] = asyncio.Queue()
     out_q: asyncio.Queue[PacketDTO] = asyncio.Queue()
-
     # Inject a tiny 0.1s timeout for testing speed
     buffer = ReassemblyBuffer(in_q, out_q, array_timeout=0.1)
-
     await buffer.start()
-
     # Send the first fragment
     frag1 = create_dto(" I", "000A", "001201F4", base_time)
-    await in_q.put(frag1)
 
+    # Act
+    await in_q.put(frag1)
     # Wait just past our injected 0.1s timeout for the flush to happen
     out_pkt = await asyncio.wait_for(out_q.get(), timeout=0.2)
 
+    # Assert
     # We should get the unmodified original packet back
     assert out_pkt.payload == "001201F4"
 
@@ -115,44 +120,51 @@ async def test_timeout_flush(base_time: dt) -> None:
 
 
 @pytest.mark.asyncio
-async def test_unrelated_packet_does_not_abort_reassembly(base_time: dt) -> None:
+async def test_unrelated_packet_does_not_abort_reassembly(
+    base_time: dt,
+) -> None:
     """An unrelated packet passes through without flushing a pending array.
 
-    This is the core sliding-window behaviour from issue #669: an intervening
-    packet (RF noise, or a broadcast from a different device/code) must NOT
-    abort an in-flight array reassembly.  The unrelated packet is emitted
-    immediately and the pending fragment is preserved for its matching peer.
+    This is the core sliding-window behaviour from issue #669: an
+    intervening packet (RF noise, or a broadcast from a different
+    device/code) must NOT abort an in-flight array reassembly. The
+    unrelated packet is emitted immediately and the pending fragment is
+    preserved for its matching peer.
     """
+    # Arrange
     in_q: asyncio.Queue[PacketDTO] = asyncio.Queue()
     out_q: asyncio.Queue[PacketDTO] = asyncio.Queue()
     buffer = ReassemblyBuffer(in_q, out_q)
-
     await buffer.start()
 
     # Send the first fragment of a 000A array
     frag1 = create_dto(" I", "000A", "001201F4", base_time)
-    await in_q.put(frag1)
-
-    # The pending fragment is buffered, nothing emitted yet
-    assert out_q.empty()
-
     # An unrelated 30C9 packet arrives between the two fragments
     unrelated = create_dto(" I", "30C9", "0001C8", base_time + td(seconds=1))
-    await in_q.put(unrelated)
-
-    # The unrelated packet passes straight through immediately...
-    out_pkt_unrelated = await asyncio.wait_for(out_q.get(), timeout=1.0)
-    assert out_pkt_unrelated.code == "30C9"
-    assert out_pkt_unrelated.payload == "0001C8"
-
-    # ...and the 000A fragment is STILL buffered (not flushed)
-    assert out_q.empty()
-
     # The second 000A fragment now arrives and completes the array
     frag2 = create_dto(" I", "000A", "081001F409C4", base_time + td(seconds=2))
-    await in_q.put(frag2)
 
+    # Act
+    await in_q.put(frag1)
+    # The pending fragment is buffered, nothing emitted yet
+    is_empty_after_frag1 = out_q.empty()
+
+    await in_q.put(unrelated)
+    # The unrelated packet passes straight through immediately...
+    out_pkt_unrelated = await asyncio.wait_for(out_q.get(), timeout=1.0)
+    # ...and the 000A fragment is STILL buffered (not flushed)
+    is_empty_after_unrelated = out_q.empty()
+
+    await in_q.put(frag2)
     out_pkt_stitched = await asyncio.wait_for(out_q.get(), timeout=1.0)
+
+    # Assert
+    assert is_empty_after_frag1 is True
+
+    assert out_pkt_unrelated.code == "30C9"
+    assert out_pkt_unrelated.payload == "0001C8"
+    assert is_empty_after_unrelated is True
+
     assert out_pkt_stitched.code == "000A"
     assert out_pkt_stitched.payload == "001201F4081001F409C4"
     assert out_pkt_stitched.length == "010"
@@ -164,46 +176,49 @@ async def test_unrelated_packet_does_not_abort_reassembly(base_time: dt) -> None
 async def test_concurrent_arrays_from_different_sources(base_time: dt) -> None:
     """Two arrays from different sources reassemble in parallel.
 
-    The sliding window keys pending arrays by (src_id, code), so fragments
-    from two distinct devices interleaved over the radio must each stitch
-    with their own peer rather than aborting one another.
+    The sliding window keys pending arrays by (src_id, code), so
+    fragments from two distinct devices interleaved over the radio must
+    each stitch with their own peer rather than aborting one another.
     """
+    # Arrange
     in_q: asyncio.Queue[PacketDTO] = asyncio.Queue()
     out_q: asyncio.Queue[PacketDTO] = asyncio.Queue()
     buffer = ReassemblyBuffer(in_q, out_q)
-
     await buffer.start()
 
     # Device A starts an array
     frag_a1 = create_dto(" I", "000A", "001201F4", base_time, addr1="01:158182")
-    await in_q.put(frag_a1)
-
     # Device B starts an array (same code, different src) before A completes
     frag_b1 = create_dto(
         " I", "000A", "00AA00BB", base_time + td(seconds=1), addr1="01:223036"
     )
-    await in_q.put(frag_b1)
-
-    # Neither is emitted yet: both are buffered concurrently
-    assert out_q.empty()
-
     # Device A's second fragment arrives
     frag_a2 = create_dto(
         " I", "000A", "081001F409C4", base_time + td(seconds=2), addr1="01:158182"
     )
-    await in_q.put(frag_a2)
-
-    out_a = await asyncio.wait_for(out_q.get(), timeout=1.0)
-    assert out_a.addr1 == "01:158182"
-    assert out_a.payload == "001201F4081001F409C4"
-
     # Device B's second fragment arrives
     frag_b2 = create_dto(
         " I", "000A", "0810AABBCC", base_time + td(seconds=3), addr1="01:223036"
     )
-    await in_q.put(frag_b2)
 
+    # Act
+    await in_q.put(frag_a1)
+    await in_q.put(frag_b1)
+    # Neither is emitted yet: both are buffered concurrently
+    is_empty_after_first_frags = out_q.empty()
+
+    await in_q.put(frag_a2)
+    out_a = await asyncio.wait_for(out_q.get(), timeout=1.0)
+
+    await in_q.put(frag_b2)
     out_b = await asyncio.wait_for(out_q.get(), timeout=1.0)
+
+    # Assert
+    assert is_empty_after_first_frags is True
+
+    assert out_a.addr1 == "01:158182"
+    assert out_a.payload == "001201F4081001F409C4"
+
     assert out_b.addr1 == "01:223036"
     assert out_b.payload == "00AA00BB0810AABBCC"
 
@@ -213,22 +228,26 @@ async def test_concurrent_arrays_from_different_sources(base_time: dt) -> None:
 @pytest.mark.asyncio
 async def test_timeout_flushes_all_pending(base_time: dt) -> None:
     """A timeout flushes every pending array, not just a single slot."""
+    # Arrange
     in_q: asyncio.Queue[PacketDTO] = asyncio.Queue()
     out_q: asyncio.Queue[PacketDTO] = asyncio.Queue()
-
     buffer = ReassemblyBuffer(in_q, out_q, array_timeout=0.1)
-
     await buffer.start()
 
     # Two unrelated pending arrays from different sources
-    await in_q.put(create_dto(" I", "000A", "001201F4", base_time, addr1="01:158182"))
-    await in_q.put(create_dto(" I", "000A", "00AA00BB", base_time, addr1="01:223036"))
+    frag_a = create_dto(" I", "000A", "001201F4", base_time, addr1="01:158182")
+    frag_b = create_dto(" I", "000A", "00AA00BB", base_time, addr1="01:223036")
+
+    # Act
+    await in_q.put(frag_a)
+    await in_q.put(frag_b)
 
     # Both should be flushed after the timeout
     flushed: list[PacketDTO] = []
     for _ in range(2):
         flushed.append(await asyncio.wait_for(out_q.get(), timeout=0.5))
 
+    # Assert
     flushed_codes = sorted(p.addr1 for p in flushed)
     assert flushed_codes == ["01:158182", "01:223036"]
     for p in flushed:


### PR DESCRIPTION
### The Problem:

The recently merged sliding window buffer logic (PR #726 resolving Issue #669) introduced excellent technical implementations and detailed documentation. However, the new comments and docstrings exceeded the repository's strict maximum line-length limits (Issue #583). Furthermore, the newly added tests were logically sound but did not strictly adhere to our standardized Arrange, Act, Assert (AAA) structural pattern.

### Consequences:

Failing to maintain a standardized test structure makes the test suite harder to read and maintain over time. Exceeding line lengths breaks strict linter compliance and reduces readability in side-by-side diffs.

### The Fix:

Wrapped all extended comments to conform to our line-length limits and refactored the test suite to explicitly use the AAA pattern, without altering any underlying logic.

### Technical Implementation:
- Re-flowed block comments and docstrings in `src/ramses_rf/pipeline/reassembly.py` to be <= 72 characters.
- In `tests/tests_rf/pipeline/test_reassembly.py`, reorganised variable initialization, execution, and assertions into explicitly labelled `# Arrange`, `# Act`, and `# Assert` blocks.
- Preserved and relocated all original inline comments into their appropriate functional blocks.

### Testing Performed:

Ran the full pytest suite. All multi-packet array reassembly tests pass successfully, confirming zero logic regressions. Passed strict static analysis via `mypy --strict`.

### Risks of NOT Implementing:

Accumulation of formatting technical debt in the test suite and ongoing linter violations regarding maximum line lengths.

### Risks of Implementing:

Minimal. The core pipeline logic was intentionally untouched. The only theoretical risk is a typo introduced during text wrapping, though tests and static analysis confirm structural integrity.

### Mitigation Steps:

Full pytest run and `mypy --strict` execution confirmed no syntax, typing, or logical errors were introduced during the refactor.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.
