### PR TITLE
Refactor: Phase 2.95 (F4.0-PR3) - The Reader Purge for Heating Controllers

### DIFF
--- a/src/ramses_rf/devices/heat_controllers.py
+++ b/src/ramses_rf/devices/heat_controllers.py
@@ -137,12 +137,6 @@ class UfhController(Parent, DeviceHeat):  # UFC (02):
 
     childs: list[Child]  # TODO: check (code so complex, not sure if this is true)
 
-    _setpoints: Message | None
-    _heat_demand: Message | None
-    _heat_demands: Message | None
-    _relay_demand: Message | None
-    _relay_demand_fa: Message | None
-
     # 12:27:24.398 067  I --- 02:000921 --:------ 01:191718 3150 002 0360
     # 12:27:24.546 068  I --- 02:000921 --:------ 01:191718 3150 002 065A
     # 12:27:24.693 067  I --- 02:000921 --:------ 01:191718 3150 002 045C
@@ -158,11 +152,6 @@ class UfhController(Parent, DeviceHeat):  # UFC (02):
     def _init_ufh_state(self) -> None:
         """Initialize UFH-specific instance attributes (idempotent)."""
         self.__dict__.setdefault("circuit_by_id", {f"{i:02X}": {} for i in range(8)})
-        self.__dict__.setdefault("_setpoints", None)
-        self.__dict__.setdefault("_heat_demand", None)
-        self.__dict__.setdefault("_heat_demands", None)
-        self.__dict__.setdefault("_relay_demand", None)
-        self.__dict__.setdefault("_relay_demand_fa", None)
 
     def _post_class_promote(self) -> None:
         """Initialize UFH state when promoted in-place from a generic device."""
@@ -221,9 +210,9 @@ class UfhController(Parent, DeviceHeat):  # UFC (02):
 
         elif msg.code == Code._0008:  # relay_demand
             if msg.payload.get(SZ_DOMAIN_ID) == FC:
-                self._relay_demand = msg
+                pass
             else:  # FA
-                self._relay_demand_fa = msg
+                pass
 
         elif msg.code == Code._000C:  # zone_devices
             # {'zone_type': '09', 'ufh_idx': '00', 'zone_idx': '09', 'device_role': 'ufh_actuator', 'devices':['01:095421']}
@@ -244,13 +233,13 @@ class UfhController(Parent, DeviceHeat):  # UFC (02):
         elif msg.code == Code._22C9:  # setpoint_bounds
             # .I --- 02:017205 --:------ 02:017205 22C9 024 00076C0A280101076C0A28010...
             # .I --- 02:017205 --:------ 02:017205 22C9 006 04076C0A2801
-            self._setpoints = msg
+            pass
 
         elif msg.code == Code._3150:  # heat_demands
             if isinstance(msg.payload, list):  # the circuit demands
-                self._heat_demands = msg
+                pass
             elif msg.payload.get(SZ_DOMAIN_ID) == FC:
-                self._heat_demand = msg
+                pass
             else:
                 zone_idx = msg.payload.get(SZ_ZONE_IDX)
                 msg_dst_tcs = getattr(msg.dst, "tcs", None)

--- a/tests/tests/test_class_promotion.py
+++ b/tests/tests/test_class_promotion.py
@@ -105,15 +105,6 @@ def test_ufh_controller_post_class_promote_initializes_state(
 
     assert set(ufh.circuit_by_id.keys()) == {f"{i:02X}" for i in range(8)}
 
-    for attr in (
-        "_setpoints",
-        "_heat_demand",
-        "_heat_demands",
-        "_relay_demand",
-        "_relay_demand_fa",
-    ):
-        assert getattr(ufh, attr) is None
-
 
 def test_controller_post_class_promote_sets_tcs_attribute(
     bare_instance_factory: BareFactory,


### PR DESCRIPTION
### ⚠️ STACKED PR: Depends on #746

### The Problem:

Following the successful transition of the API getters to the new frozen CQRS state models, the legacy raw message caching variables inside `UfhController` (such as `_setpoints`, `_heat_demand`, `_heat_demands`, `_relay_demand`, and `_relay_demand_fa`) are now entirely orphaned. This dead code is polluting the class namespace, adding unnecessary memory overhead, and creating technical debt.

### Consequences:

If this is not resolved, the codebase remains cluttered with obsolete L7 parsing logic. Future maintainers may be confused by multiple state-holding variables (e.g., the legacy caching variables versus the new CQRS state models), increasing the cognitive load and the risk of architectural regressions during future feature development.

### The Fix:

Safely eradicated all legacy read-time message caching variables from the `UfhController` namespace whilst strictly preserving the underlying RF message write-paths and routing logic.

### Technical Implementation:
- **Variable Purge:** Removed the definitions and initialisations of the orphaned caching variables from `_init_ufh_state()` inside `heat_controllers.py`.
- **Routing Preservation:** Inside `_handle_msg()`, the legacy assignment operations for these variables were substituted with `pass` statements. This ensures that the structural `if/elif` blocks, inline documentation, and child-zone message propagation (e.g., passing messages to `msg_dst_tcs`) remain functionally flawless.
- **Test Suite Alignment:** When `ramses_rf` eavesdrops on a new device, it dynamically promotes its class (e.g., from a generic `Device` to a `UfhController`) in-place, bypassing `__init__`. The `_post_class_promote()` hook exists to build necessary instance attributes to prevent `AttributeError` exceptions. We had to modify `test_class_promotion.py` because the regression test was specifically asserting that this hook initialised the now-deleted variables to `None`. With the variables purged, the test correctly failed with an `AttributeError`. The obsolete assertions were removed, leaving the test focused purely on verifying the essential `circuit_by_id` dictionary initialisation.

### Testing Performed:
- Ran strict static type checking via `mypy --strict` to ensure no typing regressions or hanging references to the deleted variables.
- Executed the full pytest suite.
- Updated `test_ufh_controller_post_class_promote_initializes_state` to accurately reflect the newly cleaned class namespace, ensuring the promotion hook still functions for vital attributes.

### Risks of NOT Implementing:

Leaving dead code in place directly contradicts the goals of the CQRS migration, maintaining a hybrid, bloated architecture that makes debugging and future refactoring significantly more difficult.

### Risks of Implementing:

The primary risk was accidentally severing the write-paths during the purge—specifically, dropping downstream message routing to child zones or disrupting the structural integrity of the `_handle_msg` packet handler.

### Mitigation Steps:
- Only variable assignments were purged. The structural branching of `_handle_msg` was rigidly maintained using `pass` statements.
- No standard parent/child message propagation logic or graph mutation logic (like dictionary population) was altered.
- Full unit testing confirmed that the system's ability to eavesdrop, promote classes, and route RF packets remains entirely stable.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.  
