### PR TITLE
feat: add discovery commands for Programmer

### DIFF
--- a/src/ramses_rf/devices/heat_controllers.py
+++ b/src/ramses_rf/devices/heat_controllers.py
@@ -115,6 +115,20 @@ class Programmer(Controller):  # PRG (23):
 
     _SLUG = DevType.PRG
 
+    def _setup_discovery_cmds(self) -> None:
+        super()._setup_discovery_cmds()
+
+        if not self.is_faked:
+            # PRGs respond to RP for 1090, 10A0, 3EF1
+            self.discovery.add_cmd(
+                Command.from_attrs(RQ, self.id, Code._1090, PayloadT("00")),
+                60 * 60 * 6,  # every 6 hours
+            )
+            self.discovery.add_cmd(
+                Command.from_attrs(RQ, self.id, Code._10A0, PayloadT("00")),
+                60 * 60 * 6,
+            )
+
 
 class RfgGateway(DeviceHeat):  # RFG (30:)
     """The RFG100 base class."""


### PR DESCRIPTION
Phase 2 of (https://github.com/ramses-rf/ramses_cc/pull/759) fill discovery command gaps for device types that can respond to RQ but have no _setup_discovery_cmds() override.

Programmer (23:): add RQ 1090, 10A0 (every 6h) — PRGs have RP for these codes in the protocol schema.

HvacRemote (REM): add RQ 10D0 (every 24h) — REMs have RP for 10D0 (filter change status) in the protocol schema.

Note: TRV (04:) and DHW (07:) as far as I can see these are passive-only by protocol design (zero RP codes) and cannot be actively probed. The discover_known_devices service in ramses_cc creates them from known_list/schema, but they only get state data when they broadcast traffic on their own.

https://github.com/ramses-rf/ramses_cc/issues/627

