### PR TITLE
fix: restore HGI ID patching in PortProtocol.send_cmd

### DIFF
--- a/src/ramses_tx/protocol/core.py
+++ b/src/ramses_tx/protocol/core.py
@@ -302,6 +302,13 @@ class PortProtocol(_DeviceIdFilterMixin):
             _LOGGER.warning(f"{cmd} < num_repeats set to 0, as wait_for_reply is True")
             num_repeats = 0
 
+        # Patch command with actual HGI ID if it uses the default placeholder.
+        # PortProtocol.send_cmd overrides _BaseProtocol.send_cmd (which does this
+        # patching at base.py:309), so we must replicate it here. Without this,
+        # all commands go out with the 18:000730 placeholder instead of the real
+        # HGI ID. See ramses_cc#757.
+        cmd = self._patch_cmd_if_needed(cmd)
+
         # Manual filter check to avoid calling super().send_cmd(), which fails
         if not self._is_wanted_addrs(cmd.src.id, cmd.dst.id, sending=True):
             raise ProtocolError(f"Command excluded by device_id filter: {cmd}")

--- a/tests/tests_rf/test_hgi_behaviors.py
+++ b/tests/tests_rf/test_hgi_behaviors.py
@@ -138,7 +138,9 @@ async def _test_gwy_device(gwy: Gateway, test_idx: int) -> None:
         assert False, pkt  # should have failed, but has not!
 
     # NOTE: both HGI80/evofw3 will swap out addr0 (only) for its own device_id
-    if cmd_str[7:16] == HGI_DEVICE_ID:
+    # evofw3 will also patch src if it is the HGI placeholder (incl. --:------
+    # which Command normalizes to 18:000730 when addr0 is 18:000730)
+    if cmd_str[7:16] == HGI_DEVICE_ID or (not is_hgi80 and cmd.src.id == HGI_DEVICE_ID):
         pkt_str = cmd_str[:7] + gwy.hgi.id + cmd_str[16:]
     else:
         pkt_str = cmd_str


### PR DESCRIPTION
PortProtocol.send_cmd overrides _BaseProtocol.send_cmd and skips the _patch_cmd_if_needed() call, so all commands go out with the 18:000730 placeholder instead of the real HGI ID. This affects all transport types (native MQTT, HA MQTT bridge, serial/USB).

Confirmed on two independent systems: TX commands carry 18:000730 while RX shows the real ESP ID. The ESP rewrites the ID for RF, so devices still respond, but the MQTT frame carries the wrong placeholder.

[See ramses_cc issue 757.
](https://github.com/ramses-rf/ramses_cc/issues/757)
