### PR TITLE
fix: align 10D0 field names between parser and CQRS dispatcher

### DIFF
--- a/src/ramses_rf/devices/dev_base.py
+++ b/src/ramses_rf/devices/dev_base.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     from ramses_rf.models import DeviceTraits
     from ramses_rf.systems import Evohome, Zone
     from ramses_tx.const import IndexT
+    from ramses_tx.dtos import PacketDTO
     from ramses_tx.typing import DeviceIdT
 
 
@@ -479,12 +480,14 @@ class HgiGateway(Device):  # HGI (18:)
 
     async def is_active(self) -> bool:
         """Return True if the gateway has received messages recently."""
-        msg: Message | None = getattr(self._gwy._engine, "_this_msg", None)
+        msg: PacketDTO | None = getattr(
+            getattr(self._gwy._engine, "_protocol", None), "_this_msg", None
+        )
 
-        if not msg or not hasattr(msg, "dtm"):
+        if not msg or not hasattr(msg, "timestamp"):
             return False
 
-        dtm: dt = msg.dtm
+        dtm: dt = msg.timestamp
         now = dt.now(UTC).astimezone(dtm.tzinfo) if dtm.tzinfo is not None else dt.now()
 
         # Compare against our new dynamic property

--- a/src/ramses_rf/dispatcher.py
+++ b/src/ramses_rf/dispatcher.py
@@ -522,10 +522,10 @@ def _update_hvac_state(target: Any, p: dict[str, Any], msg: Message) -> None:
             updates[f] = p[f]
 
     # Handle non-standard names passed by the semantic parsers
-    if "remaining_days" in p:
-        updates["filter_remaining_days"] = p["remaining_days"]
-    if "remaining_percent" in p:
-        updates["filter_remaining_percent"] = p["remaining_percent"]
+    if "days_remaining" in p:
+        updates["filter_remaining_days"] = p["days_remaining"]
+    if "percent_remaining" in p:
+        updates["filter_remaining_percent"] = p["percent_remaining"]
     if "minutes" in p and msg.code == Code._22F3:
         updates["boost_timer_mins"] = p["minutes"]
     if "req_speed" in p:

--- a/tests/tests_rf/device/test_base.py
+++ b/tests/tests_rf/device/test_base.py
@@ -30,7 +30,8 @@ def mock_gateway() -> MagicMock:
     gwy.config.tzinfo = None
     gwy.tzinfo = None
     gwy._engine = MagicMock()
-    gwy._engine._this_msg = None
+    gwy._engine._protocol = MagicMock()
+    gwy._engine._protocol._this_msg = None
     gwy._this_msg = None
     return gwy
 
@@ -146,7 +147,7 @@ class TestHgiGateway:
         :param hgi_gateway: The gateway fixture.
         :type hgi_gateway: HgiGateway
         """
-        hgi_gateway._gwy._engine._this_msg = None  # type: ignore[attr-defined]
+        hgi_gateway._gwy._engine._protocol._this_msg = None
         assert not await hgi_gateway.is_active()
 
     @pytest.mark.asyncio
@@ -157,9 +158,9 @@ class TestHgiGateway:
         :type hgi_gateway: HgiGateway
         """
         mock_msg = MagicMock()
-        mock_msg.dtm = dt.now(UTC)
+        mock_msg.timestamp = dt.now(UTC)
 
-        hgi_gateway._gwy._engine._this_msg = mock_msg  # type: ignore[attr-defined]
+        hgi_gateway._gwy._engine._protocol._this_msg = mock_msg
         assert await hgi_gateway.is_active()
 
     @pytest.mark.asyncio
@@ -172,9 +173,9 @@ class TestHgiGateway:
         """
         mock_msg = MagicMock()
         expired_dtm = dt.now(UTC) - (GATEWAY_MESSAGE_TIMEOUT + td(seconds=1))
-        mock_msg.dtm = expired_dtm
+        mock_msg.timestamp = expired_dtm
 
-        hgi_gateway._gwy._engine._this_msg = mock_msg  # type: ignore[attr-defined]
+        hgi_gateway._gwy._engine._protocol._this_msg = mock_msg
         assert not await hgi_gateway.is_active()
 
     @pytest.mark.asyncio
@@ -185,9 +186,9 @@ class TestHgiGateway:
         :type hgi_gateway: HgiGateway
         """
         mock_msg = MagicMock()
-        mock_msg.dtm = dt.now()
+        mock_msg.timestamp = dt.now()
 
-        hgi_gateway._gwy._engine._this_msg = mock_msg  # type: ignore[attr-defined]
+        hgi_gateway._gwy._engine._protocol._this_msg = mock_msg
         assert await hgi_gateway.is_active()
 
     def test_message_timeout_custom(self, hgi_gateway: HgiGateway) -> None:
@@ -215,7 +216,7 @@ class TestHgiGateway:
         # Create a timestamp 10 minutes in the past
         # Under the default 5-minute timeout, this would be inactive.
         # Under our custom 15-minute timeout, this must be active.
-        mock_msg.dtm = dt.now(UTC) - td(minutes=10)
+        mock_msg.timestamp = dt.now(UTC) - td(minutes=10)
 
-        hgi_gateway._gwy._engine._this_msg = mock_msg  # type: ignore[attr-defined]
+        hgi_gateway._gwy._engine._protocol._this_msg = mock_msg
         assert await hgi_gateway.is_active() is True


### PR DESCRIPTION
The 10D0 parser returns `days_remaining` and `percent_remaining` (from SZ_REMAINING_DAYS / SZ_REMAINING_PERCENT), but the CQRS ingestion engine in `_update_hvac_state` was checking for `remaining_days` and `remaining_percent`.  The field names didn't match, so filter_remaining data from 10D0 packets was silently dropped and never ingested into `hvac_state`.

Fix: update the dispatcher to check for the correct field names (`days_remaining`, `percent_remaining`) that the parser actually produces.

Fix 2: HgiGateway.is_active fix (accessing _protocol._this_msg + timestamp instead of _this_msg + dtm). 


This resolves the `filter_remaining_percent` not updating issue reported on PR #730.

https://github.com/ramses-rf/ramses_cc/pull/744 depends on this

@PWhite-Eng 