### PR TITLE
fix: Resolve silent discovery polling failure for device-level entities (#649)

### DIFF
--- a/src/ramses_rf/devices/dev_registry.py
+++ b/src/ramses_rf/devices/dev_registry.py
@@ -291,6 +291,7 @@ class DeviceRegistry:
             # Instantiate the new strict device class via the factory
             traits = DeviceTraits.from_dict(traits_dict)
             new_dev = self._device_factory_cb(old_dev.addr, None, traits)
+            new_dev._setup_discovery_cmds()
 
             # FORCE IT BACK IN: In case the factory doesn't auto-register
             if new_dev.id not in self.device_by_id:
@@ -493,6 +494,7 @@ class DeviceRegistry:
 
             try:
                 dev = self._device_factory_cb(Address(device_id), msg, traits)
+                dev._setup_discovery_cmds()
             except Exception as err:
                 _TRACE.error(f"FACTORY EXCEPTION: Failed creating {device_id}: {err}")
                 raise
@@ -676,6 +678,7 @@ class DeviceRegistry:
 
         # 2. Instantiate using the completely decoupled factory
         new_dev = self._device_factory_cb(old_dev.addr, None, traits)
+        new_dev._setup_discovery_cmds()
 
         # 3. Migrate CQRS Read-Model State
         if hasattr(old_dev, "temp_state") and hasattr(new_dev, "temp_state"):

--- a/tests/tests_rf/test_issue_649_polling.py
+++ b/tests/tests_rf/test_issue_649_polling.py
@@ -1,0 +1,44 @@
+"""TDD Test for Issue #649: Polling task never sending."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ramses_rf.address import Address
+from ramses_rf.devices.dev_registry import DeviceRegistry
+from ramses_rf.devices.hvac_ventilators import FilterChange
+from ramses_rf.discovery import DiscoveryService
+from ramses_rf.models import DeviceTraits
+
+
+@pytest.mark.asyncio
+async def test_issue_649_discovery_cmds_populated() -> None:
+    # Arrange
+    mock_gwy = MagicMock()
+    mock_gwy.config = MagicMock()
+    mock_gwy.config.disable_discovery = False
+    mock_gwy.config.known_list = {}  # <-- FIX: Use a real dict, not a MagicMock
+    mock_gwy.config.hgi_id = "18:000000"
+
+    def mock_factory(
+        addr: Address, msg: MagicMock, traits: DeviceTraits
+    ) -> FilterChange:
+        dev = FilterChange(mock_gwy, addr, traits=traits)
+        dev.discovery = DiscoveryService(dev, mock_gwy)
+        return dev
+
+    registry = DeviceRegistry(
+        device_filter=MagicMock(),
+        config=mock_gwy.config,
+        device_factory_cb=mock_factory,
+    )
+
+    # Act
+    dev = registry.get_device("32:111111")
+
+    # Assert
+    assert hasattr(dev, "discovery"), "Device missing discovery service"
+    assert dev.discovery.cmds, "Issue #649: Discovery cmds dictionary is empty"
+
+    scheduled_codes = [task["command"].code for task in dev.discovery.cmds.values()]
+    assert "10D0" in scheduled_codes, "10D0 filter poll not scheduled"


### PR DESCRIPTION
### The Problem:

As brilliantly identified by community member @wimpie70 in Issue #649, PR #466 introduced a regression by removing a lazy-evaluation property getter (`@property def discovery_cmds()`). This getter previously masked a lifecycle initialization step. Without it, device-level entities (like `FilterChange` and `HvacVentilator`) were never instructed to populate their discovery/polling command dictionaries, resulting in a silent infinite loop of nothingness.

### Consequences:

If left unfixed, background polling for affected sensors (such as the filter remaining days feature) fails silently. The system believes it is polling, but no actual RF commands are ever queued or transmitted.

### The Fix:

We have adopted wimpie70's recommended "Option B" (explicit initialisation). We injected an explicit lifecycle hook into the newly decoupled `DeviceRegistry` to command devices to populate their polling dictionaries immediately upon creation.

### Technical Implementation:
- **Registry Hook:** Appended `dev._setup_discovery_cmds()` directly after the `_device_factory_cb()` execution within `get_device()`, `_promote_device_class()`, and `_handle_promote_class()` in `src/ramses_rf/devices/dev_registry.py`.
- **Architectural Alignment:** This perfectly aligns with the Phase 2.8 CQRS refactoring goals, pushing state mutation out of lazy getters and into explicit, predictable factory initialization steps.

### Testing Performed:
- Authored `tests/tests_rf/test_issue_649_polling.py` using a Test-Driven Development (TDD) approach.
- The test mocks the gateway and instantiates a `FilterChange` (10D0) device via the registry factory, strictly asserting that `device.discovery.cmds` is populated and contains the target `10D0` Code.
- Ran the full 33,000+ `pytest` suite to guarantee zero regressions across other device types.

### Risks of NOT Implementing:

Device-level sensors will remain non-functional, and users will permanently lose access to battery, filter, and fault polling data that relies on the `DiscoveryService`.

### Risks of Implementing:

There is a minor theoretical risk of "double-adding" commands if a specific subclass attempts to manually trigger `_setup_discovery_cmds()` later in its lifecycle.

### Mitigation Steps:

This risk is entirely mitigated by the native `add_cmd()` method within `DiscoveryService`, which inherently deduplicates polling requests based on the packet `rx_header`. Mypy strict mode was also enforced to ensure no signature violations occurred during the registry update.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.
