### PR TITLE
fix: filter null-marker values in HVAC state ingestion (#742 _cc)

### DIFF
--- a/src/ramses_rf/dispatcher.py
+++ b/src/ramses_rf/dispatcher.py
@@ -516,19 +516,36 @@ def _update_hvac_state(target: Any, p: dict[str, Any], msg: Message) -> None:
         "dewpoint_temp",
     ]
 
+    # Filter out null-marker values that 31DA/31D9 snapshots emit for
+    # sensors the device does not have.  Without this, every polling cycle
+    # (~10 min) overwrites good telemetry from 22F1/12A0/22F7 with null
+    # markers, causing sensors to bounce to None/FF/0.  See issue #742.
+    _NULL_HUMIDITY_FIELDS = frozenset({SZ_INDOOR_HUMIDITY, SZ_OUTDOOR_HUMIDITY})
+
     updates: dict[str, Any] = {}
     for f in fields:
-        if f in p:
-            updates[f] = p[f]
+        if f not in p:
+            continue
+        val = p[f]
+        # None = "not implemented" (e.g. EF in bypass_position)
+        if val is None:
+            continue
+        # "FF" = "no data" marker from 31D9 raw hex fan_mode
+        if f == SZ_FAN_MODE and val == "FF":
+            continue
+        # 0.0 for humidity = "no sensor" (00 parses as 0%, physically impossible)
+        if f in _NULL_HUMIDITY_FIELDS and val == 0:
+            continue
+        updates[f] = val
 
     # Handle non-standard names passed by the semantic parsers
-    if "days_remaining" in p:
+    if "days_remaining" in p and p["days_remaining"] is not None:
         updates["filter_remaining_days"] = p["days_remaining"]
-    if "percent_remaining" in p:
+    if "percent_remaining" in p and p["percent_remaining"] is not None:
         updates["filter_remaining_percent"] = p["percent_remaining"]
-    if "minutes" in p and msg.code == Code._22F3:
+    if "minutes" in p and msg.code == Code._22F3 and p["minutes"] is not None:
         updates["boost_timer_mins"] = p["minutes"]
-    if "req_speed" in p:
+    if "req_speed" in p and p["req_speed"] is not None:
         updates["request_fan_speed"] = p["req_speed"]
 
     if not updates:

--- a/src/ramses_rf/parsers/hvac.py
+++ b/src/ramses_rf/parsers/hvac.py
@@ -794,6 +794,7 @@ def parser_2411(payload: str, msg: Message) -> dict[str, Any]:
         "01": (2, centile),  # 52 (0.0-25.0) (%)
         "0F": (2, hex_to_percent),  # xx (0.0-1.0) (%)
         "10": (4, counter),  # 31 (0-1800) (days)
+        "13": (4, counter),  # 31 - ClimaRad Ventura filter time (variant)
         "20": (4, counter),  # 01 - Support parameter
         "90": (4, counter),  # 3E - Away mode Exhaust fan rate (%)
         "92": (4, hex_to_temp),  # 75 (0-30) (C)

--- a/tests/tests/test_parser_helpers.py
+++ b/tests/tests/test_parser_helpers.py
@@ -109,6 +109,29 @@ def test_22f1_vasco_directed_mode_max_06_still_vasco() -> None:
     assert result["fan_mode"] == "low"
 
 
+# --- 2411 parser data_type tests (issue #740) ---
+
+
+def test_2411_data_type_13_ventura_filter_time() -> None:
+    """2411 param 31 with data_type 13 (ClimaRad Ventura) must parse without warning.
+
+    The Ventura sends data_type 13 instead of 10 for the filter time parameter.
+    See issue #740.
+    """
+    msg = _make_22f1_msg(
+        "2026-06-26T22:08:35.885000 040 RP --- 32:022222 29:091138 --:------ 2411 022 "
+        "0000313E130000006400000000000075300000000164"
+    )
+    result = msg.payload
+    assert result["parameter"] == "31"
+    assert result["description"] == "Time to change filter (days)"
+    assert result["value"] == 100  # 0x00000064 = 100
+    assert result["min_value"] == 0
+    assert result["max_value"] == 30000  # 0x00007530
+    assert result["precision"] == 1
+    assert "_unknown_data_type" not in result
+
+
 def test_helper_demand_transform() -> None:
     assert [x[1] for x in TRANSFORMS] == [_transform(x[0]) for x in TRANSFORMS]
 

--- a/tests/tests_rf/test_dispatcher.py
+++ b/tests/tests_rf/test_dispatcher.py
@@ -9,8 +9,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from ramses_rf import Device, dispatcher
+from ramses_rf.const import (
+    SZ_BYPASS_POSITION,
+    SZ_FAN_MODE,
+    SZ_INDOOR_HUMIDITY,
+    Code,
+    DevType,
+)
 from ramses_rf.gateway import Gateway, GatewayConfig
 from ramses_rf.messages import Message
+from ramses_rf.models import HvacState
 from ramses_rf.state import MessageStore
 from ramses_tx import Address, DeviceIdT, Packet
 
@@ -266,3 +274,86 @@ class TestDispatcherHeartbeats:
         # which triggers mock_dev._handle_msg(msg) containing the
         # timestamp updates
         mock_gateway._engine._loop.call_soon.assert_any_call(mock_dev._handle_msg, msg)
+
+
+class TestHvacStateNullMarkerFiltering:
+    """Test that _update_hvac_state does not overwrite good state with
+    null-marker values from 31DA/31D9 snapshots.
+
+    See issue #742: HVAC sensors bounce to None/FF/0 every ~10 min because
+    31DA polling snapshots include "no sensor" values for unsupported sensors.
+    """
+
+    def _make_device(self) -> MagicMock:
+        """Create a mock HVAC device with a real HvacState."""
+        dev = MagicMock()
+        dev.id = "32:153289"
+        dev._SLUG = DevType.FAN
+        dev.hvac_state = HvacState()
+        dev.events = []
+        return dev
+
+    def _make_msg(self, code: Code, payload: dict) -> MagicMock:
+        """Create a mock message with the given code and payload."""
+        msg = MagicMock()
+        msg.code = code
+        msg.payload = payload
+        return msg
+
+    def test_none_bypass_position_does_not_overwrite_good_value(self) -> None:
+        """bypass_position=None (EF = not implemented) must not overwrite."""
+        dev = self._make_device()
+        dev.hvac_state = HvacState(bypass_position=0.5)
+
+        payload = {SZ_BYPASS_POSITION: None}
+        msg = self._make_msg(Code._31DA, payload)
+
+        dispatcher._update_hvac_state(dev, payload, msg)
+        assert dev.hvac_state.bypass_position == 0.5
+
+    def test_ff_fan_mode_does_not_overwrite_good_value(self) -> None:
+        """fan_mode='FF' (no data from 31D9) must not overwrite."""
+        dev = self._make_device()
+        dev.hvac_state = HvacState(fan_mode="low")
+
+        payload = {SZ_FAN_MODE: "FF"}
+        msg = self._make_msg(Code._31D9, payload)
+
+        dispatcher._update_hvac_state(dev, payload, msg)
+        assert dev.hvac_state.fan_mode == "low"
+
+    def test_zero_humidity_does_not_overwrite_good_value(self) -> None:
+        """indoor_humidity=0.0 (00 = no sensor) must not overwrite."""
+        dev = self._make_device()
+        dev.hvac_state = HvacState(indoor_humidity=0.55)
+
+        payload = {SZ_INDOOR_HUMIDITY: 0.0}
+        msg = self._make_msg(Code._31DA, payload)
+
+        dispatcher._update_hvac_state(dev, payload, msg)
+        assert dev.hvac_state.indoor_humidity == 0.55
+
+    def test_good_values_still_update(self) -> None:
+        """Normal (non-null-marker) values must still update the state."""
+        dev = self._make_device()
+        dev.hvac_state = HvacState(fan_mode="low", indoor_humidity=0.40)
+
+        payload = {SZ_FAN_MODE: "high", SZ_INDOOR_HUMIDITY: 0.55}
+        msg = self._make_msg(Code._22F1, payload)
+
+        dispatcher._update_hvac_state(dev, payload, msg)
+        assert dev.hvac_state.fan_mode == "high"
+        assert dev.hvac_state.indoor_humidity == 0.55
+
+    def test_null_markers_do_not_set_initial_state(self) -> None:
+        """Null markers must not set state from None to a null value."""
+        dev = self._make_device()
+        # All fields start as None
+
+        payload = {SZ_FAN_MODE: "FF", SZ_INDOOR_HUMIDITY: 0.0, SZ_BYPASS_POSITION: None}
+        msg = self._make_msg(Code._31DA, payload)
+
+        dispatcher._update_hvac_state(dev, payload, msg)
+        assert dev.hvac_state.fan_mode is None
+        assert dev.hvac_state.indoor_humidity is None
+        assert dev.hvac_state.bypass_position is None


### PR DESCRIPTION
The _update_hvac_state function (introduced in PR #649 ?) blindly copied all parsed fields into the device's hvac_state.  The 31DA snapshot message contains null markers for sensors the device does not have:
  - indoor_humidity: 0.0 (from "00" = no sensor)
  - bypass_position: None (from "EF" = not implemented)
  - fan_mode: "FF" (from 31D9 raw hex = no data)

Every polling cycle (~10 min) these null markers overwrote good telemetry from 22F1/12A0/22F7, causing sensors to bounce to None/FF/0.

Filter out null-marker values before updating state:
  - Skip None values (not implemented / no sensor)
  - Skip "FF" for fan_mode (no-data marker from 31D9)
  - Skip 0.0 for humidity fields (00 = no sensor, 0% is impossible)

- fixes issue https://github.com/ramses-rf/ramses_cc/issues/742

- fixes https://github.com/ramses-rf/ramses_cc/issues/740: Add data_type 13 to 2411 parser for ClimaRad Ventura