### PR TITLE
fix(hvac): map SZ_REQ_REASON to request_reason in dispatcher

### DIFF
--- a/src/ramses_rf/dispatcher.py
+++ b/src/ramses_rf/dispatcher.py
@@ -513,7 +513,6 @@ def _update_hvac_state(target: Any, p: dict[str, Any], msg: Message) -> None:
         SZ_FILTER_DIRTY,
         SZ_FROST_CYCLE,
         SZ_HAS_FAULT,
-        SZ_REQ_REASON,
         "dewpoint_temp",
     ]
 
@@ -548,6 +547,8 @@ def _update_hvac_state(target: Any, p: dict[str, Any], msg: Message) -> None:
         updates["boost_timer_mins"] = p[SZ_MINUTES]
     if "req_speed" in p and p["req_speed"] is not None:
         updates["request_fan_speed"] = p["req_speed"]
+    if SZ_REQ_REASON in p and p[SZ_REQ_REASON] is not None:
+        updates["request_reason"] = p[SZ_REQ_REASON]
 
     if not updates:
         return

--- a/tests/tests_rf/test_dispatcher.py
+++ b/tests/tests_rf/test_dispatcher.py
@@ -21,6 +21,7 @@ from ramses_rf.messages import Message
 from ramses_rf.models import HvacState
 from ramses_rf.state import MessageStore
 from ramses_tx import Address, DeviceIdT, Packet
+from ramses_tx.const import SZ_REQ_REASON
 
 
 @pytest.fixture
@@ -357,3 +358,96 @@ class TestHvacStateNullMarkerFiltering:
         assert dev.hvac_state.fan_mode is None
         assert dev.hvac_state.indoor_humidity is None
         assert dev.hvac_state.bypass_position is None
+
+    # --- req_reason → request_reason mapping (PR #745) ---
+
+    def test_req_reason_maps_to_request_reason(self) -> None:
+        """SZ_REQ_REASON (parser key 'req_reason') must map to
+        HvacState.request_reason, not be passed as 'req_reason'.
+
+        Regression test for the CQRS state extraction failure:
+            HvacState.__init__() got an unexpected keyword argument
+            'req_reason'
+        """
+        dev = self._make_device()
+
+        payload = {SZ_REQ_REASON: "HUM"}
+        msg = self._make_msg(Code._2210, payload)
+
+        dispatcher._update_hvac_state(dev, payload, msg)
+        assert dev.hvac_state.request_reason == "HUM"
+
+    def test_req_reason_co2(self) -> None:
+        """req_reason='CO2' (payload byte 02) must map to request_reason."""
+        dev = self._make_device()
+
+        payload = {SZ_REQ_REASON: "CO2"}
+        msg = self._make_msg(Code._2210, payload)
+
+        dispatcher._update_hvac_state(dev, payload, msg)
+        assert dev.hvac_state.request_reason == "CO2"
+
+    def test_req_reason_idle(self) -> None:
+        """req_reason='IDL' (payload byte 00) must map to request_reason."""
+        dev = self._make_device()
+
+        payload = {SZ_REQ_REASON: "IDL"}
+        msg = self._make_msg(Code._2210, payload)
+
+        dispatcher._update_hvac_state(dev, payload, msg)
+        assert dev.hvac_state.request_reason == "IDL"
+
+    def test_req_reason_does_not_overwrite_with_none(self) -> None:
+        """A None req_reason must not overwrite an existing request_reason."""
+        dev = self._make_device()
+        dev.hvac_state = HvacState(request_reason="HUM")
+
+        payload = {SZ_REQ_REASON: None}
+        msg = self._make_msg(Code._2210, payload)
+
+        dispatcher._update_hvac_state(dev, payload, msg)
+        assert dev.hvac_state.request_reason == "HUM"
+
+    def test_req_reason_with_other_fields(self) -> None:
+        """req_reason must update alongside other fields without error."""
+        dev = self._make_device()
+
+        payload = {SZ_REQ_REASON: "CO2", SZ_FAN_MODE: "high", SZ_INDOOR_HUMIDITY: 0.55}
+        msg = self._make_msg(Code._2210, payload)
+
+        dispatcher._update_hvac_state(dev, payload, msg)
+        assert dev.hvac_state.request_reason == "CO2"
+        assert dev.hvac_state.fan_mode == "high"
+        assert dev.hvac_state.indoor_humidity == 0.55
+
+    def test_req_reason_absent_does_not_clear(self) -> None:
+        """If req_reason is absent from the payload, request_reason must
+        not be touched."""
+        dev = self._make_device()
+        dev.hvac_state = HvacState(request_reason="HUM")
+
+        payload = {SZ_FAN_MODE: "low"}
+        msg = self._make_msg(Code._22F1, payload)
+
+        dispatcher._update_hvac_state(dev, payload, msg)
+        assert dev.hvac_state.request_reason == "HUM"
+        assert dev.hvac_state.fan_mode == "low"
+
+    def test_no_req_reason_error_raised(self) -> None:
+        """Ensure _update_hvac_state does not raise TypeError for
+        req_reason (the original bug).
+
+        Before the fix, SZ_REQ_REASON was in the fields list and was
+        passed directly as updates['req_reason'] to dataclasses.replace,
+        causing:
+            TypeError: HvacState.__init__() got an unexpected keyword
+            argument 'req_reason'
+        """
+        dev = self._make_device()
+
+        payload = {SZ_REQ_REASON: "HUM", SZ_FAN_MODE: "auto"}
+        msg = self._make_msg(Code._2210, payload)
+
+        # Must not raise
+        dispatcher._update_hvac_state(dev, payload, msg)
+        assert dev.hvac_state.request_reason == "HUM"


### PR DESCRIPTION
PR #743 fixed the req_reason → request_reason mapping in pipeline/ingestion.py (StateProjector) but missed the same bug in dispatcher.py's _update_hvac_state.

SZ_REQ_REASON was in the `fields` list, so it was passed directly as updates["req_reason"] to dataclasses.replace(), causing:

`HvacState.__init__()` got an unexpected keyword argument
  'req_reason'. Did you mean 'request_reason'?

This error fired on every 2210 packet, silently failing the entire hvac_state update (not just request_reason).

Fix: remove SZ_REQ_REASON from the `fields` list and add the proper translation: updates["request_reason"] = p[SZ_REQ_REASON], matching the pattern already used in pipeline/ingestion.py.

Complements ramses_cc PR #737 (SIGNAL_UPDATE timing fix) which defers entity updates until CQRS ingestion completes.  Both fixes are needed: this PR ensures the state is correctly updated, PR #737 ensures entities read it after the update.

Refs: ramses_cc#742, ramses_cc#749
Related: ramses_rf#743, ramses_cc#737

Relationship to other PRs/issues:

- Complements ramses_cc [PR 737](https://github.com/ramses-rf/ramses_cc/pull/737) (SIGNAL_UPDATE timing fix) which defers entity updates until CQRS ingestion completes. Both fixes are needed: this PR ensures the state is correctly updated, _cc [PR 737](https://github.com/ramses-rf/ramses_cc/pull/737) ensures entities read it after the update.

- Completes ramses_rf PR #743 which fixed the same mapping in the ingestion pipeline but missed the dispatcher.

Refs ramses_cc [issue 742](https://github.com/ramses-rf/ramses_cc/issues/742) (HVAC sensors bounce to None/FF) — the req_reason error was causing silent state update failures, contributing to stale/bouncing sensor values.

Refs ramses_cc [issue 749](https://github.com/ramses-rf/ramses_cc/issues/749) (original CQRS state extraction failure report).
Evidence from production logs

```
2026-06-28 14:11:15.976 ERROR (MainThread) [ramses_rf.pipeline.ingestion] CQRS state extraction failed for src 32:153289: HvacState.__init__() got an unexpected keyword argument 'req_reason'. Did you mean 'request_reason'?
2026-06-28 14:11:15.978 ERROR (MainThread) [ramses_rf.pipeline.ingestion] CQRS state extraction failed for dst 18:130236: HvacState.__init__() got an unexpected keyword argument 'req_reason'. Did you mean 'request_reason'?
```
This error repeats on every 2210 packet cycle.

## Test plan
- ramses_rf test suite passes (32552 passed, 1 pre-existing snapshot failure)
- ruff check passes
- Verified dataclasses.replace(HvacState(), request_reason="HUM") works correctly
- Test on dev HA with Orcon/Ventura — verify no more req_reason errors in logs
- Verify request_reason sensor/attribute updates correctly (IDL/CO2/HUM)
