### PR TITLE
Fix: Resolve nested Enum leakage and missing legacy keys in HVAC status shim

### DIFF
--- a/src/ramses_rf/devices/hvac_ventilators.py
+++ b/src/ramses_rf/devices/hvac_ventilators.py
@@ -413,9 +413,9 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
     def _handle_2411_message(self, msg: Message) -> None:
         """Handle incoming 2411 parameter messages.
 
-        This method processes 2411 parameter update messages, updates the device's
-        message store, and triggers any registered parameter update callbacks.
-        It handles parameter value normalization and validation.
+        This method processes 2411 parameter update messages, updates the
+        device's message store, and triggers any registered parameter update
+        callbacks. It handles parameter value normalization and validation.
 
         :param msg: The incoming 2411 message
         :type msg: Message to process
@@ -444,7 +444,8 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         if param_id == "75" and isinstance(param_value, (int, float)):
             param_value = round(float(param_value), 1)
         elif param_id in ("52", "95"):  # Percentage parameters
-            param_value = round(float(param_value), 3)  # Keep precision for percentages
+            # Keep precision for percentages
+            param_value = round(float(param_value), 3)
 
         # Store in params
         old_value = self.get_2411_param(param_id)
@@ -527,12 +528,16 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
             Code._22F8,  # Air quality base
         ):
             self.discovery.add_cmd(
-                Command.from_attrs(RQ, self.id, code, PayloadT("00")), 60 * 30, delay=15
+                Command.from_attrs(RQ, self.id, code, PayloadT("00")),
+                60 * 30,
+                delay=15,
             )
 
         for code in (Code._313E, Code._3222):
             self.discovery.add_cmd(
-                Command.from_attrs(RQ, self.id, code, PayloadT("00")), 60 * 30, delay=30
+                Command.from_attrs(RQ, self.id, code, PayloadT("00")),
+                60 * 30,
+                delay=30,
             )
 
     def add_bound_device(self, device_id: str, device_type: str) -> None:
@@ -625,7 +630,8 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
     async def set_fan_mode(self, fan_mode: str | int) -> Packet | None:
         """Set the operating mode/speed of the ventilator.
 
-        :param fan_mode: The desired fan mode (e.g., 'low', 'medium', 'high', 'boost').
+        :param fan_mode: The desired fan mode (e.g., 'low', 'medium', 'high',
+                         'boost').
         :return: The sent packet.
         :raises CommandInvalid: If unable to determine a valid source ID.
         """
@@ -643,7 +649,10 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
                 )
 
         _LOGGER.debug(
-            "Sending set_fan_mode '%s' to %s via src %s", fan_mode, self.id, src_id
+            "Sending set_fan_mode '%s' to %s via src %s",
+            fan_mode,
+            self.id,
+            src_id,
         )
 
         cmd = Command.set_fan_mode(self.id, fan_mode, src_id=src_id)
@@ -654,7 +663,8 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
     async def air_quality(self) -> float | None:
         """Return the current air quality measurement.
 
-        :return: The air quality measurement as a float, or None if not available
+        :return: The air quality measurement as a float, or None if not
+                 available
         :rtype: float | None
         """
         return self.hvac_state.air_quality
@@ -721,7 +731,8 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
     async def exhaust_temp(self) -> float | None:
         """Return the current exhaust air temperature.
 
-        :return: The exhaust air temperature in degrees Celsius, or None if not available
+        :return: The exhaust air temperature in degrees Celsius, or None if not
+                 available
         :rtype: float | None
         """
         return self.hvac_state.exhaust_temp
@@ -768,7 +779,8 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
     async def indoor_temp(self) -> float | None:
         """Return the current indoor temperature.
 
-        :return: The indoor temperature in degrees Celsius, or None if not available
+        :return: The indoor temperature in degrees Celsius, or None if not
+                 available
         :rtype: float | None
         """
         return self.hvac_state.indoor_temp
@@ -788,7 +800,8 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
     async def outdoor_temp(self) -> float | None:
         """Return the outdoor temperature in Celsius.
 
-        :return: The outdoor temperature in degrees Celsius, or None if not available
+        :return: The outdoor temperature in degrees Celsius, or None if not
+                 available
         :rtype: float | None
         """
         return self.hvac_state.outdoor_temp
@@ -820,7 +833,8 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
     async def request_fan_speed(self) -> float | None:
         """Return the requested fan speed.
 
-        :return: The requested fan speed as a percentage, or None if not available
+        :return: The requested fan speed as a percentage, or None if not
+                 available
         :rtype: float | None
         """
         return self.hvac_state.request_fan_speed
@@ -915,13 +929,18 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
         for key, value in merged_status.items():
             # Ensure Enums are serialised to strings to prevent leakage
             k_str = str(getattr(key, "value", key))
-            v_clean = getattr(value, "value", value)
 
-            # Legacy shim: remap newer CQRS keys to legacy downstream keys
-            if k_str in ("indoor_temperature", "indoor_temp"):
-                k_str = "temperature"
+            # Safely unbox lists containing Enums (e.g. speed_capabilities)
+            if isinstance(value, list):
+                v_clean = [getattr(item, "value", item) for item in value]
+            else:
+                v_clean = getattr(value, "value", value)
 
             shim_status[k_str] = v_clean
+
+            # Legacy shim: map newer CQRS keys back to legacy downstream keys
+            if k_str in ("indoor_temperature", "indoor_temp"):
+                shim_status["temperature"] = v_clean
 
         return shim_status
 
@@ -938,7 +957,8 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
     async def filter_dirty(self) -> bool | None:
         """Return the dirty filter diagnostic flag.
 
-        :return: True if the filter is dirty, False if clean, or None if unavailable.
+        :return: True if the filter is dirty, False if clean, or None if
+                 unavailable.
         :rtype: bool | None
         """
         return self.hvac_state.filter_dirty
@@ -946,7 +966,8 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
     async def frost_cycle(self) -> bool | None:
         """Return the frost cycle diagnostic flag.
 
-        :return: True if the frost cycle is active, False otherwise, or None if unavailable.
+        :return: True if the frost cycle is active, False otherwise, or None
+                 if unavailable.
         :rtype: bool | None
         """
         return self.hvac_state.frost_cycle
@@ -954,7 +975,8 @@ class HvacVentilator(FilterChange):  # FAN: RP/31DA, I/31D[9A], 2411
     async def has_fault(self) -> bool | None:
         """Return the hardware fault diagnostic flag.
 
-        :return: True if a fault is active, False otherwise, or None if unavailable.
+        :return: True if a fault is active, False otherwise, or None if
+                 unavailable.
         :rtype: bool | None
         """
         return self.hvac_state.has_fault

--- a/tests/tests_rf/device/test_hvac_ventilator.py
+++ b/tests/tests_rf/device/test_hvac_ventilator.py
@@ -726,7 +726,7 @@ def test_device_traits_to_dict_unboxes_enums() -> None:
 
 @pytest.mark.asyncio
 async def test_hvac_ventilator_status_dictionary_shim() -> None:
-    """Ensure the status dictionary remaps keys and unboxes Enums."""
+    """Ensure the status dictionary explicitly maintains legacy keys."""
 
     # Arrange
     mock_gwy = MagicMock()
@@ -744,7 +744,39 @@ async def test_hvac_ventilator_status_dictionary_shim() -> None:
     # Assert
     assert "temperature" in status_dict
     assert status_dict["temperature"] == 21.5
-    assert "indoor_temp" not in status_dict
+
+    # Bug A: indoor_temp is a primary key that Home Assistant expects.
+    # It must not be dropped when mapping to 'temperature'.
+    assert "indoor_temp" in status_dict
+    assert status_dict["indoor_temp"] == 21.5
 
     assert status_dict["fan_mode"] == "active_fault"
     assert not isinstance(status_dict["fan_mode"], Enum)
+
+
+@pytest.mark.asyncio
+async def test_hvac_ventilator_status_shim_unboxes_list_of_enums() -> None:
+    """Ensure the status shim safely unboxes lists containing Enums."""
+
+    # Arrange
+    mock_gwy = MagicMock()
+    mock_gwy.config.disable_discovery = True
+
+    ventilator = HvacVentilator(mock_gwy, Address("32:123456"))
+    ventilator.hvac_state = HvacState(
+        speed_capabilities=cast(list[str], [MockEnum.TEST_VAL, MockEnum.TEST_VAL])
+    )
+
+    # Act
+    status_dict = await ventilator.status()
+
+    # Assert
+    assert "speed_capabilities" in status_dict
+    capabilities = status_dict["speed_capabilities"]
+
+    # Bug B: speed_capabilities is a list of Enums. The duck-typing getattr()
+    # approach silently fails to unbox the items inside the list, causing JSON
+    # serialisation failures downstream.
+    assert isinstance(capabilities, list)
+    assert all(not isinstance(item, Enum) for item in capabilities)
+    assert capabilities[0] == "active_fault"


### PR DESCRIPTION
### The Problem:
Users running the master branch are experiencing silent sensor failures for HVAC devices (sensors remain as `None` or "unavailable") (References `ramses_cc` Issue #727). The recent dictionary shim introduced in PR #725 successfully unboxed top-level Enums but failed on two edge cases: it did not unbox Enums hidden inside lists (like `speed_capabilities`), and it destructively renamed `indoor_temp` to `temperature` rather than providing both.

### Consequences:
If this is not fixed, the Home Assistant integration (`ramses_cc`) will continue to silently fail for all HVAC devices. The un-serialisable Enum objects leaking through the boundary cause the Home Assistant state machine to reject the updates entirely.

### The Fix:
Updated the `HvacVentilator.status()` boundary shim to safely unbox nested Enums within lists and explicitly preserve legacy downstream dictionary keys alongside their modern CQRS mappings.

### Technical Implementation:
- Added an `isinstance(value, list)` evaluation within the `HvacVentilator.status()` dictionary loop to safely extract nested Enum values via list comprehension.
- Updated the legacy remapping logic to map `temperature` to the `indoor_temp` value without destructively deleting the original `indoor_temp` key.

### Testing Performed:
Updated `test_hvac_ventilator.py` with strict Arrange-Act-Assert (AAA) unit tests targeting the boundary shim:
1. `test_hvac_ventilator_status_dictionary_shim`: Verifies that `indoor_temp` survives the dictionary translation while still safely duplicating its value to the `temperature` key.
2. `test_hvac_ventilator_status_shim_unboxes_list_of_enums`: Verifies that lists containing Enums (e.g., `speed_capabilities`) are successfully unpacked into standard strings.

### Risks of NOT Implementing:
The `ramses_cc` integration will remain completely broken for HVAC devices on the master branch, leading to user confusion and failing upstream test suites.

### Risks of Implementing:
Minimal. This change only affects the formatting of the boundary shim layer and does not touch the core RF protocol or internal state management.

### Mitigation Steps:
Covered the translation edge-cases with comprehensive AAA unit tests to ensure `getattr` duck-typing handles lists and explicitly verifies the preservation of downstream keys.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.
