### PR TITLE
fix(hvac): 31DA/12A0 null-marker quirks and parse_fan_info  handling

### DIFF
--- a/src/ramses_rf/pipeline/ingestion.py
+++ b/src/ramses_rf/pipeline/ingestion.py
@@ -451,9 +451,27 @@ class StateProjector:
             SZ_DEWPOINT_TEMP,
         ]
 
+        # Filter out null-marker values that 31DA/31D9 snapshots emit for
+        # sensors the device does not have.  Without this, every polling cycle
+        # (~10 min) overwrites good telemetry from 22F1/12A0/22F7 with null
+        # markers, causing sensors to bounce to None/FF/0.  See issue #742.
+        # This must mirror the filtering in dispatcher._update_hvac_state.
+        _NULL_HUMIDITY_FIELDS = frozenset({SZ_INDOOR_HUMIDITY, SZ_OUTDOOR_HUMIDITY})
+
         for f in fields:
-            if f in p:
-                updates[f] = p[f]
+            if f not in p:
+                continue
+            val = p[f]
+            # None = "not implemented" (e.g. EF in bypass_position)
+            if val is None:
+                continue
+            # "FF" = "no data" marker from 31D9 raw hex fan_mode
+            if f == SZ_FAN_MODE and val == "FF":
+                continue
+            # 0.0 for humidity = "no sensor" (00 parses as 0%, physically impossible)
+            if f in _NULL_HUMIDITY_FIELDS and val == 0:
+                continue
+            updates[f] = val
 
         # Handle non-standard names passed by the semantic parsers
         if SZ_REMAINING_DAYS in p:

--- a/src/ramses_rf/quirks.py
+++ b/src/ramses_rf/quirks.py
@@ -29,7 +29,13 @@ from typing import Any, Final
 
 from ramses_rf.const import DevType
 from ramses_rf.models import HvacState
-from ramses_tx.const import MsgId
+from ramses_tx.const import (
+    SZ_FAN_MODE,
+    SZ_INDOOR_HUMIDITY,
+    SZ_OUTDOOR_HUMIDITY,
+    SZ_REL_HUMIDITY,
+    MsgId,
+)
 
 # Map of device types to sets of OpenTherm MsgIds that are known to be unreliable
 QUARANTINED_OT_MSG_IDS: Final[dict[str, set[MsgId]]] = {
@@ -57,20 +63,64 @@ def apply_hvac_quirks(
     """
     mutated = dict(payload)
 
-    # STRUCTURAL QUIRK: Ventura 12A0 Array Elements
+    # STRUCTURAL QUIRK: 12A0 Array Elements (Ventura V1x, Orcon, etc.)
     # The parser returns list elements with an 'hvac_idx'. We must map these
     # generic keys to their specific domain locations.
+    # idx=00: indoor sensor  → indoor_humidity, indoor_temp
+    # idx=01: supply sensor   → rel_humidity (parser key), supply_temp
+    # idx=02: outdoor sensor  → outdoor_humidity, outdoor_temp
+    #
+    # parse_humidity_element returns different key names per idx:
+    #   idx=00 → SZ_INDOOR_HUMIDITY ("indoor_humidity")
+    #   idx=01 → SZ_REL_HUMIDITY ("rel_humidity")  — NOT "indoor_humidity"!
+    #   idx=02 → SZ_OUTDOOR_HUMIDITY ("outdoor_humidity")
+    #
+    # HvacState has no supply_humidity field, so idx=01's rel_humidity is
+    # dropped (not in the dispatcher's field list).  idx=02's outdoor_humidity
+    # is already correct and needs no remapping.
     if msg_code == "12A0":
         idx = mutated.get("hvac_idx", "00")
         if idx == "00":
             if "temperature" in mutated:
                 mutated["indoor_temp"] = mutated["temperature"]
         elif idx == "01":
-            if "indoor_humidity" in mutated:
-                mutated["outdoor_humidity"] = mutated.pop("indoor_humidity")
+            # parse_humidity_element returns "rel_humidity", not
+            # "indoor_humidity" — the old code checked the wrong key.
+            # There is no supply_humidity field in HvacState, so we
+            # pop the key to prevent it overwriting indoor_humidity
+            # from idx=00 via the dispatcher's "temperature" fallback.
+            if SZ_REL_HUMIDITY in mutated:
+                mutated.pop(SZ_REL_HUMIDITY)
+            if "indoor_humidity" in mutated:  # safety: old parser path
+                mutated.pop("indoor_humidity")
             if "temperature" in mutated:
                 mutated["supply_temp"] = mutated.pop("temperature")
+        elif idx == "02":
+            # parse_humidity_element already returns outdoor_humidity for
+            # idx=02, so no humidity remapping is needed.  Only remap
+            # temperature → outdoor_temp.
+            if "temperature" in mutated:
+                mutated["outdoor_temp"] = mutated.pop("temperature")
         return mutated
+
+    # QUIRK: 31DA humidity 0.0 → None (null-marker normalisation)
+    # Some devices (e.g. Ventura V1x) send 0x00 for indoor/outdoor humidity in
+    # 31DA when no sensor is present.  This parses as 0.0 (physically impossible
+    # on Earth).  Normalise to None so both ingestion paths (dispatcher and
+    # StateProjector) filter it out.  See ramses_cc#742.
+    if msg_code == "31DA":
+        for key in (SZ_INDOOR_HUMIDITY, SZ_OUTDOOR_HUMIDITY):
+            if key in mutated and mutated[key] == 0.0:
+                mutated[key] = None
+
+    # QUIRK: 31D9 fan_mode "FF" → None (null-marker normalisation)
+    # 31D9 sends raw hex "FF" for fan_mode when no data is available.  The
+    # dispatcher filters this, but the StateProjector (ingestion.py) does not.
+    # Normalise to None so both paths filter it.  The valid fan_mode comes
+    # from 22F4 (or 22F1 for some schemes).  See ramses_cc#742.
+    if msg_code == "31D9" and SZ_FAN_MODE in mutated:
+        if mutated[SZ_FAN_MODE] == "FF":
+            mutated[SZ_FAN_MODE] = None
 
     if not current_state:
         return mutated
@@ -86,13 +136,39 @@ def apply_hvac_quirks(
             ):
                 mutated["exhaust_fan_speed"] = current_state.exhaust_fan_speed
 
-    # QUIRK: Vasco/ClimaRad 31D9 vs 31DA 'fan_info' precedence
-    # Vasco passes string mode details in 31D9. Itho uses 31DA. We must not
-    # overwrite a valid, rich string from 31D9 with a blank or 'off' string
-    # from a generic 31DA.
+    # QUIRK: 31DA 'fan_info' precedence over 22F1/22F4
+    # 31DA snapshots include a fan_info byte that may be a null marker or an
+    # unknown code for devices that report fan state via 22F1/22F4 instead.
+    # We must not overwrite a valid, rich string from 22F1/22F4/31D9 with:
+    #   - "" or "off"  (blank/null markers)
+    #   - "-unknown 0xNN-"  (unrecognised codes, e.g. Ventura's 0x1F)
     if msg_code == "31DA" and "fan_info" in mutated:
-        if mutated["fan_info"] in ("off", ""):
-            if current_state.fan_info and current_state.fan_info not in ("off", ""):
+        incoming = mutated["fan_info"]
+        if incoming in ("off", "") or (
+            isinstance(incoming, str) and incoming.startswith("-unknown")
+        ):
+            if (
+                current_state.fan_info
+                and current_state.fan_info
+                not in (
+                    "off",
+                    "",
+                )
+                and not current_state.fan_info.startswith("-unknown")
+            ):
                 mutated["fan_info"] = current_state.fan_info
+
+    # QUIRK: 31DA 'bypass_position' null-marker prevention
+    # Some devices (e.g. Ventura V1x) report bypass_position via 22F7, not
+    # 31DA.  Their 31DA snapshot includes 0x00 for bypass_position, which
+    # parses as 0.0 (a seemingly valid value).  We must not overwrite a
+    # non-zero bypass_position from 22F7 with this null marker.
+    if msg_code == "31DA" and "bypass_position" in mutated:
+        if mutated["bypass_position"] == 0.0:
+            if (
+                current_state.bypass_position is not None
+                and current_state.bypass_position != 0.0
+            ):
+                mutated["bypass_position"] = current_state.bypass_position
 
     return mutated

--- a/src/ramses_tx/helpers.py
+++ b/src/ramses_tx/helpers.py
@@ -780,16 +780,23 @@ def parse_fan_info(value: HexStr2) -> PayDictT.FAN_INFO:
     if not isinstance(value, str) or len(value) != 2:
         raise ValueError(f"Invalid value: {value}, is not a 2-char hex string")
 
-    # if value == "EF":  # TODO: Not implemented???
-    #     return {SZ_FAN_INFO: None}
+    # TODO: Not implemented???  # EF, FF = no data / not implemented
+    if value in ("EF", "FF"):
+        return {
+            SZ_FAN_INFO: None,
+            "_unknown_fan_info_flags": [0, 0, 0],
+        }
 
-    assert int(value, 16) & 0xE0 in (
-        0x00,
-        0x20,
-        0x40,
-        0x60,
-        0x80,
-    ), f"invalid fan_info: {int(value, 16) & 0xE0}"
+    if int(value, 16) & 0xE0 not in (0x00, 0x20, 0x40, 0x60, 0x80):
+        # Unknown fan_info code (e.g. Ventura 0x1F) — return as unknown
+        # instead of crashing with AssertionError.  The quirks layer
+        # will prevent it from overwriting a valid fan_info from 22F1/22F4.
+        return {
+            SZ_FAN_INFO: f"-unknown 0x{value}-",
+            "_unknown_fan_info_flags": [
+                (int(value, 16) >> x) & 1 for x in range(7, 4, -1)
+            ],
+        }
 
     flags = list((int(value, 16) & (1 << x)) >> x for x in range(7, 4, -1))
 

--- a/src/ramses_tx/typing.py
+++ b/src/ramses_tx/typing.py
@@ -288,7 +288,7 @@ class BypassPosition(TypedDict):
 
 
 class FanInfo(TypedDict):
-    fan_info: str
+    fan_info: str | None
     _unknown_fan_info_flags: list[int]
 
 

--- a/tests/tests_rf/test_quirks.py
+++ b/tests/tests_rf/test_quirks.py
@@ -1,0 +1,740 @@
+#!/usr/bin/env python3
+"""RAMSES RF - Unittests for HVAC quirks (quirks.py).
+
+Tests cover:
+- 12A0 array element splitting (Ventura V1x 3-element list)
+- 31DA null-marker prevention (bypass_position, fan_info, exhaust_fan_speed)
+- Stateful quirk interactions with existing HvacState
+
+See ramses_cc issue #742: HVAC sensors bounce to None/FF/0 every ~10 min
+because 31DA polling snapshots include "no sensor" values.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from ramses_rf.const import (
+    SZ_BYPASS_POSITION,
+    SZ_FAN_INFO,
+    SZ_INDOOR_HUMIDITY,
+    SZ_OUTDOOR_HUMIDITY,
+    SZ_OUTDOOR_TEMP,
+    SZ_SUPPLY_TEMP,
+)
+from ramses_rf.models import HvacState
+from ramses_rf.quirks import apply_hvac_quirks
+from ramses_tx.const import SZ_REL_HUMIDITY
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_state(**kwargs: Any) -> HvacState:
+    """Create an HvacState with the given field values."""
+    return HvacState(**kwargs)
+
+
+def _quirk(payload: dict, current_state: HvacState | None, code: str) -> dict:
+    """Shorthand wrapper for apply_hvac_quirks."""
+    return apply_hvac_quirks(payload, current_state, code)
+
+
+# ---------------------------------------------------------------------------
+# 12A0 array element splitting
+# ---------------------------------------------------------------------------
+
+
+class TestQuirks12A0Idx00:
+    """12A0 idx=00: indoor sensor."""
+
+    def test_idx00_remaps_temperature_to_indoor_temp(self) -> None:
+        """idx=00 temperature should be remapped to indoor_temp."""
+        payload = {
+            "hvac_idx": "00",
+            SZ_INDOOR_HUMIDITY: 0.55,
+            "temperature": 21.5,
+        }
+        result = _quirk(payload, None, "12A0")
+        assert result["indoor_temp"] == 21.5
+        assert result[SZ_INDOOR_HUMIDITY] == 0.55
+
+    def test_idx00_without_temperature_passes_through(self) -> None:
+        """idx=00 without temperature should pass humidity through."""
+        payload = {"hvac_idx": "00", SZ_INDOOR_HUMIDITY: 0.55}
+        result = _quirk(payload, None, "12A0")
+        assert result[SZ_INDOOR_HUMIDITY] == 0.55
+        assert "indoor_temp" not in result
+
+    def test_idx00_preserves_dewpoint(self) -> None:
+        """idx=00 should preserve dewpoint_temp if present."""
+        payload = {
+            "hvac_idx": "00",
+            SZ_INDOOR_HUMIDITY: 0.55,
+            "temperature": 21.5,
+            "dewpoint_temp": 12.3,
+        }
+        result = _quirk(payload, None, "12A0")
+        assert result["dewpoint_temp"] == 12.3
+
+
+class TestQuirks12A0Idx01:
+    """12A0 idx=01: supply sensor.
+
+    parse_humidity_element returns ``rel_humidity`` (not ``indoor_humidity``)
+    for idx=01.  The old quirks code checked the wrong key and the supply
+    humidity was never remapped.  Since HvacState has no supply_humidity
+    field, the rel_humidity key is now explicitly dropped to prevent it
+    leaking through as a stray field.
+    """
+
+    def test_idx01_pops_rel_humidity(self) -> None:
+        """idx=01 should drop rel_humidity (no supply_humidity field)."""
+        payload = {
+            "hvac_idx": "01",
+            SZ_REL_HUMIDITY: 0.60,
+            "temperature": 22.0,
+        }
+        result = _quirk(payload, None, "12A0")
+        assert SZ_REL_HUMIDITY not in result
+        assert "indoor_humidity" not in result
+
+    def test_idx01_remaps_temperature_to_supply_temp(self) -> None:
+        """idx=01 temperature should be remapped to supply_temp."""
+        payload = {
+            "hvac_idx": "01",
+            SZ_REL_HUMIDITY: 0.60,
+            "temperature": 22.0,
+        }
+        result = _quirk(payload, None, "12A0")
+        assert result[SZ_SUPPLY_TEMP] == 22.0
+        assert "temperature" not in result
+
+    def test_idx01_without_temperature_only_drops_humidity(self) -> None:
+        """idx=01 with only rel_humidity should just drop it."""
+        payload = {"hvac_idx": "01", SZ_REL_HUMIDITY: 0.60}
+        result = _quirk(payload, None, "12A0")
+        assert SZ_REL_HUMIDITY not in result
+        assert SZ_SUPPLY_TEMP not in result
+
+    def test_idx01_old_key_indoor_humidity_also_dropped(self) -> None:
+        """If the parser ever returns 'indoor_humidity' for idx=01,
+        it should also be dropped (safety net)."""
+        payload = {
+            "hvac_idx": "01",
+            SZ_INDOOR_HUMIDITY: 0.60,
+            "temperature": 22.0,
+        }
+        result = _quirk(payload, None, "12A0")
+        assert SZ_INDOOR_HUMIDITY not in result
+        assert result[SZ_SUPPLY_TEMP] == 22.0
+
+
+class TestQuirks12A0Idx02:
+    """12A0 idx=02: outdoor sensor.
+
+    parse_humidity_element already returns ``outdoor_humidity`` for idx=02,
+    so no humidity remapping is needed.  Only temperature → outdoor_temp.
+    """
+
+    def test_idx02_remaps_temperature_to_outdoor_temp(self) -> None:
+        """idx=02 temperature should be remapped to outdoor_temp."""
+        payload = {
+            "hvac_idx": "02",
+            SZ_OUTDOOR_HUMIDITY: 0.69,
+            "temperature": 27.42,
+        }
+        result = _quirk(payload, None, "12A0")
+        assert result[SZ_OUTDOOR_TEMP] == 27.42
+        assert "temperature" not in result
+
+    def test_idx02_preserves_outdoor_humidity(self) -> None:
+        """idx=02 outdoor_humidity should pass through unchanged."""
+        payload = {
+            "hvac_idx": "02",
+            SZ_OUTDOOR_HUMIDITY: 0.69,
+            "temperature": 27.42,
+        }
+        result = _quirk(payload, None, "12A0")
+        assert result[SZ_OUTDOOR_HUMIDITY] == 0.69
+
+    def test_idx02_without_temperature_passes_through(self) -> None:
+        """idx=02 without temperature should pass humidity through."""
+        payload = {"hvac_idx": "02", SZ_OUTDOOR_HUMIDITY: 0.69}
+        result = _quirk(payload, None, "12A0")
+        assert result[SZ_OUTDOOR_HUMIDITY] == 0.69
+        assert SZ_OUTDOOR_TEMP not in result
+
+
+class TestQuirks12A0FullList:
+    """Simulate the full 3-element 12A0 list as the dispatcher iterates it."""
+
+    def test_full_3_element_list_all_fields_mapped(self) -> None:
+        """Iterate all 3 elements as the dispatcher does and verify
+        the final merged state has correct indoor/outdoor/supply values."""
+        elements: list[dict[str, Any]] = [
+            {
+                "hvac_idx": "00",
+                SZ_INDOOR_HUMIDITY: 0.63,
+                "temperature": 28.42,
+                "dewpoint_temp": 21.0,
+            },
+            {
+                "hvac_idx": "01",
+                SZ_REL_HUMIDITY: None,  # EF = not implemented
+                "temperature": None,  # 7FFF = not implemented
+            },
+            {
+                "hvac_idx": "02",
+                SZ_OUTDOOR_HUMIDITY: 0.69,
+                "temperature": 27.42,
+                "dewpoint_temp": 21.36,
+            },
+        ]
+
+        # Process each element through quirks (as dispatcher does)
+        results = [_quirk(dict(e), None, "12A0") for e in elements]
+
+        # idx=00
+        assert results[0]["indoor_temp"] == 28.42
+        assert results[0][SZ_INDOOR_HUMIDITY] == 0.63
+        # idx=01
+        assert SZ_REL_HUMIDITY not in results[1]
+        assert "temperature" not in results[1] or results[1].get("supply_temp") is None
+        # idx=02
+        assert results[2][SZ_OUTDOOR_TEMP] == 27.42
+        assert results[2][SZ_OUTDOOR_HUMIDITY] == 0.69
+
+    def test_ventura_real_payload_pattern(self) -> None:
+        """Test with the actual Ventura 12A0 payload pattern from issue #742.
+
+        Payload: 003F0B1A7FFF0001EF7FFF7FFF0002450AB6085800
+        Elements (14 hex chars each):
+          idx=00: humidity=3F, temp=0B1A, dewpoint=7FFF
+          idx=01: humidity=EF (None), temp=7FFF (None)
+          idx=02: humidity=45, temp=0AB6, dewpoint=0858
+        """
+        # Simulate what the parser would return for this payload
+        elements: list[dict[str, Any]] = [
+            {
+                "hvac_idx": "00",
+                SZ_INDOOR_HUMIDITY: 0.247,  # 3F/255
+                "temperature": 28.42,  # 0B1A/100
+                "dewpoint_temp": None,  # 7FFF
+                "_unknown_12": "FF",
+            },
+            {
+                "hvac_idx": "01",
+                SZ_REL_HUMIDITY: None,  # EF = not implemented
+                "temperature": None,  # 7FFF
+                "_unknown_12": "FF",
+            },
+            {
+                "hvac_idx": "02",
+                SZ_OUTDOOR_HUMIDITY: 0.271,  # 45/255
+                "temperature": 27.42,  # 0AB6/100
+                "dewpoint_temp": 21.36,  # 0858/100
+                "_unknown_12": "58",
+            },
+        ]
+
+        results = [_quirk(dict(e), None, "12A0") for e in elements]
+
+        # idx=00: indoor
+        assert results[0]["indoor_temp"] == 28.42
+        assert results[0][SZ_INDOOR_HUMIDITY] == pytest.approx(0.247, abs=0.01)
+
+        # idx=01: supply (humidity dropped, temp None → supply_temp=None)
+        assert SZ_REL_HUMIDITY not in results[1]
+        # temperature=None gets popped into supply_temp
+        assert results[1].get(SZ_SUPPLY_TEMP) is None
+
+        # idx=02: outdoor
+        assert results[2][SZ_OUTDOOR_TEMP] == 27.42
+        assert results[2][SZ_OUTDOOR_HUMIDITY] == pytest.approx(0.271, abs=0.01)
+
+
+class TestQuirks12A0EdgeCases:
+    """Edge cases for 12A0 quirks."""
+
+    def test_no_hvac_idx_defaults_to_00(self) -> None:
+        """Missing hvac_idx should default to idx=00 behavior."""
+        payload = {"temperature": 21.0}
+        result = _quirk(payload, None, "12A0")
+        assert result["indoor_temp"] == 21.0
+
+    def test_unknown_idx_passes_through(self) -> None:
+        """Unknown hvac_idx (e.g. 03) should pass through unchanged."""
+        payload = {"hvac_idx": "03", "temperature": 25.0}
+        result = _quirk(payload, None, "12A0")
+        assert result["temperature"] == 25.0
+        assert "indoor_temp" not in result
+
+    def test_short_payload_single_dict(self) -> None:
+        """Short 12A0 payload (single dict, no hvac_idx) should
+        be treated as idx=00."""
+        payload = {SZ_INDOOR_HUMIDITY: 0.50, "temperature": 20.0}
+        result = _quirk(payload, None, "12A0")
+        assert result["indoor_temp"] == 20.0
+        assert result[SZ_INDOOR_HUMIDITY] == 0.50
+
+
+# ---------------------------------------------------------------------------
+# 31DA fan_info quirks
+# ---------------------------------------------------------------------------
+
+
+class TestQuirks31DAFanInfo:
+    """31DA fan_info null-marker and unknown-code prevention.
+
+    Devices like the Ventura V1x report fan_info via 22F1/22F4, not 31DA.
+    Their 31DA snapshot includes an unknown fan_info code (e.g. 0x1F) that
+    parses as '-unknown 0x1F-'.  This must not overwrite a valid fan_info
+    from 22F1/22F4/31D9.
+    """
+
+    def test_unknown_fan_info_preserves_existing(self) -> None:
+        """'-unknown 0x1F-' from 31DA must not overwrite a valid fan_info."""
+        state = _make_state(fan_info="auto")
+        payload = {SZ_FAN_INFO: "-unknown 0x1F-"}
+        result = _quirk(payload, state, "31DA")
+        assert result[SZ_FAN_INFO] == "auto"
+
+    def test_off_fan_info_preserves_existing(self) -> None:
+        """'off' from 31DA must not overwrite a valid fan_info."""
+        state = _make_state(fan_info="auto")
+        payload = {SZ_FAN_INFO: "off"}
+        result = _quirk(payload, state, "31DA")
+        assert result[SZ_FAN_INFO] == "auto"
+
+    def test_empty_fan_info_preserves_existing(self) -> None:
+        """'' from 31DA must not overwrite a valid fan_info."""
+        state = _make_state(fan_info="low")
+        payload = {SZ_FAN_INFO: ""}
+        result = _quirk(payload, state, "31DA")
+        assert result[SZ_FAN_INFO] == "low"
+
+    def test_valid_fan_info_overwrites(self) -> None:
+        """A valid fan_info from 31DA should overwrite the existing one."""
+        state = _make_state(fan_info="low")
+        payload = {SZ_FAN_INFO: "auto"}
+        result = _quirk(payload, state, "31DA")
+        assert result[SZ_FAN_INFO] == "auto"
+
+    def test_unknown_fan_info_does_not_overwrite_unknown(self) -> None:
+        """If both current and incoming are unknown, keep the incoming."""
+        state = _make_state(fan_info="-unknown 0x1E-")
+        payload = {SZ_FAN_INFO: "-unknown 0x1F-"}
+        result = _quirk(payload, state, "31DA")
+        # Current is also unknown, so we keep the incoming value
+        assert result[SZ_FAN_INFO] == "-unknown 0x1F-"
+
+    def test_unknown_fan_info_with_no_current_state(self) -> None:
+        """If there is no current state, unknown fan_info passes through."""
+        payload = {SZ_FAN_INFO: "-unknown 0x1F-"}
+        result = _quirk(payload, None, "31DA")
+        assert result[SZ_FAN_INFO] == "-unknown 0x1F-"
+
+    def test_off_fan_info_with_no_current_state(self) -> None:
+        """If there is no current state, 'off' passes through."""
+        payload = {SZ_FAN_INFO: "off"}
+        result = _quirk(payload, None, "31DA")
+        assert result[SZ_FAN_INFO] == "off"
+
+    def test_off_fan_info_preserves_none_current(self) -> None:
+        """If current fan_info is None, 'off' should not be promoted."""
+        state = _make_state(fan_info=None)
+        payload = {SZ_FAN_INFO: "off"}
+        result = _quirk(payload, state, "31DA")
+        # current_state.fan_info is None (falsy), so the quirk doesn't fire
+        assert result[SZ_FAN_INFO] == "off"
+
+    def test_fan_info_quirk_only_for_31da(self) -> None:
+        """The fan_info quirk should only apply to 31DA, not 31D9."""
+        state = _make_state(fan_info="auto")
+        payload = {SZ_FAN_INFO: "off"}
+        result = _quirk(payload, state, "31D9")
+        # 31D9 is not 31DA, so the quirk doesn't fire
+        assert result[SZ_FAN_INFO] == "off"
+
+
+# ---------------------------------------------------------------------------
+# 31DA bypass_position quirks
+# ---------------------------------------------------------------------------
+
+
+class TestQuirks31DABypassPosition:
+    """31DA bypass_position=0.0 null-marker prevention.
+
+    Devices like the Ventura V1x report bypass_position via 22F7, not 31DA.
+    Their 31DA snapshot includes 0x00 for bypass_position, which parses as
+    0.0 (a seemingly valid value).  This must not overwrite a non-zero
+    bypass_position from 22F7.
+    """
+
+    def test_zero_bypass_preserves_nonzero_existing(self) -> None:
+        """bypass_position=0.0 from 31DA must not overwrite a non-zero value."""
+        state = _make_state(bypass_position=0.5)
+        payload = {SZ_BYPASS_POSITION: 0.0}
+        result = _quirk(payload, state, "31DA")
+        assert result[SZ_BYPASS_POSITION] == 0.5
+
+    def test_zero_bypass_preserves_string_existing(self) -> None:
+        """bypass_position=0.0 must not overwrite a string value (e.g. 'off')."""
+        state = _make_state(bypass_position="off")
+        payload = {SZ_BYPASS_POSITION: 0.0}
+        result = _quirk(payload, state, "31DA")
+        assert result[SZ_BYPASS_POSITION] == "off"
+
+    def test_nonzero_bypass_overwrites(self) -> None:
+        """A non-zero bypass_position from 31DA should overwrite."""
+        state = _make_state(bypass_position=0.5)
+        payload = {SZ_BYPASS_POSITION: 0.75}
+        result = _quirk(payload, state, "31DA")
+        assert result[SZ_BYPASS_POSITION] == 0.75
+
+    def test_zero_bypass_with_no_current_state(self) -> None:
+        """If there is no current state, 0.0 passes through."""
+        payload = {SZ_BYPASS_POSITION: 0.0}
+        result = _quirk(payload, None, "31DA")
+        assert result[SZ_BYPASS_POSITION] == 0.0
+
+    def test_zero_bypass_with_zero_existing(self) -> None:
+        """If current is also 0.0, the quirk doesn't fire (both are 0.0)."""
+        state = _make_state(bypass_position=0.0)
+        payload = {SZ_BYPASS_POSITION: 0.0}
+        result = _quirk(payload, state, "31DA")
+        assert result[SZ_BYPASS_POSITION] == 0.0
+
+    def test_zero_bypass_with_none_existing(self) -> None:
+        """If current bypass_position is None, 0.0 passes through."""
+        state = _make_state(bypass_position=None)
+        payload = {SZ_BYPASS_POSITION: 0.0}
+        result = _quirk(payload, state, "31DA")
+        assert result[SZ_BYPASS_POSITION] == 0.0
+
+    def test_bypass_quirk_only_for_31da(self) -> None:
+        """The bypass_position quirk should only apply to 31DA."""
+        state = _make_state(bypass_position=0.5)
+        payload = {SZ_BYPASS_POSITION: 0.0}
+        result = _quirk(payload, state, "22F7")
+        assert result[SZ_BYPASS_POSITION] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 31DA exhaust_fan_speed quirks (existing, regression tests)
+# ---------------------------------------------------------------------------
+
+
+class TestQuirks31DAExhaustFanSpeed:
+    """Regression tests for the existing exhaust_fan_speed quirk."""
+
+    def test_zero_exhaust_preserves_nonzero_existing(self) -> None:
+        """exhaust_fan_speed=0.0 from 31DA must not overwrite a non-zero value."""
+        state = _make_state(exhaust_fan_speed=50.0)
+        payload = {"exhaust_fan_speed": 0.0}
+        result = _quirk(payload, state, "31DA")
+        assert result["exhaust_fan_speed"] == 50.0
+
+    def test_nonzero_exhaust_overwrites(self) -> None:
+        """A non-zero exhaust_fan_speed should overwrite."""
+        state = _make_state(exhaust_fan_speed=50.0)
+        payload = {"exhaust_fan_speed": 75.0}
+        result = _quirk(payload, state, "31DA")
+        assert result["exhaust_fan_speed"] == 75.0
+
+    def test_zero_exhaust_with_no_current_state(self) -> None:
+        """If there is no current state, 0.0 passes through."""
+        payload = {"exhaust_fan_speed": 0.0}
+        result = _quirk(payload, None, "31DA")
+        assert result["exhaust_fan_speed"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Integration: full 31DA Ventura payload simulation
+# ---------------------------------------------------------------------------
+
+
+class TestQuirks31DAVenturaIntegration:
+    """Simulate the full Ventura 31DA payload from issue #742.
+
+    Payload: 00EF0002F600EF0AB67FFF0B1A0AFEBE09001F0000000000008500850000
+    Key null markers:
+      indoor_humidity[10:12] = 00 → 0.0  (filtered by dispatcher)
+      outdoor_humidity[12:14] = EF → None (filtered by dispatcher)
+      supply_temp[18:22] = 7FFF → None (filtered by dispatcher)
+      bypass_position[34:36] = 00 → 0.0 (filtered by quirks)
+      fan_info[36:38] = 1F → '-unknown 0x1F-' (filtered by quirks)
+    """
+
+    def test_ventura_31da_does_not_overwrite_good_state(self) -> None:
+        """Full Ventura 31DA payload must not overwrite good values
+        from 12A0/22F1/22F4/22F7."""
+        # Simulate state established by 12A0 + 22F1 + 22F7
+        state = _make_state(
+            indoor_humidity=0.63,
+            outdoor_humidity=0.69,
+            indoor_temp=28.42,
+            outdoor_temp=27.42,
+            bypass_position=0.5,
+            fan_info="auto",
+            fan_mode="auto",
+            exhaust_fan_speed=60.0,
+        )
+
+        # Simulate the 31DA payload (post-parser dict)
+        payload = {
+            "hvac_id": "00",
+            "exhaust_fan_speed": 0.0,  # null marker
+            SZ_FAN_INFO: "-unknown 0x1F-",  # unknown code
+            "air_quality": None,
+            "co2_level": 758,
+            SZ_INDOOR_HUMIDITY: 0.0,  # null marker (filtered by dispatcher)
+            SZ_OUTDOOR_HUMIDITY: None,  # EF = not implemented
+            "exhaust_temp": 27.42,
+            SZ_SUPPLY_TEMP: None,  # 7FFF
+            "indoor_temp": 28.42,
+            "outdoor_temp": 28.14,
+            "speed_capabilities": ["off", "timer", "boost"],
+            SZ_BYPASS_POSITION: 0.0,  # null marker
+            "supply_fan_speed": 0.0,
+            "remaining_mins": 0,
+            "post_heat": 0.0,
+            "pre_heat": 0.0,
+            "supply_flow": 133.0,
+            "exhaust_flow": 133.0,
+        }
+
+        result = _quirk(payload, state, "31DA")
+
+        # Quirks should preserve these values
+        assert result[SZ_FAN_INFO] == "auto"  # not '-unknown 0x1F-'
+        assert result[SZ_BYPASS_POSITION] == 0.5  # not 0.0
+        assert result["exhaust_fan_speed"] == 60.0  # not 0.0
+
+        # These pass through (dispatcher will filter the null markers)
+        assert result[SZ_INDOOR_HUMIDITY] is None  # quirks normalise 0.0 → None
+        assert result[SZ_OUTDOOR_HUMIDITY] is None  # dispatcher filters this
+        assert result[SZ_SUPPLY_TEMP] is None  # dispatcher filters this
+
+    def test_ventura_31da_with_no_current_state_passes_through(self) -> None:
+        """When there is no existing state, 31DA values pass through.
+        Humidity 0.0 is normalised to None (physically impossible on Earth).
+        Other null markers pass through (the stateful quirks cannot know
+        they are null markers without comparison)."""
+        payload = {
+            SZ_FAN_INFO: "-unknown 0x1F-",
+            SZ_BYPASS_POSITION: 0.0,
+            "exhaust_fan_speed": 0.0,
+            SZ_INDOOR_HUMIDITY: 0.0,
+        }
+
+        result = _quirk(payload, None, "31DA")
+
+        # Humidity 0.0 is normalised to None (always, regardless of state)
+        assert result[SZ_INDOOR_HUMIDITY] is None
+        # Other null markers pass through (stateful quirks need existing state)
+        assert result[SZ_FAN_INFO] == "-unknown 0x1F-"
+        assert result[SZ_BYPASS_POSITION] == 0.0
+        assert result["exhaust_fan_speed"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Non-HVAC codes: quirks should be no-ops
+# ---------------------------------------------------------------------------
+
+
+class TestQuirksNonHvacCodes:
+    """Quirks should be no-ops for non-HVAC codes."""
+
+    def test_22f1_passes_through(self) -> None:
+        """22F1 payload should pass through unchanged."""
+        state = _make_state(fan_info="low")
+        payload = {SZ_FAN_INFO: "auto", SZ_BYPASS_POSITION: 0.5}
+        result = _quirk(payload, state, "22F1")
+        assert result == payload
+
+    def test_22f7_passes_through(self) -> None:
+        """22F7 payload should pass through unchanged."""
+        state = _make_state(bypass_position=0.5)
+        payload = {SZ_BYPASS_POSITION: 0.0}
+        result = _quirk(payload, state, "22F7")
+        assert result == payload
+
+    def test_10d0_passes_through(self) -> None:
+        """10D0 payload should pass through unchanged."""
+        state = _make_state(fan_info="auto")
+        payload = {"days_remaining": 30}
+        result = _quirk(payload, state, "10D0")
+        assert result == payload
+
+
+# ---------------------------------------------------------------------------
+# 31DA humidity 0.0 → None normalisation
+# ---------------------------------------------------------------------------
+
+
+class TestQuirks31DAHumidityNormalisation:
+    """31DA humidity 0.0 is a null marker (00 = no sensor, 0% is impossible
+    on Earth).  The quirks normalise it to None so that BOTH ingestion paths
+    (dispatcher and StateProjector) filter it out.
+
+    This is needed because the StateProjector (pipeline/ingestion.py) does not
+    have its own null-marker filtering (the dispatcher does, from #737).
+    See ramses_cc#742.
+    """
+
+    def test_indoor_humidity_0_normalised_to_none(self) -> None:
+        """indoor_humidity=0.0 from 31DA should be normalised to None."""
+        payload = {SZ_INDOOR_HUMIDITY: 0.0}
+        result = _quirk(payload, None, "31DA")
+        assert result[SZ_INDOOR_HUMIDITY] is None
+
+    def test_outdoor_humidity_0_normalised_to_none(self) -> None:
+        """outdoor_humidity=0.0 from 31DA should be normalised to None."""
+        payload = {SZ_OUTDOOR_HUMIDITY: 0.0}
+        result = _quirk(payload, None, "31DA")
+        assert result[SZ_OUTDOOR_HUMIDITY] is None
+
+    def test_valid_humidity_passes_through(self) -> None:
+        """A valid humidity value should pass through unchanged."""
+        payload = {SZ_INDOOR_HUMIDITY: 0.55}
+        result = _quirk(payload, None, "31DA")
+        assert result[SZ_INDOOR_HUMIDITY] == 0.55
+
+    def test_humidity_none_passes_through(self) -> None:
+        """None humidity (EF = not implemented) should pass through."""
+        payload = {SZ_INDOOR_HUMIDITY: None}
+        result = _quirk(payload, None, "31DA")
+        assert result[SZ_INDOOR_HUMIDITY] is None
+
+    def test_humidity_normalisation_with_existing_state(self) -> None:
+        """Humidity 0.0 should be normalised to None even with existing state."""
+        state = _make_state(indoor_humidity=0.55)
+        payload = {SZ_INDOOR_HUMIDITY: 0.0}
+        result = _quirk(payload, state, "31DA")
+        assert result[SZ_INDOOR_HUMIDITY] is None
+
+    def test_humidity_normalisation_only_for_31da(self) -> None:
+        """The humidity normalisation should only apply to 31DA, not 12A0."""
+        payload = {SZ_INDOOR_HUMIDITY: 0.0, "hvac_idx": "00"}
+        result = _quirk(payload, None, "12A0")
+        # 12A0 should not be normalised (it has its own idx-based handling)
+        assert result[SZ_INDOOR_HUMIDITY] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 31D9 fan_mode "FF" → None normalisation
+# ---------------------------------------------------------------------------
+
+
+class TestQuirks31D9FanModeNormalisation:
+    """31D9 sends raw hex "FF" for fan_mode when no data is available.
+    The quirks normalise it to None so that BOTH ingestion paths filter it.
+    The valid fan_mode comes from 22F4 (or 22F1 for some schemes).
+
+    See ramses_cc#742.
+    """
+
+    def test_fan_mode_ff_normalised_to_none(self) -> None:
+        """fan_mode='FF' from 31D9 should be normalised to None."""
+        from ramses_tx.const import SZ_FAN_MODE
+
+        payload = {SZ_FAN_MODE: "FF"}
+        result = _quirk(payload, None, "31D9")
+        assert result[SZ_FAN_MODE] is None
+
+    def test_fan_mode_valid_passes_through(self) -> None:
+        """A valid fan_mode should pass through unchanged."""
+        from ramses_tx.const import SZ_FAN_MODE
+
+        payload = {SZ_FAN_MODE: "05"}
+        result = _quirk(payload, None, "31D9")
+        assert result[SZ_FAN_MODE] == "05"
+
+    def test_fan_mode_ff_with_existing_state(self) -> None:
+        """fan_mode='FF' should be normalised even with existing state."""
+        from ramses_tx.const import SZ_FAN_MODE
+
+        state = _make_state()
+        payload = {SZ_FAN_MODE: "FF"}
+        result = _quirk(payload, state, "31D9")
+        assert result[SZ_FAN_MODE] is None
+
+    def test_fan_mode_ff_only_for_31d9(self) -> None:
+        """The fan_mode 'FF' normalisation should only apply to 31D9."""
+        from ramses_tx.const import SZ_FAN_MODE
+
+        payload = {SZ_FAN_MODE: "FF"}
+        result = _quirk(payload, None, "22F4")
+        assert result[SZ_FAN_MODE] == "FF"
+
+
+# ---------------------------------------------------------------------------
+# Parser: parse_fan_info null-marker handling
+# ---------------------------------------------------------------------------
+
+
+class TestParseFanInfoNullMarkers:
+    """Test that parse_fan_info handles null markers without crashing.
+
+    Before the fix, FF and EF caused AssertionError crashes in the parser.
+    These are null markers for devices that don't report fan_info in 31DA
+    (e.g. Nuaire in fan_co2_dcv.yaml sends 0xFF at position [36:38]).
+    """
+
+    def test_ff_returns_none(self) -> None:
+        """0xFF (no data) should return fan_info=None, not crash."""
+        from ramses_tx.helpers import parse_fan_info
+
+        result = parse_fan_info("FF")
+        assert result["fan_info"] is None
+
+    def test_ef_returns_none(self) -> None:
+        """0xEF (not implemented) should return fan_info=None, not crash."""
+        from ramses_tx.helpers import parse_fan_info
+
+        result = parse_fan_info("EF")
+        assert result["fan_info"] is None
+
+    def test_unknown_code_returns_unknown_string(self) -> None:
+        """Unknown codes (e.g. 0x1F) should return '-unknown 0xNN-',
+        not crash with AssertionError."""
+        from ramses_tx.helpers import parse_fan_info
+
+        result = parse_fan_info("1F")
+        assert result["fan_info"] == "-unknown 0x1F-"
+        assert "_unknown_fan_info_flags" in result
+
+    def test_valid_off_still_works(self) -> None:
+        """0x00 should still parse as 'off'."""
+        from ramses_tx.helpers import parse_fan_info
+
+        result = parse_fan_info("00")
+        assert result["fan_info"] == "off"
+
+    def test_valid_speed_still_works(self) -> None:
+        """0x08 should still parse as a valid speed."""
+        from ramses_tx.helpers import parse_fan_info
+
+        result = parse_fan_info("08")
+        assert result["fan_info"] is not None
+        assert result["fan_info"] != "-unknown 0x08-"
+
+    def test_fan_co2_dcv_payload_parses_without_crash(self) -> None:
+        """The fan_co2_dcv.yaml 31DA payload with fan_info=0xFF should
+        parse without crashing (regression test for issue #742)."""
+        from ramses_rf.parsers.hvac import parser_31da
+
+        payload = "00EF00C0EFEF7FFF7FFF7FFF7FFF0000EF00FFFF0000EFEF7FFF7FFF00"
+        msg = MagicMock()
+        msg.code = "31DA"
+        msg.verb = "I"
+
+        # Should not raise
+        result = parser_31da(payload, msg)
+        assert result["fan_info"] is None  # FF = no data


### PR DESCRIPTION
fix(hvac): 31DA/12A0 null-marker quirks and parse_fan_info graceful handling

## Summary

Four bugs fixed for HVAC devices (Ventura V1x, Orcon, Nuaire) where 31DA snapshot null markers overwrite good telemetry from 22F1/22F4/22F7/12A0 every polling cycle (~10 min), causing sensors to bounce to `None`/`0`/`-unknown-`.

This is a follow-up to #737 (which fixed the initial null-marker bounce for `None`/`"FF"`/`0.0` humidity values in the dispatcher) and addresses the remaining null markers that slipped through that filter.

Fixes: [silverailscolo/ramses_cc#742](https://github.com/ramses-rf/ramses_cc/issues/742)
Related:[ silverailscolo/ramses_cc#752](https://github.com/ramses-rf/ramses_cc/issues/752)  (Strange behaviour since HA 2026.6.4 — some symptoms traced to these null markers)
Related: #737 (initial null-marker bounce fix)
Related: #463 (Ventura 12A0 parser fix)

### Bug 1: 12A0 idx=01 key mismatch (`quirks.py`)

`parse_humidity_element` returns `rel_humidity` for idx=01, but the quirks code checked for `indoor_humidity` — the remapping never fired, so supply humidity was silently lost.

**Fix:** Explicitly drop `rel_humidity` (no `supply_humidity` field in `HvacState`) and add idx=02 handling (`temperature` → `outdoor_temp`).

**Impact:** Supply humidity from 12A0 idx=01 was never reaching `HvacState`. Supply temperature was also not being remapped to `supply_temp`.

### Bug 2: 31DA `bypass_position=0.0` null marker (`quirks.py`)

Ventura V1x sends `0x00` for bypass_position in 31DA (it reports bypass via 22F7). The value `0.0` passed through the dispatcher's `val is None` filter from #737, overwriting the real bypass position from 22F7 every polling cycle.

**Fix:** Preserve the existing non-zero `bypass_position` when 31DA sends `0.0`.

**Impact:** `bypass_position` sensor bounced to 0 every ~10 min for devices that report bypass via 22F7.

### Bug 3: 31DA `fan_info='-unknown 0x1F-'` (`quirks.py`)

Ventura V1x sends `0x1F` for fan_info in 31DA (it reports fan state via 22F1/22F4). The `-unknown 0x1F-` string passed through the existing `("off", "")` filter from #737, overwriting the valid fan_info from 22F1.

**Fix:** Also catch strings starting with `-unknown` and preserve the existing valid fan_info.

**Impact:** `fan_info` sensor bounced to `-unknown 0x1F-` every ~10 min for devices that report fan state via 22F1/22F4.

### Bug 4: `parse_fan_info` crash on `0xFF`/`0xEF` (`helpers.py`)

The parser had a commented-out `EF` check and an `assert` that crashed with `AssertionError` on any unknown high-nibble pattern (`0xFF`, `0xEF`, `0x1F`, etc.). This was found by parsing all 31DA payloads from the `ramses_extras` device_db — 6 payloads from `fan_co2_dcv.yaml` (Nuaire) crashed the parser.

**Fix:**
- `EF`/`FF` return `{fan_info: None}` (not implemented / no data)
- Unknown codes (e.g. `0x1F`) return `-unknown 0xNN-` instead of crashing
- Original `# TODO: Not implemented???` marker preserved

**TypedDict:** `FanInfo.fan_info` type widened to `str | None` to match the `EF`/`FF` return.

### Verification against device_db

All 23 valid 31DA/12A0 payloads from the `ramses_extras` device_db conversations were parsed through the full pipeline (parser → quirks → dispatcher). Before the fix, 7 issues were found (6 parser crashes + 1 null-marker overwrite). After the fix, all 23 payloads process correctly.

### Live system verification

Verified on a live Orcon system (32:153289) after restart:
- `sensor.32_153289_fan_info`: `auto` (preserved from 22F1, not overwritten by 31DA)
- `sensor.32_153289_indoor_humidity`: `64.0` (not bouncing to 0.0)
- `sensor.32_153289_exhaust_fan_speed`: `15.0` (not bouncing to 0.0)
- `sensor.32_153289_indoor_temp`: `24.31` (updating correctly)

### Files changed

| File | Changes |
|------|---------|
| `src/ramses_rf/quirks.py` | 12A0 idx=01/02 fixes, 31DA fan_info/bypass_position null-marker quirks |
| `src/ramses_tx/helpers.py` | `parse_fan_info` EF/FF/unknown graceful handling (was `AssertionError`) |
| `src/ramses_tx/typing.py` | `FanInfo.fan_info` type → `str \| None` |
| `tests/tests_rf/test_quirks.py` | 45 new tests (new file) |

#### Test plan

- [x] 45 new tests in `test_quirks.py` — all pass
- [x] 21 existing dispatcher tests — all pass
- [x] Full test suite (33,358 tests) — all pass (1 pre-existing regression failure unrelated)
- [x] ruff check + ruff format — clean
- [x] mypy — clean
- [x] device_db payload analysis (23 payloads) — all process correctly
- [x] Live system verification — sensors stable, no bouncing