### PR TITLE
fix: drop raw-hex fan_mode from 31D9 to prevent toggle with 22F4

### DIFF
--- a/src/ramses_rf/dispatcher.py
+++ b/src/ramses_rf/dispatcher.py
@@ -530,9 +530,15 @@ def _update_hvac_state(target: Any, p: dict[str, Any], msg: Message) -> None:
         # None = "not implemented" (e.g. EF in bypass_position)
         if val is None:
             continue
-        # "FF" = "no data" marker from 31D9 raw hex fan_mode
-        if f == SZ_FAN_MODE and val == "FF":
-            continue
+        # Raw hex (e.g. "FF", "04") = non-semantic fan_mode from 31D9
+        # long-payload devices; the quirk normalises these to None, but
+        # filter here as belt-and-suspenders.  See ramses_cc issue 723.
+        if f == SZ_FAN_MODE and isinstance(val, str) and len(val) == 2:
+            try:
+                int(val, 16)
+                continue
+            except ValueError:
+                pass
         # 0.0 for humidity = "no sensor" (00 parses as 0%, physically impossible)
         if f in _NULL_HUMIDITY_FIELDS and val == 0:
             continue

--- a/src/ramses_rf/pipeline/ingestion.py
+++ b/src/ramses_rf/pipeline/ingestion.py
@@ -465,9 +465,15 @@ class StateProjector:
             # None = "not implemented" (e.g. EF in bypass_position)
             if val is None:
                 continue
-            # "FF" = "no data" marker from 31D9 raw hex fan_mode
-            if f == SZ_FAN_MODE and val == "FF":
-                continue
+            # Raw hex (e.g. "FF", "04") = non-semantic fan_mode from 31D9
+            # long-payload devices; the quirk normalises these to None, but
+            # filter here as belt-and-suspenders.  See ramses_cc issue 723.
+            if f == SZ_FAN_MODE and isinstance(val, str) and len(val) == 2:
+                try:
+                    int(val, 16)
+                    continue
+                except ValueError:
+                    pass
             # 0.0 for humidity = "no sensor" (00 parses as 0%, physically impossible)
             if f in _NULL_HUMIDITY_FIELDS and val == 0:
                 continue

--- a/src/ramses_rf/quirks.py
+++ b/src/ramses_rf/quirks.py
@@ -121,14 +121,30 @@ def apply_hvac_quirks(
             if key in mutated and mutated[key] == 0.0:
                 mutated[key] = None
 
-    # QUIRK: 31D9 fan_mode "FF" → None (null-marker normalisation)
-    # 31D9 sends raw hex "FF" for fan_mode when no data is available.  The
-    # dispatcher filters this, but the StateProjector (ingestion.py) does not.
-    # Normalise to None so both paths filter it.  The valid fan_mode comes
-    # from 22F4 (or 22F1 for some schemes).  See ramses_cc#742.
+    # QUIRK: 31D9 raw-hex fan_mode → None (semantic-value preservation)
+    # For long-payload devices (Orcon, Brofer, etc.), the 31D9 parser sets
+    # fan_mode = payload[4:6] — a raw hex byte like "04", "C8", "FF".  These
+    # are NOT semantic names and conflict with the semantic fan_mode from
+    # 22F4 ("off", "paused", "auto", "manual") or 22F1 (scheme-specific
+    # names like "away", "low", "high", "boost").  The raw hex overwrites
+    # the good semantic value every 31D9 broadcast cycle, causing fan_mode
+    # to toggle (e.g. "auto" ↔ "04").
+    #
+    # Vasco/ClimaRad short payloads (msg.len == 3) are already converted to
+    # semantic strings by the parser's _31D9_FAN_INFO_VASCO lookup, so they
+    # won't match the hex pattern and are preserved.
+    #
+    # Drop any fan_mode that is a 2-char hex string (raw byte).  The
+    # authoritative semantic fan_mode comes from 22F4 (polled) or 22F1
+    # (command reply).  See ramses_cc issue 723.
     if msg_code == "31D9" and SZ_FAN_MODE in mutated:
-        if mutated[SZ_FAN_MODE] == "FF":
-            mutated[SZ_FAN_MODE] = None
+        val = mutated[SZ_FAN_MODE]
+        if isinstance(val, str) and len(val) == 2:
+            try:
+                int(val, 16)  # is it a raw hex byte?
+                mutated[SZ_FAN_MODE] = None
+            except ValueError:
+                pass  # semantic string, keep it
 
     if not current_state:
         return mutated

--- a/tests/tests_rf/test_quirks.py
+++ b/tests/tests_rf/test_quirks.py
@@ -638,16 +638,22 @@ class TestQuirks31DAHumidityNormalisation:
 
 
 # ---------------------------------------------------------------------------
-# 31D9 fan_mode "FF" → None normalisation
+# 31D9 raw-hex fan_mode → None normalisation
 # ---------------------------------------------------------------------------
 
 
 class TestQuirks31D9FanModeNormalisation:
-    """31D9 sends raw hex "FF" for fan_mode when no data is available.
-    The quirks normalise it to None so that BOTH ingestion paths filter it.
-    The valid fan_mode comes from 22F4 (or 22F1 for some schemes).
+    """31D9 long-payload devices (Orcon, Brofer) send raw hex bytes for
+    fan_mode (e.g. "04", "FF", "C8").  These are not semantic names and
+    conflict with the semantic fan_mode from 22F4/22F1.  The quirks
+    normalise any 2-char hex string to None so that BOTH ingestion paths
+    filter it.  The valid semantic fan_mode comes from 22F4 (polled) or
+    22F1 (command reply).
 
-    See ramses_cc#742.
+    Vasco/ClimaRad short payloads (msg.len == 3) are already converted to
+    semantic strings by the parser and are preserved.
+
+    See ramses_cc issue 723 and ramses_cc issue 742.
     """
 
     def test_fan_mode_ff_normalised_to_none(self) -> None:
@@ -658,30 +664,78 @@ class TestQuirks31D9FanModeNormalisation:
         result = _quirk(payload, None, "31D9")
         assert result[SZ_FAN_MODE] is None
 
-    def test_fan_mode_valid_passes_through(self) -> None:
-        """A valid fan_mode should pass through unchanged."""
+    def test_fan_mode_04_normalised_to_none(self) -> None:
+        """fan_mode='04' (raw hex, Orcon) from 31D9 should be normalised."""
         from ramses_tx.const import SZ_FAN_MODE
 
-        payload = {SZ_FAN_MODE: "05"}
+        payload = {SZ_FAN_MODE: "04"}
         result = _quirk(payload, None, "31D9")
-        assert result[SZ_FAN_MODE] == "05"
+        assert result[SZ_FAN_MODE] is None
 
-    def test_fan_mode_ff_with_existing_state(self) -> None:
-        """fan_mode='FF' should be normalised even with existing state."""
+    def test_fan_mode_c8_normalised_to_none(self) -> None:
+        """fan_mode='C8' (raw hex, Itho boost) from 31D9 should be normalised."""
         from ramses_tx.const import SZ_FAN_MODE
 
-        state = _make_state()
-        payload = {SZ_FAN_MODE: "FF"}
+        payload = {SZ_FAN_MODE: "C8"}
+        result = _quirk(payload, None, "31D9")
+        assert result[SZ_FAN_MODE] is None
+
+    def test_fan_mode_00_normalised_to_none(self) -> None:
+        """fan_mode='00' (raw hex, off) from 31D9 should be normalised."""
+        from ramses_tx.const import SZ_FAN_MODE
+
+        payload = {SZ_FAN_MODE: "00"}
+        result = _quirk(payload, None, "31D9")
+        assert result[SZ_FAN_MODE] is None
+
+    def test_fan_mode_semantic_auto_preserved(self) -> None:
+        """Semantic fan_mode='auto' (from Vasco lookup) should pass through."""
+        from ramses_tx.const import SZ_FAN_MODE
+
+        payload = {SZ_FAN_MODE: "auto"}
+        result = _quirk(payload, None, "31D9")
+        assert result[SZ_FAN_MODE] == "auto"
+
+    def test_fan_mode_semantic_off_preserved(self) -> None:
+        """Semantic fan_mode='off' (from Vasco lookup) should pass through."""
+        from ramses_tx.const import SZ_FAN_MODE
+
+        payload = {SZ_FAN_MODE: "off"}
+        result = _quirk(payload, None, "31D9")
+        assert result[SZ_FAN_MODE] == "off"
+
+    def test_fan_mode_semantic_vasco_speed_preserved(self) -> None:
+        """Semantic fan_mode='4 (boost)' (from Vasco lookup) should pass through."""
+        from ramses_tx.const import SZ_FAN_MODE
+
+        payload = {SZ_FAN_MODE: "4 (boost)"}
+        result = _quirk(payload, None, "31D9")
+        assert result[SZ_FAN_MODE] == "4 (boost)"
+
+    def test_fan_mode_raw_hex_with_existing_state(self) -> None:
+        """Raw hex fan_mode should be normalised even with existing state."""
+        from ramses_tx.const import SZ_FAN_MODE
+
+        state = _make_state(fan_mode="auto")
+        payload = {SZ_FAN_MODE: "04"}
         result = _quirk(payload, state, "31D9")
         assert result[SZ_FAN_MODE] is None
 
-    def test_fan_mode_ff_only_for_31d9(self) -> None:
-        """The fan_mode 'FF' normalisation should only apply to 31D9."""
+    def test_fan_mode_raw_hex_only_for_31d9(self) -> None:
+        """The raw-hex normalisation should only apply to 31D9, not 22F4."""
         from ramses_tx.const import SZ_FAN_MODE
 
-        payload = {SZ_FAN_MODE: "FF"}
+        payload = {SZ_FAN_MODE: "04"}
         result = _quirk(payload, None, "22F4")
-        assert result[SZ_FAN_MODE] == "FF"
+        assert result[SZ_FAN_MODE] == "04"
+
+    def test_fan_mode_lowercase_hex_normalised(self) -> None:
+        """Lowercase raw hex should also be normalised."""
+        from ramses_tx.const import SZ_FAN_MODE
+
+        payload = {SZ_FAN_MODE: "0a"}
+        result = _quirk(payload, None, "31D9")
+        assert result[SZ_FAN_MODE] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
31D9 long-payload devices (Orcon, Brofer) emit raw hex bytes for fan_mode (e.g. "04", "C8", "FF") which conflict with the semantic fan_mode from 22F4 ("auto", "off", "paused", "manual") or 22F1 (scheme-specific names). Every 31D9 broadcast cycle overwrites the good semantic value, causing fan_mode to toggle (e.g. "auto" ↔ "04" every ~30 minutes).

The previous fix only normalised "FF" → None.  This extends the quirk to drop any 2-char hex string (raw byte) from 31D9 fan_mode.  Semantic strings from the Vasco/ClimaRad short-payload lookup (e.g. "auto", "off", "4 (boost)") are preserved — they don't match the hex pattern.

The dispatcher and pipeline/ingestion.py filters are updated to match, providing belt-and-suspenders protection across both ingestion paths.

The authoritative semantic fan_mode comes from:
- 22F4 (polled RP, every ~30 min)
- 22F1 (command reply, when user sets fan mode)

See [ramses_cc issue 723.](https://github.com/ramses-rf/ramses_cc/issues/723)

