### PR TITLE
fix: revert 12A0 idx=02 temperature→outdoor_temp remapping

### DIFF
--- a/src/ramses_rf/quirks.py
+++ b/src/ramses_rf/quirks.py
@@ -97,10 +97,18 @@ def apply_hvac_quirks(
                 mutated["supply_temp"] = mutated.pop("temperature")
         elif idx == "02":
             # parse_humidity_element already returns outdoor_humidity for
-            # idx=02, so no humidity remapping is needed.  Only remap
-            # temperature → outdoor_temp.
-            if "temperature" in mutated:
-                mutated["outdoor_temp"] = mutated.pop("temperature")
+            # idx=02, so no humidity remapping is needed.
+            #
+            # NOTE: idx=02 also includes a temperature field, but we do NOT
+            # remap it to outdoor_temp.  The 12A0 array comes from a separate
+            # HUM sensor, and the dispatcher routes it to the FAN's hvac_state
+            # (as dst target).  If we remap temperature → outdoor_temp here,
+            # it creates a second outdoor_temp source that conflicts with
+            # 31DA's outdoor_temp, causing the sensor to bounce between the
+            # two values every polling cycle.  31DA is the authoritative
+            # source for outdoor_temp; 12A0 idx=02 only contributes
+            # outdoor_humidity.  See ramses_cc#742.
+            pass
         return mutated
 
     # QUIRK: 31DA humidity 0.0 → None (null-marker normalisation)

--- a/tests/tests_rf/test_quirks.py
+++ b/tests/tests_rf/test_quirks.py
@@ -138,19 +138,29 @@ class TestQuirks12A0Idx02:
     """12A0 idx=02: outdoor sensor.
 
     parse_humidity_element already returns ``outdoor_humidity`` for idx=02,
-    so no humidity remapping is needed.  Only temperature → outdoor_temp.
+    so no humidity remapping is needed.
+
+    The temperature field is NOT remapped to outdoor_temp — 12A0 comes from
+    a separate HUM sensor, and remapping it creates a second outdoor_temp
+    source that conflicts with 31DA's outdoor_temp on the FAN's hvac_state.
+    See ramses_cc#742.
     """
 
-    def test_idx02_remaps_temperature_to_outdoor_temp(self) -> None:
-        """idx=02 temperature should be remapped to outdoor_temp."""
+    def test_idx02_does_not_remap_temperature_to_outdoor_temp(self) -> None:
+        """idx=02 temperature should NOT be remapped to outdoor_temp.
+
+        31DA is the authoritative source for outdoor_temp.  Remapping 12A0
+        idx=02 temperature causes outdoor_temp to bounce between the HUM
+        sensor reading (12A0) and the FAN snapshot (31DA).
+        """
         payload = {
             "hvac_idx": "02",
             SZ_OUTDOOR_HUMIDITY: 0.69,
             "temperature": 27.42,
         }
         result = _quirk(payload, None, "12A0")
-        assert result[SZ_OUTDOOR_TEMP] == 27.42
-        assert "temperature" not in result
+        assert SZ_OUTDOOR_TEMP not in result
+        assert "temperature" in result  # left as-is, not remapped
 
     def test_idx02_preserves_outdoor_humidity(self) -> None:
         """idx=02 outdoor_humidity should pass through unchanged."""
@@ -205,8 +215,8 @@ class TestQuirks12A0FullList:
         # idx=01
         assert SZ_REL_HUMIDITY not in results[1]
         assert "temperature" not in results[1] or results[1].get("supply_temp") is None
-        # idx=02
-        assert results[2][SZ_OUTDOOR_TEMP] == 27.42
+        # idx=02: outdoor_humidity passes through, temperature is NOT remapped
+        assert SZ_OUTDOOR_TEMP not in results[2]  # not remapped (31DA is authoritative)
         assert results[2][SZ_OUTDOOR_HUMIDITY] == 0.69
 
     def test_ventura_real_payload_pattern(self) -> None:
@@ -253,8 +263,8 @@ class TestQuirks12A0FullList:
         # temperature=None gets popped into supply_temp
         assert results[1].get(SZ_SUPPLY_TEMP) is None
 
-        # idx=02: outdoor
-        assert results[2][SZ_OUTDOOR_TEMP] == 27.42
+        # idx=02: outdoor (humidity only, temp NOT remapped to outdoor_temp)
+        assert SZ_OUTDOOR_TEMP not in results[2]  # not remapped (31DA is authoritative)
         assert results[2][SZ_OUTDOOR_HUMIDITY] == pytest.approx(0.271, abs=0.01)
 
 


### PR DESCRIPTION
fix: revert 12A0 idx=02 temperature→outdoor_temp remapping

The idx=02 remapping introduced in PR 749 caused outdoor_temp to bounce on Ventura setups.  12A0 comes from a separate HUM sensor, and the dispatcher routes it to the FAN's hvac_state (as dst target).  When both 12A0 (HUM sensor) and 31DA (FAN snapshot) provide outdoor_temp, the sensor bounces between the two values every polling cycle.

31DA is the authoritative source for outdoor_temp.  12A0 idx=02 now only contributes outdoor_humidity (which 31DA may not provide).

All other fixes from PR 749 remain intact:
- 12A0 idx=00: temperature → indoor_temp (unchanged)
- 12A0 idx=01: rel_humidity dropped, temperature → supply_temp (unchanged)
- 31DA humidity 0.0 → None normalisation (unchanged)
- 31D9 fan_mode "FF" → None normalisation (unchanged)
- 31DA bypass_position/fan_info/exhaust_fan_speed preservation (unchanged)
- pipeline/ingestion.py null-marker filtering (unchanged)
