### PR TITLE
ci: Implement dual-workflow architecture for safe PR coverage comments

### DIFF
--- a/.github/workflows/check-cov.yml
+++ b/.github/workflows/check-cov.yml
@@ -22,23 +22,13 @@ on:
       "tests/**",
     ]
 
-  pull_request_target:
-    branches: [ "master" ]
-    paths: [
-      ".github/workflows/check-cov.yml",
-      "pyproject.toml",
-      "requirements/**",
-      "src/**.py",
-      "tests/**",
-    ]
-
   schedule:
     - cron: "0 7 * * 5"
 
   workflow_dispatch:
 
 permissions:
-  pull-requests: write
+  contents: read
 
 jobs:
   coverage:
@@ -91,14 +81,18 @@ jobs:
           output: both
           thresholds: '80 95'
 
-      - name: Add Pytest Coverage comment
-        # can only run on pr_target repository
-        if: github.event_name == 'pull_request_target'
-        uses: MishaKav/pytest-coverage-comment@v1
+      - name: Save PR number
+        if: github.event_name == 'pull_request'
+        run: echo ${{ github.event.pull_request.number }} > pr-number.txt
+
+      - name: Upload coverage artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
         with:
-          pytest-xml-coverage-path: ./coverage.xml
-          # custom settings
-          report-only-changed-files: true
-          remove-links-to-files: true
+          name: coverage-artifact
+          path: |
+            coverage.xml
+            pr-number.txt
+          overwrite: true
 
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/post-cov.yml
+++ b/.github/workflows/post-cov.yml
@@ -1,0 +1,47 @@
+name: Post Coverage Comment
+
+on:
+  workflow_run:
+    workflows: ["Coverage"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  post-comment:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Download coverage artifact
+        id: download
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: coverage-artifact
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read PR number
+        if: steps.download.outcome == 'success'
+        id: pr-number
+        run: echo "PR_NUMBER=$(cat pr-number.txt)" >> $GITHUB_ENV
+
+      - name: Add Pytest Coverage comment
+        if: steps.download.outcome == 'success'
+        # can only run on pr_target repository originally, now runs
+        # safely via artifact decoupling
+        uses: MishaKav/pytest-coverage-comment@v1
+        with:
+          pytest-xml-coverage-path: ./coverage.xml
+          issue-number: ${{ env.PR_NUMBER }}
+          # custom settings
+          report-only-changed-files: true
+          remove-links-to-files: true
+
+      - run: echo "🍏 This job's status is ${{ job.status }}."


### PR DESCRIPTION
### The Problem:

Currently, the `check-cov.yml` workflow contains duplicate triggers (`pull_request` and `pull_request_target`). This causes a "double execution" bug where two CI pipelines spin up simultaneously. The `pull_request_target` pipeline executes against the `master` branch instead of the incoming PR, meaning the coverage bot has been posting the metrics of the base branch rather than the actual PR code. (Resolves the architectural issue raised in [ramses_cc issue 726](https://github.com/ramses-rf/ramses_cc/issues/627)).

### Consequences:

Redundant CI runs wasting GitHub Actions minutes, confusing logs, inaccurate coverage reporting on PRs submitted from external forks, and potential false failures if `master` branch dependencies drift from the PR requirements.

### The Fix:

Eliminated the duplicate triggers and implemented a secure, decoupled dual-workflow architecture for coverage reporting.

### Technical Implementation:
- **Workflow A (Generator):** Stripped the `pull_request_target` trigger from `check-cov.yml`. It now strictly uses `pull_request` triggers with `contents: read` permissions, guaranteeing it safely tests the actual incoming PR code.
- **Artifact Bridge:** Configured `actions/upload-artifact@v7` to export the resulting `coverage.xml` alongside a newly generated `pr-number.txt` file to bridge the context.
- **Workflow B (Consumer):** Introduced a new `post-cov.yml` workflow, triggered by `workflow_run`. This runs in the trusted base repository context, downloads the data via `actions/download-artifact@v8`, reads the PR number, and securely posts the comment using elevated `pull-requests: write` permissions.

### Testing Performed:

Created a Draft PR to trigger the new pipeline. Verified the successful execution of the single coverage job and the secure generation of the `coverage-artifact.zip` containing the exact target PR number and correct XML schema.

### Risks of NOT Implementing:

Continued waste of CI resources running duplicate tests, persistent reporting of inaccurate code coverage metrics, and maintaining a workflow pattern flagged by GitHub as a potential security risk when handling fork code.

### Risks of Implementing:

The decoupled nature of `workflow_run` means the coverage bot comment will post asynchronously after the main checks complete, which is slightly different from the previous synchronous behaviour.

### Mitigation Steps:

Explicitly pinned the major versions of the artifact actions (`v7` and `v8`) to match the proven, existing configuration already safely operating in the `publish-hatch` workflow.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.  
