### PR TITLE
feature/passive-scan (cc issue 762)

### DIFF
--- a/src/ramses_cli/client.py
+++ b/src/ramses_cli/client.py
@@ -27,6 +27,7 @@ from ramses_rf.const import (
     W_,
     Code,
 )
+from ramses_rf.discovery_scan import DiscoveryScan
 from ramses_rf.gateway import GatewayConfig
 from ramses_rf.helpers import deep_merge
 from ramses_rf.schemas import (
@@ -87,6 +88,7 @@ EXECUTE: Final = "execute"
 LISTEN: Final = "listen"
 MONITOR: Final = "monitor"
 PARSE: Final = "parse"
+SCAN: Final = "scan"
 
 
 COLORS = {
@@ -304,7 +306,7 @@ class PortCommand(
 
 
 #
-# 1/4: PARSE (a file, +/- eavesdrop)
+# 1/5: PARSE (a file, +/- eavesdrop)
 @click.command(cls=FileCommand)  # parse a packet log file, then stop
 @click.pass_obj
 async def parse(
@@ -324,7 +326,7 @@ async def parse(
 
 
 #
-# 2/4: MONITOR (listen to RF, +/- discovery, +/- eavesdrop)
+# 2/5: MONITOR (listen to RF, +/- discovery, +/- eavesdrop)
 @click.command(cls=PortCommand)  # (optionally) execute a command/script, then monitor
 @click.option("-d/-nd", "--discover/--no-discover", default=None)  # --no-discover
 @click.option(  # --exec-cmd 'RQ 01:123456 1F09 00'
@@ -366,7 +368,7 @@ async def monitor(
 
 
 #
-# 3/4: EXECUTE (send cmds to RF, +/- discovery, +/- eavesdrop)
+# 3/5: EXECUTE (send cmds to RF, +/- discovery, +/- eavesdrop)
 @click.command(cls=PortCommand)  # execute a (complex) script, then stop
 @click.option("-d/-nd", "--discover/--no-discover", default=None)  # --no-discover
 @click.option(  # --exec-cmd 'RQ 01:123456 1F09 00'
@@ -426,7 +428,7 @@ async def execute(
 
 
 #
-# 4/4: LISTEN (to RF, +/- eavesdrop - NO sending/discovery)
+# 4/5: LISTEN (to RF, +/- eavesdrop - NO sending/discovery)
 @click.command(cls=PortCommand)  # (optionally) execute a command, then listen
 @click.pass_obj
 async def listen(
@@ -448,6 +450,84 @@ async def listen(
     lib_config[SZ_CONFIG][SZ_DISABLE_SENDING] = True
 
     return LISTEN, lib_config, config
+
+
+#
+# 5/5: SCAN (passive device discovery — listen, classify, export, stop)
+@click.command(cls=PortCommand)
+@click.option(  # --duration seconds (0 = until Ctrl-C)
+    "-d",
+    "--duration",
+    type=int,
+    default=300,
+    help="scan duration in seconds (0 = until interrupted)",
+)
+@click.option(  # --output file
+    "-o",
+    "--output",
+    type=click.Path(),
+    help="export discovered devices to JSON file",
+)
+@click.pass_obj
+async def scan(
+    obj: Any, /, duration: int = 300, **kwargs: Any
+) -> tuple[Literal["scan"], dict[str, str], dict[str, Any]]:
+    """Passive device scan: listen to RF, classify unknown devices, export.
+
+    No discovery, no eavesdrop, no sending — pure observation.
+    Discovered devices are classified by prefix and verb/code pairs.
+
+    :param obj: The context object containing configuration.
+    :param duration: Scan duration in seconds (0 = until interrupted).
+    :param kwargs: Additional keyword arguments.
+    :return: Tuple of command name, library config, and CLI config.
+    """
+    config, lib_config = split_kwargs(obj, kwargs)
+
+    print(" - sending is force-disabled (passive scan)")
+    lib_config[SZ_CONFIG][SZ_DISABLE_SENDING] = True
+    lib_config[SZ_CONFIG][SZ_DISABLE_DISCOVERY] = True
+
+    # Pass duration and output via kwargs (consumed in async_main)
+    config["scan_duration"] = duration
+    config["scan_output"] = kwargs.get("output")
+
+    return SCAN, lib_config, config
+
+
+def _print_scan_results(scan: DiscoveryScan, output_path: str | None) -> None:
+    """Print discovered devices and optionally export to JSON file.
+
+    :param scan: The DiscoveryScan engine instance.
+    :param output_path: Optional file path to export JSON to.
+    """
+    devices = scan.get_devices()
+    if not devices:
+        print("No unknown devices discovered.")
+        return
+
+    print(f"\nFound {len(devices)} device(s):\n")
+    print(f"  {'Device ID':<12} {'Type':<6} {'Conf':<7} {'RSSI':>6}  Details")
+    print(f"  {'-' * 12} {'-' * 6} {'-' * 7} {'-' * 6}  {'-' * 30}")
+    for dev in sorted(devices, key=lambda d: d.device_id):
+        rssi_str = f"{dev.rssi:.0f}" if dev.rssi is not None else "-"
+        details = ""
+        if dev.zone_idx:
+            details += f"zone={dev.zone_idx}  "
+        if dev.bound_to:
+            details += f"bound to {dev.bound_to}"
+        if dev.is_battery:
+            details += "  battery" if details else "battery"
+        print(
+            f"  {dev.device_id:<12} {dev.likely_type:<6} "
+            f"{dev.confidence:<7} {rssi_str:>6}  {details}".rstrip()
+        )
+
+    if output_path:
+        json_data = scan.export_json()
+        with open(output_path, "w") as f:
+            f.write(json_data)
+        print(f"\nExported to {output_path}")
 
 
 def print_results(gwy: Gateway, **kwargs: Any) -> None:
@@ -718,23 +798,36 @@ async def async_main(command: str, lib_kwargs: dict[str, Any], **kwargs: Any) ->
         # python client.py -rrr listen /dev/ttyUSB0
         # cat *.log | head | python client.py parse
 
-        if command == EXECUTE:
+        if command == EXECUTE:  # 3/5
             tasks = spawn_scripts(gwy, **kwargs)
             await asyncio.gather(*tasks)
 
-        elif command == MONITOR:
+        elif command == MONITOR:  # 2/5
             _ = spawn_scripts(gwy, **kwargs)
             await gwy._engine._protocol.wait_for_connection_lost(timeout=86400)
             # timeout set to timeout=86400, to stop type checker complaint if sent to None
 
-        elif command == PARSE:
+        elif command == PARSE:  # 1/5
             # Wait indefinitely until EOF closes the transport
             await gwy._engine._protocol.wait_for_connection_lost(timeout=86400)
             # timeout set to timeout=86400, to stop type checker complaint if sent to None
 
-        elif command == LISTEN:
+        elif command == LISTEN:  # 4/5
             await gwy._engine._protocol.wait_for_connection_lost(timeout=86400)
             # timeout set to timeout=86400, to stop type checker complaint if sent to None
+
+        elif command == SCAN:  # 5/5
+            scan_engine = DiscoveryScan(gwy)
+            scan_engine.start()
+            duration = kwargs.get("scan_duration", 300)
+            if duration > 0:
+                print(f" - scanning for {duration} seconds...")
+                await asyncio.sleep(duration)
+            else:
+                print(" - scanning until interrupted (Ctrl-C)...")
+                await gwy._engine._protocol.wait_for_connection_lost(timeout=86400)
+            scan_engine.stop()
+            _print_scan_results(scan_engine, kwargs.get("scan_output"))
 
     except asyncio.CancelledError:
         msg = "ended via: CancelledError (e.g. SIGINT)"
@@ -770,6 +863,7 @@ cli.add_command(parse)
 cli.add_command(monitor)
 cli.add_command(execute)
 cli.add_command(listen)
+cli.add_command(scan)
 
 
 def _run_cli() -> None:

--- a/src/ramses_rf/discovery_scan.py
+++ b/src/ramses_rf/discovery_scan.py
@@ -85,6 +85,12 @@ _ZONE_BINDING_CODES: frozenset[str] = frozenset(
     {"3150", "30C9", "000C", "2309", "2349", "10A0", "1260", "12B0", "1F09"}
 )
 
+# 32: is unambiguous — always a FAN. A FAN sends 22F1 (which maps to REM in
+# HVAC_KLASS_BY_VC_PAIR) but is still a FAN, so the prefix must win.
+# 37: is ambiguous (REM, CO2, or HUM all use 37:) — needs the VC pair to
+# distinguish, so it's NOT in this set.
+_UNAMBIGUOUS_HVAC_PREFIXES: frozenset[str] = frozenset({"32"})
+
 
 # ---------------------------------------------------------------------------
 # Data class
@@ -482,23 +488,29 @@ def _classify(
     """Classify a device based on prefix, verb/code, and accumulated evidence.
 
     Priority:
-    1. Verb+code pair (HVAC) — strongest signal for HVAC devices
+    1. HVAC prefix (32:=FAN, 37:=REM) — unambiguous, takes precedence over
+       verb/code pairs (a FAN sends 22F1, but that doesn't make it a REM)
     2. CTL-only codes — if device sends these, it's a CTL
-    3. Prefix — fallback for CH devices
-    4. Accumulated codes — if we have a dev with codes_seen, re-evaluate
+    3. Verb+code pair (HVAC) — for non-HVAC prefixes that send HVAC codes
+    4. CH prefix — fallback for heating domain devices
+    5. Accumulated codes — re-evaluate with full evidence
     """
     prefix = dev_id[:2]
 
-    # 1. Check verb+code pair (HVAC domain)
-    vc_key = (verb, code)
-    if vc_key in _VC_TO_TYPE:
-        return _VC_TO_TYPE[vc_key]
+    # 1. Unambiguous HVAC prefixes (32:=FAN) — check first
+    if prefix in _UNAMBIGUOUS_HVAC_PREFIXES:
+        return _PREFIX_TO_TYPE[prefix]
 
     # 2. CTL-only codes (only if this device is the sender)
     if is_src and code in _CTL_ONLY_CODES:
         return DevType.CTL
 
-    # 3. Check accumulated codes if we have a dev
+    # 3. Check verb+code pair (HVAC domain, for non-HVAC prefixes)
+    vc_key = (verb, code)
+    if vc_key in _VC_TO_TYPE:
+        return _VC_TO_TYPE[vc_key]
+
+    # 4. Check accumulated codes if we have a dev
     if dev and is_src:
         for c in dev.codes_seen:
             if c in _CTL_ONLY_CODES:
@@ -509,7 +521,7 @@ def _classify(
                 if (v, c) in _VC_TO_TYPE:
                     return _VC_TO_TYPE[(v, c)]
 
-    # 4. Prefix fallback
+    # 5. CH prefix fallback
     if prefix in _PREFIX_TO_TYPE:
         return _PREFIX_TO_TYPE[prefix]
 

--- a/src/ramses_rf/discovery_scan.py
+++ b/src/ramses_rf/discovery_scan.py
@@ -1,0 +1,559 @@
+#!/usr/bin/env python3
+"""RAMSES RF - Passive device scan engine.
+
+A read-only observer that listens to RF traffic, classifies unknown devices
+by prefix and verb/code pairs, and maintains an in-memory discovery list.
+
+This module is the scan engine only — it does NOT:
+  - create devices in the registry (no `get_device()` calls)
+  - mutate topology (no `TopologyChangedEvent`s)
+  - write to disk (everything in-memory, consumer calls `export_json()`)
+  - depend on Home Assistant (plain Python, works in CLI)
+
+The consumer (ramses_cc or the CLI) is responsible for persistence,
+notifications, and user-facing accept/discard workflow.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+from datetime import datetime as dt
+from typing import TYPE_CHECKING, Any
+
+from ramses_rf.const import DevType
+from ramses_rf.protocol.ramses import HVAC_KLASS_BY_VC_PAIR
+
+if TYPE_CHECKING:
+    from ramses_rf.gateway import Gateway
+    from ramses_tx.dtos import PacketDTO
+
+
+_LOGGER = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Classification maps
+# ---------------------------------------------------------------------------
+
+# Prefix → likely DevType (CH + HVAC domain).
+# Not reused from DEV_TYPE_MAP because that maps prefix→human-readable string
+# (e.g. "controller"), not prefix→DevType enum (e.g. CTL). Also, DEV_TYPE_MAP
+# lacks HVAC prefixes (32:=FAN, 37:=REM). TopologyBuilder has a similar local
+# dict but smaller (only eavesdrop-promotable types). Keeping our own is
+# the simplest correct approach.
+_PREFIX_TO_TYPE: dict[str, DevType] = {
+    "00": DevType.TRV,  # radiator_valve (rare, same class as 04:)
+    "01": DevType.CTL,
+    "02": DevType.UFC,
+    "03": DevType.THM,
+    "04": DevType.TRV,
+    "07": DevType.DHW,
+    "08": DevType.JIM,
+    "10": DevType.BDR,
+    "12": DevType.THM,
+    "13": DevType.OTB,
+    "17": DevType.OUT,
+    "18": DevType.HGI,
+    "22": DevType.THM,
+    "23": DevType.PRG,
+    "30": DevType.RFG,
+    "31": DevType.JST,
+    "32": DevType.FAN,
+    "34": DevType.RND,
+    "37": DevType.REM,
+}
+
+# Verb+code → DevType (HVAC domain, from HVAC_KLASS_BY_VC_PAIR).
+# Keys are (verb_value, code_value) tuples for fast lookup.
+_VC_TO_TYPE: dict[tuple[str, str], DevType] = {
+    (v.value, str(c)): dt for (v, c), dt in HVAC_KLASS_BY_VC_PAIR.items()
+}
+
+# Codes that only a CTL sends (from CODES_ONLY_FROM_CTL).
+# If a device sends one of these, it's definitely a CTL.
+_CTL_ONLY_CODES: frozenset[str] = frozenset({"1030", "1F09", "313F"})
+
+# Codes that indicate battery-powered devices.
+_BATTERY_CODES: frozenset[str] = frozenset({"1060", "1FC9"})
+
+# Codes that carry zone_idx in the payload (binding telemetry).
+# Used to extract zone assignment from traffic.
+_ZONE_BINDING_CODES: frozenset[str] = frozenset(
+    {"3150", "30C9", "000C", "2309", "2349", "10A0", "1260", "12B0", "1F09"}
+)
+
+
+# ---------------------------------------------------------------------------
+# Data class
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DiscoveredDevice:
+    """A device seen on RF, classified but not yet created in the registry.
+
+    This dataclass is the scan engine's view of a device. The consumer
+    (ramses_cc) extends it with status/enabled/owner/faked fields stored
+    in HA's .storage/.
+    """
+
+    device_id: str
+    first_seen: str  # ISO timestamp
+    last_seen: str  # ISO timestamp
+    likely_type: str  # DevType value (e.g. "CTL", "TRV")
+    codes_seen: list[str] = field(default_factory=list)  # sorted, deduplicated
+    bound_to: str | None = None  # parent device ID (CTL for TRV, FAN for REM)
+    zone_idx: str | None = None  # zone index if known from payload
+    rssi: float | None = None  # running average
+    confidence: str = "low"  # high, medium, low
+    is_battery: bool = False  # seen sending battery info
+    src_count: int = 0  # number of packets where this device was src
+    dst_count: int = 0  # number of packets where this device was dst
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain dict (for JSON export)."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DiscoveredDevice:
+        """Deserialize from a plain dict (for JSON import/resume)."""
+        return cls(**{k: data[k] for k in data if k in cls.__dataclass_fields__})
+
+
+# ---------------------------------------------------------------------------
+# Scan engine
+# ---------------------------------------------------------------------------
+
+
+class DiscoveryScan:
+    """Passive device scanner. Read-only, no topology mutation.
+
+    Register as a msg_handler on the gateway. Every packet is examined:
+    - src, dst, addr3 device IDs are extracted
+    - Unknown devices are classified and added to the in-memory dict
+    - Known devices are enriched with new codes/binding info
+
+    The scan never calls ``get_device()`` or emits topology events.
+    """
+
+    def __init__(self, gwy: Gateway) -> None:
+        self._gwy = gwy
+        self._devices: dict[str, DiscoveredDevice] = {}
+        self._dirty: bool = False
+        self._remove_handler: Callable[[], None] | None = None
+
+    # -- lifecycle -----------------------------------------------------------
+
+    def start(self) -> None:
+        """Register as a msg_handler on the gateway."""
+        if self._remove_handler is not None:
+            _LOGGER.warning("DiscoveryScan.start(): already running")
+            return
+        self._remove_handler = self._gwy.add_msg_handler(self._on_packet)
+        _LOGGER.info("DiscoveryScan: started (passive observer)")
+
+    def stop(self) -> None:
+        """Unregister from gateway."""
+        if self._remove_handler:
+            self._remove_handler()
+            self._remove_handler = None
+            _LOGGER.info("DiscoveryScan: stopped")
+
+    @property
+    def is_running(self) -> bool:
+        """Whether the scan is currently listening to traffic."""
+        return self._remove_handler is not None
+
+    @property
+    def is_dirty(self) -> bool:
+        """Whether the in-memory state has changed since last export/import."""
+        return self._dirty
+
+    def clear_dirty(self) -> None:
+        """Reset the dirty flag (call after successful persistence)."""
+        self._dirty = False
+
+    # -- known device check --------------------------------------------------
+
+    def _is_known(self, dev_id: str) -> bool:
+        """Check if a device is already known to the gateway.
+
+        A device is "known" if it's in the known_list, schema, or
+        already in the device registry.
+        """
+        # Check device registry (already created devices)
+        if dev_id in self._gwy.device_registry.device_by_id:
+            return True
+
+        # Check known_list
+        if dev_id in self._gwy._gwy_config.known_list:
+            return True
+
+        # Check schema keys (CTL IDs are top-level keys)
+        return dev_id in self._gwy._gwy_config.schema
+
+    # -- packet handler ------------------------------------------------------
+
+    async def _on_packet(self, dto: PacketDTO) -> None:
+        """Async wrapper for the gateway msg_handler interface.
+
+        Delegates to the sync ``_process_packet`` so tests can call it
+        directly without an event loop.
+        """
+        self._process_packet(dto)
+
+    def _process_packet(self, dto: PacketDTO) -> None:
+        """Classify packet, update in-memory dict. No disk I/O.
+
+        Called for every valid packet from the gateway. Must be fast —
+        just dict lookups and updates.
+        """
+        # Extract device IDs from the packet
+        src = dto.addr1.strip()
+        dst = dto.addr2.strip()
+        addr3 = dto.addr3.strip() if dto.addr3 else ""
+        code = str(dto.code).strip()
+        verb = dto.verb.strip() if dto.verb else ""
+
+        # Parse RSSI (stored as string in PacketDTO)
+        rssi: float | None = None
+        if dto.rssi:
+            with contextlib.suppress(ValueError, TypeError):
+                rssi = float(dto.rssi)
+
+        # Extract zone_idx from payload if this is a binding code
+        zone_idx = (
+            _extract_zone_idx(dto.payload) if code in _ZONE_BINDING_CODES else None
+        )
+
+        # Process each address in the packet
+        # src: high-confidence (device is actively sending)
+        if src and _is_valid_address(src):
+            self._process_device(
+                src,
+                code=code,
+                verb=verb,
+                rssi=rssi,
+                zone_idx=zone_idx,
+                is_src=True,
+                dst=dst,
+            )
+
+        # dst: lower-confidence (device is being talked to)
+        if dst and _is_valid_address(dst):
+            self._process_device(
+                dst,
+                code=code,
+                verb=verb,
+                rssi=None,  # RSSI is for the sender, not the receiver
+                zone_idx=zone_idx,
+                is_src=False,
+                dst=None,
+            )
+
+        # addr3: lowest-confidence (broadcast target or relay)
+        if addr3 and _is_valid_address(addr3) and addr3 not in (src, dst):
+            self._process_device(
+                addr3,
+                code=code,
+                verb=verb,
+                rssi=None,
+                zone_idx=None,
+                is_src=False,
+                dst=None,
+            )
+
+    def _process_device(
+        self,
+        dev_id: str,
+        *,
+        code: str,
+        verb: str,
+        rssi: float | None,
+        zone_idx: str | None,
+        is_src: bool,
+        dst: str | None,
+    ) -> None:
+        """Update or create a discovery entry for a single device."""
+        # Skip if already known to the gateway
+        if self._is_known(dev_id):
+            return
+
+        now = dt.now().isoformat(timespec="seconds")
+        dev = self._devices.get(dev_id)
+
+        if dev is None:
+            # New device — classify and create entry
+            likely_type = _classify(dev_id, code, verb, is_src=is_src)
+            dev = DiscoveredDevice(
+                device_id=dev_id,
+                first_seen=now,
+                last_seen=now,
+                likely_type=likely_type,
+                codes_seen=[code] if code else [],
+                rssi=rssi,
+                confidence=_initial_confidence(is_src, code, verb),
+                is_battery=code in _BATTERY_CODES,
+                src_count=1 if is_src else 0,
+                dst_count=0 if is_src else 1,
+            )
+            # Set binding info if available
+            if zone_idx and dst and _is_valid_address(dst):
+                dev.zone_idx = zone_idx
+                dev.bound_to = dst
+                dev.confidence = "high"  # binding telemetry = high confidence
+            self._devices[dev_id] = dev
+            self._dirty = True
+            _LOGGER.info(
+                "DiscoveryScan: new device %s (%s, %s)",
+                dev_id,
+                likely_type,
+                dev.confidence,
+            )
+            return
+
+        # Existing device — enrich
+        changed = False
+
+        dev.last_seen = now
+        if is_src:
+            dev.src_count += 1
+        else:
+            dev.dst_count += 1
+
+        # Add code to codes_seen (deduplicated, keep sorted)
+        if code and code not in dev.codes_seen:
+            dev.codes_seen.append(code)
+            dev.codes_seen.sort()
+            changed = True
+
+        # Update RSSI as running average (only from src packets)
+        if rssi is not None and is_src:
+            if dev.rssi is None:
+                dev.rssi = rssi
+            else:
+                dev.rssi = (dev.rssi + rssi) / 2
+            changed = True
+
+        # Update battery flag
+        if code in _BATTERY_CODES and not dev.is_battery:
+            dev.is_battery = True
+            changed = True
+
+        # Update zone binding (prefer src packets with zone_idx)
+        if zone_idx and is_src and dst and _is_valid_address(dst):
+            if dev.zone_idx != zone_idx or dev.bound_to != dst:
+                dev.zone_idx = zone_idx
+                dev.bound_to = dst
+                dev.confidence = "high"
+                changed = True
+
+        # Upgrade confidence based on accumulated evidence
+        new_conf = _recompute_confidence(dev)
+        if new_conf != dev.confidence:
+            dev.confidence = new_conf
+            changed = True
+
+        # Re-classify if we have more info now
+        new_type = _classify(dev_id, code, verb, is_src=is_src, dev=dev)
+        if new_type != dev.likely_type and new_type != DevType.DEV:
+            dev.likely_type = new_type
+            changed = True
+
+        if changed:
+            self._dirty = True
+
+    # -- public API ----------------------------------------------------------
+
+    def get_devices(
+        self,
+        *,
+        status: str | None = None,
+        likely_type: str | None = None,
+        min_confidence: str | None = None,
+    ) -> list[DiscoveredDevice]:
+        """Return discovered devices, optionally filtered.
+
+        :param status: Not used by the engine (ramses_cc concern). Accepted
+            for API compatibility — filtering by status is done by the consumer.
+        :param likely_type: Filter by DevType value (e.g. "TRV").
+        :param min_confidence: Only return devices with at least this confidence
+            level ("low" < "medium" < "high").
+        """
+        result = list(self._devices.values())
+
+        if likely_type:
+            result = [d for d in result if d.likely_type == likely_type]
+
+        if min_confidence:
+            order = {"low": 0, "medium": 1, "high": 2}
+            min_val = order.get(min_confidence, 0)
+            result = [d for d in result if order.get(d.confidence, 0) >= min_val]
+
+        return result
+
+    def get_device(self, dev_id: str) -> DiscoveredDevice | None:
+        """Return a single discovered device by ID, or None."""
+        return self._devices.get(dev_id)
+
+    def remove_device(self, dev_id: str) -> bool:
+        """Remove a device from the in-memory list.
+
+        Returns True if the device was present and removed.
+        """
+        if dev_id in self._devices:
+            del self._devices[dev_id]
+            self._dirty = True
+            return True
+        return False
+
+    def export_json(self) -> str:
+        """Export the full device list as JSON (for CLI, persistence).
+
+        Returns a JSON string with a ``version`` key and a ``devices`` list.
+        """
+        data = {
+            "version": 1,
+            "exported_at": dt.now().isoformat(timespec="seconds"),
+            "devices": [
+                d.to_dict()
+                for d in sorted(self._devices.values(), key=lambda d: d.device_id)
+            ],
+        }
+        return json.dumps(data, indent=2, sort_keys=False)
+
+    def import_json(self, data: str) -> None:
+        """Load a previously exported list (for resume after restart).
+
+        Replaces the current in-memory dict.
+        """
+        parsed = json.loads(data)
+        self._devices = {
+            d["device_id"]: DiscoveredDevice.from_dict(d)
+            for d in parsed.get("devices", [])
+        }
+        self._dirty = False
+        _LOGGER.info("DiscoveryScan: imported %d devices", len(self._devices))
+
+    def device_count(self) -> int:
+        """Return the number of discovered devices."""
+        return len(self._devices)
+
+
+# ---------------------------------------------------------------------------
+# Classification helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_valid_address(dev_id: str) -> bool:
+    """Quick check if a device ID looks valid (N.N:NNNNNN or N:NNNNNN).
+
+    Filters out broadcast addresses (18:73030, 18:14803), placeholder
+    addresses (--:------), and corrupt IDs.
+    """
+    if not dev_id or len(dev_id) < 8:
+        return False
+    # Skip broadcast/multicast addresses
+    if dev_id in ("18:73030", "18:14803", "18:000730"):
+        return False
+    # Skip placeholder/empty addresses (e.g. "--:------")
+    if dev_id.startswith("-") or dev_id.startswith("00:------"):
+        return False
+    # Basic format check: should contain a colon
+    return ":" in dev_id
+
+
+def _classify(
+    dev_id: str,
+    code: str,
+    verb: str,
+    *,
+    is_src: bool,
+    dev: DiscoveredDevice | None = None,
+) -> DevType:
+    """Classify a device based on prefix, verb/code, and accumulated evidence.
+
+    Priority:
+    1. Verb+code pair (HVAC) — strongest signal for HVAC devices
+    2. CTL-only codes — if device sends these, it's a CTL
+    3. Prefix — fallback for CH devices
+    4. Accumulated codes — if we have a dev with codes_seen, re-evaluate
+    """
+    prefix = dev_id[:2]
+
+    # 1. Check verb+code pair (HVAC domain)
+    vc_key = (verb, code)
+    if vc_key in _VC_TO_TYPE:
+        return _VC_TO_TYPE[vc_key]
+
+    # 2. CTL-only codes (only if this device is the sender)
+    if is_src and code in _CTL_ONLY_CODES:
+        return DevType.CTL
+
+    # 3. Check accumulated codes if we have a dev
+    if dev and is_src:
+        for c in dev.codes_seen:
+            if c in _CTL_ONLY_CODES:
+                return DevType.CTL
+        # Check HVAC codes from accumulated data
+        for c in dev.codes_seen:
+            for v in (" I", "RP", "RQ", " W"):
+                if (v, c) in _VC_TO_TYPE:
+                    return _VC_TO_TYPE[(v, c)]
+
+    # 4. Prefix fallback
+    if prefix in _PREFIX_TO_TYPE:
+        return _PREFIX_TO_TYPE[prefix]
+
+    return DevType.DEV
+
+
+def _initial_confidence(is_src: bool, code: str, verb: str) -> str:
+    """Determine initial confidence for a newly seen device."""
+    if is_src and code in _ZONE_BINDING_CODES:
+        return "high"  # binding telemetry from src = high confidence
+    if is_src:
+        return "medium"  # device is actively sending
+    return "low"  # only seen as dst/addr3
+
+
+def _recompute_confidence(dev: DiscoveredDevice) -> str:
+    """Recompute confidence based on accumulated evidence."""
+    # High: has binding info (zone_idx + bound_to)
+    if dev.zone_idx and dev.bound_to:
+        return "high"
+
+    # High: sends CTL-only codes
+    if any(c in _CTL_ONLY_CODES for c in dev.codes_seen):
+        return "high"
+
+    # Medium: seen as src multiple times
+    if dev.src_count >= 2:
+        return "medium"
+
+    # Medium: seen as src at least once with known codes
+    if dev.src_count >= 1 and len(dev.codes_seen) >= 2:
+        return "medium"
+
+    # Low: only seen as dst, or seen once as src
+    return "low"
+
+
+def _extract_zone_idx(payload: str) -> str | None:
+    """Extract zone_idx from a payload string.
+
+    Zone index is typically the first 2 hex chars of the payload.
+    Returns None if payload is empty or too short.
+    """
+    if not payload or len(payload) < 2:
+        return None
+    idx = payload[:2]
+    # Validate: should be hex chars
+    try:
+        int(idx, 16)
+    except ValueError:
+        return None
+    return idx

--- a/src/ramses_rf/discovery_scan.py
+++ b/src/ramses_rf/discovery_scan.py
@@ -227,7 +227,7 @@ class DiscoveryScan:
         dst = dto.addr2.strip()
         addr3 = dto.addr3.strip() if dto.addr3 else ""
         code = str(dto.code).strip()
-        verb = dto.verb.strip() if dto.verb else ""
+        verb = dto.verb if dto.verb else ""
 
         # Parse RSSI (stored as string in PacketDTO)
         rssi: float | None = None

--- a/src/ramses_rf/discovery_scan.py
+++ b/src/ramses_rf/discovery_scan.py
@@ -148,11 +148,16 @@ class DiscoveryScan:
     # -- lifecycle -----------------------------------------------------------
 
     def start(self) -> None:
-        """Register as a msg_handler on the gateway."""
+        """Register as a raw packet handler on the gateway.
+
+        Uses ``add_raw_pkt_handler`` (not ``add_msg_handler``) so the scan
+        sees packets from unknown devices even when ``enforce_known_list=True``.
+        The raw handler fires before the device ID filter.
+        """
         if self._remove_handler is not None:
             _LOGGER.warning("DiscoveryScan.start(): already running")
             return
-        self._remove_handler = self._gwy.add_msg_handler(self._on_packet)
+        self._remove_handler = self._gwy.add_raw_pkt_handler(self._on_packet)
         _LOGGER.info("DiscoveryScan: started (passive observer)")
 
     def stop(self) -> None:

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -330,6 +330,18 @@ class Gateway(GatewayLifecycle, GatewayInterface):
     ) -> Callable[[], None]:
         return self._engine.add_msg_handler(msg_handler, msg_filter=msg_filter)
 
+    def add_raw_pkt_handler(
+        self,
+        msg_handler: Callable[[PacketDTO], Awaitable[None]],
+        /,
+    ) -> Callable[[], None]:
+        """Add a raw packet handler that fires before the device ID filter.
+
+        Used by the passive scan engine to see packets from unknown devices
+        even when ``enforce_known_list=True``.
+        """
+        return self._engine.add_raw_pkt_handler(msg_handler)
+
     def add_task(self, task: asyncio.Task[Any]) -> None:
         self._engine.add_task(task)
 

--- a/src/ramses_tx/engine.py
+++ b/src/ramses_tx/engine.py
@@ -168,6 +168,17 @@ class Engine:
         """Add a Message handler to the underlying Protocol."""
         return self._protocol.add_handler(msg_handler, msg_filter=msg_filter)
 
+    def add_raw_pkt_handler(
+        self,
+        msg_handler: MsgHandlerT,
+        /,
+    ) -> Callable[[], None]:
+        """Add a raw packet handler that fires before the device ID filter.
+
+        See ``_BaseProtocol.add_raw_pkt_handler`` for details.
+        """
+        return self._protocol.add_raw_pkt_handler(msg_handler)
+
     async def start(self) -> None:
         """Create a suitable transport for the specified packet source.
 

--- a/src/ramses_tx/protocol/base.py
+++ b/src/ramses_tx/protocol/base.py
@@ -69,6 +69,7 @@ class _BaseProtocol(ProtocolInterface, asyncio.Protocol):
         super().__init__()
         self._msg_handler = msg_handler
         self._msg_handlers: list[tuple[MsgHandlerT, MsgFilterT | None]] = []
+        self._raw_pkt_handlers: list[MsgHandlerT] = []
 
         self._transport: TransportInterface | None = None
         self._loop = asyncio.get_running_loop()
@@ -143,6 +144,28 @@ class _BaseProtocol(ProtocolInterface, asyncio.Protocol):
 
         if entry not in self._msg_handlers:
             self._msg_handlers.append(entry)
+
+        return del_handler
+
+    def add_raw_pkt_handler(
+        self,
+        msg_handler: MsgHandlerT,
+        /,
+    ) -> Callable[[], None]:
+        """Add a raw packet handler that fires BEFORE the device ID filter.
+
+        Raw handlers receive every valid PacketDTO, including packets from
+        unknown devices that would be filtered out by enforce_known_list.
+        Used by the passive scan engine to discover unknown devices.
+
+        :param msg_handler: The handler function to add.
+        :return: A callable to remove the handler.
+        """
+        self._raw_pkt_handlers.append(msg_handler)
+
+        def del_handler() -> None:
+            if msg_handler in self._raw_pkt_handlers:
+                self._raw_pkt_handlers.remove(msg_handler)
 
         return del_handler
 
@@ -554,6 +577,18 @@ class _DeviceIdFilterMixin(_BaseProtocol):
         return True
 
     def _pkt_received(self, pkt: Packet) -> None:
+        # Fire raw handlers before the device ID filter (for the scan engine)
+        if self._raw_pkt_handlers:
+            try:
+                dto = pkt.to_dto()
+            except PacketInvalid as err:
+                _LOGGER.debug(f"Dropped invalid packet for raw handlers: {err}")
+            else:
+                for handler in self._raw_pkt_handlers:
+                    res = handler(dto)
+                    if asyncio.iscoroutine(res):
+                        self._loop.create_task(res)
+
         if not self._is_wanted_addrs(pkt.src.id, pkt.dst.id):
             _LOGGER.debug("%s < Packet excluded by device_id filter", pkt)
             return

--- a/tests/tests_cli/test_client.py
+++ b/tests/tests_cli/test_client.py
@@ -850,3 +850,181 @@ def test_run_cli_valid() -> None:
 
         mock_exit.assert_not_called()
         mock_main.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests for the scan command and _print_scan_results
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_main_scan(mock_gateway: MagicMock) -> None:
+    """Test async_main logic for the SCAN command."""
+    from ramses_cli.client import SCAN
+
+    lib_kwargs: dict[str, Any] = {
+        SZ_CONFIG: {"reduce_processing": 0},
+        SZ_PACKET_LOG: {},
+    }
+    kwargs: dict[str, Any] = {
+        "long_format": False,
+        "restore_schema": None,
+        "restore_state": None,
+        "print_state": 0,
+        SZ_INPUT_FILE: "input.log",
+        "scan_duration": 0,  # 0 = until interrupted, but we'll cancel quickly
+        "scan_output": None,
+    }
+
+    with (
+        patch("ramses_cli.client.Gateway", return_value=mock_gateway),
+        patch("ramses_cli.client.normalise_config", return_value=(None, lib_kwargs)),
+        patch("ramses_cli.client.DiscoveryScan") as mock_scan_cls,
+    ):
+        mock_scan_engine = MagicMock()
+        mock_scan_engine.start = MagicMock()
+        mock_scan_engine.stop = MagicMock()
+        mock_scan_engine.get_devices.return_value = []
+        mock_scan_cls.return_value = mock_scan_engine
+
+        # Use a very short sleep to avoid hanging the test
+        async def short_sleep(_: float) -> None:
+            pass
+
+        with patch("asyncio.sleep", side_effect=short_sleep):
+            await async_main(SCAN, lib_kwargs, **kwargs)
+
+        mock_scan_engine.start.assert_called_once()
+        mock_scan_engine.stop.assert_called_once()
+        mock_gateway.start.assert_awaited_once()
+        mock_gateway.stop.assert_awaited_once()
+
+
+def test_print_scan_results_with_devices(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test _print_scan_results formats device output correctly."""
+    from ramses_cli.client import _print_scan_results
+    from ramses_rf.discovery_scan import DiscoveredDevice
+
+    devices = [
+        DiscoveredDevice(
+            device_id="01:145038",
+            first_seen="2026-01-01T00:00:00",
+            last_seen="2026-01-01T00:00:01",
+            likely_type="CTL",
+            codes_seen=["2E04", "000C"],
+            bound_to=None,
+            zone_idx="0A",
+            rssi=-68.0,
+            confidence="high",
+            is_battery=False,
+            src_count=5,
+            dst_count=2,
+        ),
+        DiscoveredDevice(
+            device_id="04:056053",
+            first_seen="2026-01-01T00:00:00",
+            last_seen="2026-01-01T00:00:01",
+            likely_type="TRV",
+            codes_seen=["3150"],
+            bound_to="01:145038",
+            zone_idx="02",
+            rssi=-72.0,
+            confidence="high",
+            is_battery=True,
+            src_count=3,
+            dst_count=0,
+        ),
+    ]
+
+    mock_scan = MagicMock()
+    mock_scan.get_devices.return_value = devices
+
+    _print_scan_results(mock_scan, None)
+
+    captured = capsys.readouterr()
+    assert "Found 2 device(s)" in captured.out
+    assert "01:145038" in captured.out
+    assert "CTL" in captured.out
+    assert "04:056053" in captured.out
+    assert "TRV" in captured.out
+    assert "zone=02" in captured.out
+    assert "bound to 01:145038" in captured.out
+    assert "battery" in captured.out
+
+
+def test_print_scan_results_no_devices(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test _print_scan_results when no devices are found."""
+    from ramses_cli.client import _print_scan_results
+
+    mock_scan = MagicMock()
+    mock_scan.get_devices.return_value = []
+
+    _print_scan_results(mock_scan, None)
+
+    captured = capsys.readouterr()
+    assert "No unknown devices discovered" in captured.out
+
+
+def test_print_scan_results_export_to_file(
+    tmp_path: Any, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Test _print_scan_results exports JSON to file when output path is given."""
+    from ramses_cli.client import _print_scan_results
+    from ramses_rf.discovery_scan import DiscoveredDevice
+
+    devices = [
+        DiscoveredDevice(
+            device_id="32:157747",
+            first_seen="2026-01-01T00:00:00",
+            last_seen="2026-01-01T00:00:01",
+            likely_type="FAN",
+            codes_seen=["31DA"],
+            bound_to=None,
+            zone_idx=None,
+            rssi=-70.0,
+            confidence="medium",
+            is_battery=False,
+            src_count=2,
+            dst_count=0,
+        ),
+    ]
+
+    mock_scan = MagicMock()
+    mock_scan.get_devices.return_value = devices
+    mock_scan.export_json.return_value = '{"devices": []}'
+
+    output_file = str(tmp_path / "found.json")
+    _print_scan_results(mock_scan, output_file)
+
+    captured = capsys.readouterr()
+    assert f"Exported to {output_file}" in captured.out
+    assert (tmp_path / "found.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_scan_command_disables_sending_and_discovery() -> None:
+    """Test that the scan command callback forces disable_sending and disable_discovery."""
+    from ramses_cli.client import SCAN, cli
+    from ramses_rf.schemas import SZ_CONFIG, SZ_DISABLE_DISCOVERY
+
+    lib_config: dict[str, Any] = {SZ_CONFIG: {}}
+    cli_config: dict[str, Any] = {}
+
+    runner = CliRunner()
+    with patch("ramses_cli.client.split_kwargs", return_value=(cli_config, lib_config)):
+        # standalone_mode=False returns the command's return value
+        result = await runner.invoke(
+            cli,
+            ["scan", "/dev/ttyUSB0", "--output", "found.json", "--duration", "60"],
+            standalone_mode=False,
+        )
+
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+
+        # scan() returns (SCAN, lib_config, cli_config)
+        command, lib_kwargs, cli_kwargs = result.return_value
+        assert command == SCAN
+        assert lib_kwargs[SZ_CONFIG]["disable_sending"] is True
+        assert lib_kwargs[SZ_CONFIG][SZ_DISABLE_DISCOVERY] is True
+        assert cli_kwargs["scan_duration"] == 60
+        assert cli_kwargs["scan_output"] == "found.json"

--- a/tests/tests_rf/test_discovery_scan.py
+++ b/tests/tests_rf/test_discovery_scan.py
@@ -72,7 +72,7 @@ def make_mock_gateway(
     gwy._gwy_config = MagicMock()
     gwy._gwy_config.known_list = known_list or {}
     gwy._gwy_config.schema = schema or {}
-    gwy.add_msg_handler = MagicMock(return_value=lambda: None)
+    gwy.add_raw_pkt_handler = MagicMock(return_value=lambda: None)
     return gwy
 
 
@@ -331,13 +331,13 @@ class TestDiscoveryScanLifecycle:
         gwy = make_mock_gateway()
         scan = DiscoveryScan(gwy)
         scan.start()
-        assert gwy.add_msg_handler.called
+        assert gwy.add_raw_pkt_handler.called
         assert scan.is_running is True
 
     def test_stop_unregisters_handler(self) -> None:
         gwy = make_mock_gateway()
         removed = MagicMock()
-        gwy.add_msg_handler = MagicMock(return_value=removed)
+        gwy.add_raw_pkt_handler = MagicMock(return_value=removed)
         scan = DiscoveryScan(gwy)
         scan.start()
         scan.stop()
@@ -349,7 +349,7 @@ class TestDiscoveryScanLifecycle:
         scan = DiscoveryScan(gwy)
         scan.start()
         scan.start()  # should not double-register
-        assert gwy.add_msg_handler.call_count == 1
+        assert gwy.add_raw_pkt_handler.call_count == 1
 
     def test_stop_without_start_is_noop(self) -> None:
         gwy = make_mock_gateway()

--- a/tests/tests_rf/test_discovery_scan.py
+++ b/tests/tests_rf/test_discovery_scan.py
@@ -14,10 +14,13 @@ These tests verify:
 
 from __future__ import annotations
 
+import asyncio
 import json
 from datetime import datetime as dt
 from typing import Any
 from unittest.mock import MagicMock
+
+import pytest
 
 from ramses_rf.const import DevType
 from ramses_rf.discovery_scan import (
@@ -637,7 +640,7 @@ class TestNoTopologyMutation:
 
     def test_no_schema_modification(self) -> None:
         """The scan should not modify the schema."""
-        original_schema = {"01:145038": {}}
+        original_schema: dict[str, Any] = {"01:145038": {}}
         gwy = make_mock_gateway(schema=original_schema)
         scan = DiscoveryScan(gwy)
         scan._process_packet(make_dto(src="04:056053", dst="01:145038", code="3150"))
@@ -688,3 +691,153 @@ class TestOutOfOrderDiscovery:
         assert "2E04" in ctl.codes_seen
         # Confidence should upgrade to medium (src_count >= 1 + codes >= 2)
         assert ctl.confidence in ("medium", "high")
+
+
+# ---------------------------------------------------------------------------
+# Integration: virtual RF with mixed CH + HVAC traffic
+# ---------------------------------------------------------------------------
+
+
+class TestVirtualRfIntegration:
+    """Integration test using the virtual RF to simulate live traffic.
+
+    Sends mixed CH + HVAC packets through a virtual serial port and verifies
+    the scan engine discovers and classifies them correctly, even with
+    enforce_known_list=True.
+    """
+
+    @pytest.mark.asyncio
+    async def test_mixed_ch_hvac_discovery(self) -> None:
+        """Scan discovers CH + HVAC devices from simulated RF traffic.
+
+        Uses the virtual RF harness to send raw packet frames through a
+        virtual serial port, just like real RF traffic.
+        """
+        from tests_rf.virtual_rf import HgiFwTypes, VirtualRf
+
+        HGI_ID = "18:222222"
+        CTL_ID = "01:145038"
+        TRV_ID = "04:056053"
+        DHW_ID = "07:046947"
+        BDR_ID = "10:067219"
+        FAN_ID = "32:157747"
+        REM_ID = "37:179540"
+
+        # Raw packet frames (evofw3 format: no RSSI, gateway adds it)
+        # Must be terminated with \r\n for the virtual RF to process them
+        # Payload length must match the declared hex length byte
+        raw_pkts: list[bytes] = [
+            # CTL broadcasts system mode
+            b" I --- 01:145038 18:222222 --:------ 2E04 003 000200\r\n",
+            # CTL sends zone device map (000C)
+            b" I --- 01:145038 18:222222 --:------ 000C 006 000F0035D5B1\r\n",
+            # TRV sends heat demand to CTL (zone 02)
+            b" I --- 04:056053 01:145038 --:------ 3150 006 02C800000000\r\n",
+            # TRV sends battery info
+            b" I --- 04:056053 01:145038 --:------ 1060 003 00C800\r\n",
+            # DHW sensor sends to CTL
+            b" I --- 07:046947 01:145038 --:------ 10A0 006 01C800000000\r\n",
+            # BDR sends state
+            b" I --- 10:067219 01:145038 --:------ 0008 002 00FF\r\n",
+            # FAN broadcasts fan state (31DA, 30 bytes payload)
+            b" I --- 32:157747 --:------ 32:157747 31DA 030 00EF007FFF3A2F04C404E204A904BA68000003C8C80000EFEF20A91F0500\r\n",
+            # FAN broadcasts fan info (31D9, 17 bytes payload)
+            b" I --- 32:157747 --:------ 32:157747 31D9 017 001A020020202020202020202020202008\r\n",
+            # REM sends fan mode to FAN
+            b" I --- 37:179540 32:157747 --:------ 22F1 003 000107\r\n",
+            # REM sends battery
+            b" I --- 37:179540 32:157747 --:------ 1060 003 00C800\r\n",
+        ]
+
+        rf = VirtualRf(2)
+        try:
+            rf.set_gateway(rf.ports[0], HGI_ID, fw_type=HgiFwTypes.EVOFW3)
+
+            from unittest.mock import patch
+
+            from ramses_rf.gateway import Gateway, GatewayConfig
+            from ramses_tx.config import EngineConfig
+
+            engine_config = EngineConfig(
+                disable_qos=True,
+                enforce_known_list=True,
+                disable_sending=True,
+            )
+            gwy_config = GatewayConfig(
+                disable_discovery=True,
+                enable_eavesdrop=False,
+                engine=engine_config,
+                known_list={HGI_ID: {}},  # only HGI — everything else unknown
+                schema={},
+            )
+
+            with patch("ramses_tx.discovery.comports", rf.comports):
+                gwy = Gateway(rf.ports[0], config=gwy_config)
+                await gwy.start()
+
+            scan = DiscoveryScan(gwy)
+            scan.start()
+
+            # Dump packets into the virtual RF (one at a time to avoid buffer overflow)
+            for pkt in raw_pkts:
+                await rf.dump_frames_to_rf([pkt])
+                await asyncio.sleep(0.05)
+            await asyncio.sleep(1)  # let packets fully process
+
+            scan.stop()
+
+            # Verify registry only has HGI
+            registry_ids = set(gwy.device_registry.device_by_id.keys())
+            assert registry_ids == {HGI_ID}, (
+                f"Registry should only have HGI, got: {registry_ids}"
+            )
+
+            # Verify scan discovered all unknown devices
+            discovered = {d.device_id: d for d in scan.get_devices()}
+            assert CTL_ID in discovered, (
+                f"CTL not discovered: {list(discovered.keys())}"
+            )
+            assert TRV_ID in discovered, (
+                f"TRV not discovered: {list(discovered.keys())}"
+            )
+            assert DHW_ID in discovered, (
+                f"DHW not discovered: {list(discovered.keys())}"
+            )
+            assert BDR_ID in discovered, (
+                f"BDR not discovered: {list(discovered.keys())}"
+            )
+            assert FAN_ID in discovered, (
+                f"FAN not discovered: {list(discovered.keys())}"
+            )
+            assert REM_ID in discovered, (
+                f"REM not discovered: {list(discovered.keys())}"
+            )
+
+            # Verify classification
+            assert discovered[CTL_ID].likely_type == "CTL"
+            assert discovered[TRV_ID].likely_type == "TRV"
+            assert discovered[DHW_ID].likely_type == "DHW"
+            assert discovered[BDR_ID].likely_type == "BDR"
+            assert discovered[FAN_ID].likely_type == "FAN"
+            assert discovered[REM_ID].likely_type == "REM"
+
+            # Verify TRV has zone binding
+            trv = discovered[TRV_ID]
+            assert trv.zone_idx == "02"
+            assert trv.bound_to == CTL_ID
+            assert trv.confidence == "high"
+            assert trv.is_battery is True
+
+            # Verify FAN is classified as FAN (not REM, despite 22F1)
+            fan = discovered[FAN_ID]
+            assert fan.likely_type == "FAN"
+            assert "31DA" in fan.codes_seen
+
+            # Verify REM is classified as REM
+            rem = discovered[REM_ID]
+            assert rem.likely_type == "REM"
+            assert "22F1" in rem.codes_seen
+
+            await gwy.stop()
+        finally:
+            await rf.stop()

--- a/tests/tests_rf/test_discovery_scan.py
+++ b/tests/tests_rf/test_discovery_scan.py
@@ -159,6 +159,15 @@ class TestClassify:
         """I 1298 → CO2."""
         assert _classify("37:123456", "1298", " I", is_src=True) == DevType.CO2
 
+    def test_hvac_prefix_wins_over_vc_pair(self) -> None:
+        """A FAN (32:) sending 22F1 should stay FAN, not become REM."""
+        assert _classify("32:157747", "22F1", " I", is_src=True) == DevType.FAN
+
+    def test_vc_pair_for_non_hvac_prefix(self) -> None:
+        """A non-HVAC prefix sending an HVAC code should use the VC pair."""
+        # 18: is HGI, but if it sends I 31DA it's acting as FAN
+        assert _classify("18:123456", "31DA", " I", is_src=True) == DevType.FAN
+
     def test_ctl_only_code(self) -> None:
         """A device sending 1030 (CTL-only code) is classified as CTL."""
         assert _classify("01:145038", "1030", " I", is_src=True) == DevType.CTL

--- a/tests/tests_rf/test_discovery_scan.py
+++ b/tests/tests_rf/test_discovery_scan.py
@@ -1,0 +1,681 @@
+# --- START OF FILE test_discovery_scan.py ---
+
+"""Tests for the passive device scan engine (ramses_rf.discovery_scan).
+
+These tests verify:
+- Device classification by prefix and verb/code pairs
+- In-memory discovery list management
+- JSON export/import round-trip
+- Confidence scoring
+- Zone binding extraction
+- Known device filtering
+- No topology mutation (read-only)
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime as dt
+from typing import Any
+from unittest.mock import MagicMock
+
+from ramses_rf.const import DevType
+from ramses_rf.discovery_scan import (
+    DiscoveredDevice,
+    DiscoveryScan,
+    _classify,
+    _extract_zone_idx,
+    _initial_confidence,
+    _is_valid_address,
+    _recompute_confidence,
+)
+from ramses_tx.dtos import PacketDTO
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_dto(
+    src: str = "04:056053",
+    dst: str = "01:145038",
+    addr3: str = "--:------",
+    code: str = "3150",
+    verb: str = " I",
+    payload: str = "02C8",
+    rssi: str = "-72",
+) -> PacketDTO:
+    """Create a PacketDTO for testing."""
+    return PacketDTO(
+        timestamp=dt.now(),
+        rssi=rssi,
+        verb=verb,
+        seq="00",
+        addr1=src,
+        addr2=dst,
+        addr3=addr3,
+        code=code,
+        length="006",
+        payload=payload,
+    )
+
+
+def make_mock_gateway(
+    known_list: dict[str, Any] | None = None,
+    schema: dict[str, Any] | None = None,
+    device_by_id: dict[str, Any] | None = None,
+) -> MagicMock:
+    """Create a mock Gateway with the minimum interface DiscoveryScan needs."""
+    gwy = MagicMock()
+    gwy.device_registry = MagicMock()
+    gwy.device_registry.device_by_id = device_by_id or {}
+    gwy._gwy_config = MagicMock()
+    gwy._gwy_config.known_list = known_list or {}
+    gwy._gwy_config.schema = schema or {}
+    gwy.add_msg_handler = MagicMock(return_value=lambda: None)
+    return gwy
+
+
+# ---------------------------------------------------------------------------
+# Classification helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsValidAddress:
+    """Tests for _is_valid_address."""
+
+    def test_valid_device_id(self) -> None:
+        assert _is_valid_address("04:056053") is True
+
+    def test_valid_ctl_id(self) -> None:
+        assert _is_valid_address("01:145038") is True
+
+    def test_broadcast_address_rejected(self) -> None:
+        assert _is_valid_address("18:73030") is False
+
+    def test_empty_rejected(self) -> None:
+        assert _is_valid_address("") is False
+
+    def test_no_colon_rejected(self) -> None:
+        assert _is_valid_address("04056053") is False
+
+    def test_too_short_rejected(self) -> None:
+        assert _is_valid_address("04:056") is False
+
+    def test_placeholder_rejected(self) -> None:
+        assert _is_valid_address("--:------") is False
+
+    def test_all_zeros_rejected(self) -> None:
+        assert _is_valid_address("00:------") is False
+
+
+class TestExtractZoneIdx:
+    """Tests for _extract_zone_idx."""
+
+    def test_valid_zone_idx(self) -> None:
+        assert _extract_zone_idx("02C8") == "02"
+
+    def test_hw_zone(self) -> None:
+        # "HW" is not valid hex — should return None
+        assert _extract_zone_idx("HW...") is None
+
+    def test_empty_payload(self) -> None:
+        assert _extract_zone_idx("") is None
+
+    def test_short_payload(self) -> None:
+        assert _extract_zone_idx("0") is None
+
+
+class TestClassify:
+    """Tests for _classify."""
+
+    def test_prefix_ctl(self) -> None:
+        assert _classify("01:145038", "2E04", " I", is_src=True) == DevType.CTL
+
+    def test_prefix_trv(self) -> None:
+        assert _classify("04:056053", "3150", " I", is_src=True) == DevType.TRV
+
+    def test_prefix_dhw(self) -> None:
+        assert _classify("07:046947", "10A0", " I", is_src=True) == DevType.DHW
+
+    def test_prefix_bdr(self) -> None:
+        assert _classify("10:067219", "0008", " I", is_src=True) == DevType.BDR
+
+    def test_prefix_fan(self) -> None:
+        assert _classify("32:157747", "31DA", " I", is_src=True) == DevType.FAN
+
+    def test_prefix_rem(self) -> None:
+        assert _classify("37:179540", "22F1", " I", is_src=True) == DevType.REM
+
+    def test_vc_pair_fan(self) -> None:
+        """I 31DA → FAN (from HVAC_KLASS_BY_VC_PAIR)."""
+        assert _classify("32:157747", "31DA", " I", is_src=True) == DevType.FAN
+
+    def test_vc_pair_rem(self) -> None:
+        """I 22F1 → REM."""
+        assert _classify("37:179540", "22F1", " I", is_src=True) == DevType.REM
+
+    def test_vc_pair_co2(self) -> None:
+        """I 1298 → CO2."""
+        assert _classify("37:123456", "1298", " I", is_src=True) == DevType.CO2
+
+    def test_ctl_only_code(self) -> None:
+        """A device sending 1030 (CTL-only code) is classified as CTL."""
+        assert _classify("01:145038", "1030", " I", is_src=True) == DevType.CTL
+
+    def test_ctl_only_code_not_from_dst(self) -> None:
+        """CTL-only code from dst (not src) should not classify as CTL."""
+        result = _classify("01:145038", "1030", " I", is_src=False)
+        # Falls back to prefix
+        assert result == DevType.CTL  # prefix 01 = CTL anyway
+
+    def test_unknown_prefix(self) -> None:
+        """Unknown prefix with no VC match returns DEV."""
+        assert _classify("99:999999", "0001", " I", is_src=True) == DevType.DEV
+
+    def test_reclassify_with_dev(self) -> None:
+        """Re-classify using accumulated codes_seen."""
+        dev = DiscoveredDevice(
+            device_id="01:145038",
+            first_seen="2026-07-01T10:00:00",
+            last_seen="2026-07-01T10:00:00",
+            likely_type="DEV",
+            codes_seen=["1030", "2E04"],
+        )
+        result = _classify("01:145038", "0001", " I", is_src=True, dev=dev)
+        assert result == DevType.CTL
+
+
+class TestConfidence:
+    """Tests for confidence scoring."""
+
+    def test_initial_high_for_binding_code(self) -> None:
+        assert _initial_confidence(True, "3150", " I") == "high"
+
+    def test_initial_medium_for_src(self) -> None:
+        assert _initial_confidence(True, "0001", " I") == "medium"
+
+    def test_initial_low_for_dst(self) -> None:
+        assert _initial_confidence(False, "0001", " I") == "low"
+
+    def test_recompute_high_with_binding(self) -> None:
+        dev = DiscoveredDevice(
+            device_id="04:056053",
+            first_seen="",
+            last_seen="",
+            likely_type="TRV",
+            zone_idx="02",
+            bound_to="01:145038",
+        )
+        assert _recompute_confidence(dev) == "high"
+
+    def test_recompute_high_with_ctl_code(self) -> None:
+        dev = DiscoveredDevice(
+            device_id="01:145038",
+            first_seen="",
+            last_seen="",
+            likely_type="CTL",
+            codes_seen=["1030"],
+        )
+        assert _recompute_confidence(dev) == "high"
+
+    def test_recompute_medium_multiple_src(self) -> None:
+        dev = DiscoveredDevice(
+            device_id="04:056053",
+            first_seen="",
+            last_seen="",
+            likely_type="TRV",
+            src_count=3,
+        )
+        assert _recompute_confidence(dev) == "medium"
+
+    def test_recompute_low_dst_only(self) -> None:
+        dev = DiscoveredDevice(
+            device_id="04:056053",
+            first_seen="",
+            last_seen="",
+            likely_type="TRV",
+            dst_count=5,
+            src_count=0,
+        )
+        assert _recompute_confidence(dev) == "low"
+
+
+# ---------------------------------------------------------------------------
+# DiscoveredDevice dataclass tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoveredDevice:
+    """Tests for the DiscoveredDevice dataclass."""
+
+    def test_to_dict(self) -> None:
+        dev = DiscoveredDevice(
+            device_id="04:056053",
+            first_seen="2026-07-01T10:00:00",
+            last_seen="2026-07-01T10:01:00",
+            likely_type="TRV",
+            codes_seen=["1060", "3150"],
+            bound_to="01:145038",
+            zone_idx="02",
+            rssi=-72.0,
+            confidence="high",
+        )
+        d = dev.to_dict()
+        assert d["device_id"] == "04:056053"
+        assert d["likely_type"] == "TRV"
+        assert d["codes_seen"] == ["1060", "3150"]
+        assert d["bound_to"] == "01:145038"
+        assert d["zone_idx"] == "02"
+
+    def test_from_dict(self) -> None:
+        data = {
+            "device_id": "04:056053",
+            "first_seen": "2026-07-01T10:00:00",
+            "last_seen": "2026-07-01T10:01:00",
+            "likely_type": "TRV",
+            "codes_seen": ["1060", "3150"],
+            "bound_to": "01:145038",
+            "zone_idx": "02",
+            "rssi": -72.0,
+            "confidence": "high",
+            "is_battery": True,
+            "src_count": 5,
+            "dst_count": 2,
+        }
+        dev = DiscoveredDevice.from_dict(data)
+        assert dev.device_id == "04:056053"
+        assert dev.likely_type == "TRV"
+        assert dev.is_battery is True
+
+    def test_from_dict_ignores_extra_fields(self) -> None:
+        """from_dict should ignore fields not in the dataclass."""
+        data = {
+            "device_id": "04:056053",
+            "first_seen": "",
+            "last_seen": "",
+            "likely_type": "TRV",
+            "status": "accepted",  # ramses_cc concern, not engine
+            "enabled": True,
+        }
+        dev = DiscoveredDevice.from_dict(data)
+        assert dev.device_id == "04:056053"
+        assert not hasattr(dev, "status")
+
+    def test_round_trip(self) -> None:
+        """to_dict → from_dict → should be identical."""
+        dev = DiscoveredDevice(
+            device_id="04:056053",
+            first_seen="2026-07-01T10:00:00",
+            last_seen="2026-07-01T10:01:00",
+            likely_type="TRV",
+            codes_seen=["1060", "3150"],
+            rssi=-72.0,
+            confidence="medium",
+        )
+        dev2 = DiscoveredDevice.from_dict(dev.to_dict())
+        assert dev2.device_id == dev.device_id
+        assert dev2.codes_seen == dev.codes_seen
+        assert dev2.rssi == dev.rssi
+
+
+# ---------------------------------------------------------------------------
+# DiscoveryScan engine tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoveryScanLifecycle:
+    """Tests for start/stop lifecycle."""
+
+    def test_start_registers_handler(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan.start()
+        assert gwy.add_msg_handler.called
+        assert scan.is_running is True
+
+    def test_stop_unregisters_handler(self) -> None:
+        gwy = make_mock_gateway()
+        removed = MagicMock()
+        gwy.add_msg_handler = MagicMock(return_value=removed)
+        scan = DiscoveryScan(gwy)
+        scan.start()
+        scan.stop()
+        assert removed.called
+        assert scan.is_running is False
+
+    def test_start_twice_warns(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan.start()
+        scan.start()  # should not double-register
+        assert gwy.add_msg_handler.call_count == 1
+
+    def test_stop_without_start_is_noop(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan.stop()  # should not raise
+
+
+class TestDiscoveryScanPacketHandling:
+    """Tests for packet processing logic."""
+
+    def test_new_device_from_src(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(make_dto(src="04:056053", dst="01:145038", code="3150"))
+        dev = scan.get_device("04:056053")
+        assert dev is not None
+        assert dev.likely_type == "TRV"
+        assert dev.confidence == "high"  # 3150 is a binding code
+        assert dev.src_count == 1
+        assert "3150" in dev.codes_seen
+
+    def test_new_device_from_dst(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(make_dto(src="04:056053", dst="01:145038", code="3150"))
+        # dst (01:145038) should also be recorded
+        dev = scan.get_device("01:145038")
+        assert dev is not None
+        assert dev.dst_count == 1
+        assert dev.confidence == "low"  # only seen as dst
+
+    def test_known_device_skipped(self) -> None:
+        gwy = make_mock_gateway(known_list={"04:056053": {}})
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(make_dto(src="04:056053", code="3150"))
+        assert scan.get_device("04:056053") is None
+
+    def test_known_in_schema_skipped(self) -> None:
+        gwy = make_mock_gateway(schema={"01:145038": {}})
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(make_dto(src="01:145038", code="2E04"))
+        assert scan.get_device("01:145038") is None
+
+    def test_known_in_registry_skipped(self) -> None:
+        gwy = make_mock_gateway(device_by_id={"04:056053": MagicMock()})
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(make_dto(src="04:056053", code="3150"))
+        assert scan.get_device("04:056053") is None
+
+    def test_rssi_running_average(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        # First packet
+        scan._process_packet(make_dto(src="04:056053", code="3150", rssi="-70"))
+        dev = scan.get_device("04:056053")
+        assert dev is not None
+        assert dev.rssi == -70.0
+        # Second packet — should average
+        scan._process_packet(make_dto(src="04:056053", code="30C9", rssi="-80"))
+        assert dev.rssi == -75.0
+
+    def test_rssi_not_updated_from_dst(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(
+            make_dto(src="04:056053", dst="01:145038", code="3150", rssi="-70")
+        )
+        # dst device should not get rssi from this packet
+        dst_dev = scan.get_device("01:145038")
+        assert dst_dev is not None
+        assert dst_dev.rssi is None
+
+    def test_zone_binding_extracted(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(
+            make_dto(src="04:056053", dst="01:145038", code="3150", payload="02C8")
+        )
+        dev = scan.get_device("04:056053")
+        assert dev is not None
+        assert dev.zone_idx == "02"
+        assert dev.bound_to == "01:145038"
+        assert dev.confidence == "high"
+
+    def test_codes_seen_deduplicated_and_sorted(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(make_dto(src="04:056053", code="3150"))
+        scan._process_packet(make_dto(src="04:056053", code="1060"))
+        scan._process_packet(make_dto(src="04:056053", code="3150"))  # duplicate
+        dev = scan.get_device("04:056053")
+        assert dev is not None
+        assert dev.codes_seen == ["1060", "3150"]  # sorted, no dupes
+
+    def test_battery_flag_set(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(make_dto(src="04:056053", code="1060"))
+        dev = scan.get_device("04:056053")
+        assert dev is not None
+        assert dev.is_battery is True
+
+    def test_addr3_processed(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(
+            make_dto(
+                src="01:145038",
+                dst="18:006402",
+                addr3="04:056053",
+                code="000C",
+            )
+        )
+        dev = scan.get_device("04:056053")
+        assert dev is not None
+        assert dev.dst_count == 1  # addr3 treated as non-src
+
+    def test_broadcast_address_skipped(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(make_dto(src="01:145038", dst="18:73030", code="2E04"))
+        # 18:73030 is broadcast — should not be in discovery list
+        assert scan.get_device("18:73030") is None
+
+    def test_hvac_fan_discovered(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(
+            make_dto(src="32:157747", dst="18:006402", code="31DA", verb=" I")
+        )
+        dev = scan.get_device("32:157747")
+        assert dev is not None
+        assert dev.likely_type == "FAN"
+
+    def test_hvac_rem_discovered(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(
+            make_dto(src="37:179540", dst="32:157747", code="22F1", verb=" I")
+        )
+        dev = scan.get_device("37:179540")
+        assert dev is not None
+        assert dev.likely_type == "REM"
+
+    def test_dirty_flag_set_on_new_device(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        assert scan.is_dirty is False
+        scan._process_packet(make_dto(src="04:056053", code="3150"))
+        assert scan.is_dirty is True
+
+    def test_clear_dirty(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(make_dto(src="04:056053", code="3150"))
+        scan.clear_dirty()
+        assert scan.is_dirty is False
+
+
+class TestDiscoveryScanGetDevices:
+    """Tests for get_devices with filters."""
+
+    def test_get_all_devices(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(make_dto(src="04:056053", code="3150"))
+        scan._process_packet(make_dto(src="01:145038", code="2E04"))
+        assert len(scan.get_devices()) == 2
+
+    def test_filter_by_type(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(make_dto(src="04:056053", code="3150"))
+        scan._process_packet(make_dto(src="01:145038", code="2E04"))
+        trvs = scan.get_devices(likely_type="TRV")
+        assert len(trvs) == 1
+        assert trvs[0].device_id == "04:056053"
+
+    def test_filter_by_min_confidence(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        # 04:056053 sends binding code → high
+        scan._process_packet(make_dto(src="04:056053", dst="01:145038", code="3150"))
+        # 01:145038 only seen as dst → low
+        high_only = scan.get_devices(min_confidence="high")
+        assert len(high_only) == 1
+        assert high_only[0].device_id == "04:056053"
+
+    def test_device_count(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        assert scan.device_count() == 0
+        scan._process_packet(make_dto(src="04:056053", code="3150"))
+        assert scan.device_count() == 2  # src + dst both recorded
+
+
+class TestDiscoveryScanRemoveDevice:
+    """Tests for remove_device."""
+
+    def test_remove_existing(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(make_dto(src="04:056053", code="3150"))
+        assert scan.remove_device("04:056053") is True
+        assert scan.get_device("04:056053") is None
+
+    def test_remove_nonexistent(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        assert scan.remove_device("99:999999") is False
+
+
+class TestDiscoveryScanExportImport:
+    """Tests for JSON export/import."""
+
+    def test_export_json_structure(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(make_dto(src="04:056053", dst="01:145038", code="3150"))
+        data = json.loads(scan.export_json())
+        assert "version" in data
+        assert "devices" in data
+        assert len(data["devices"]) == 2
+
+    def test_export_import_round_trip(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(make_dto(src="04:056053", dst="01:145038", code="3150"))
+        scan._process_packet(make_dto(src="04:056053", code="1060"))
+        exported = scan.export_json()
+
+        # New scan, import the data
+        scan2 = DiscoveryScan(make_mock_gateway())
+        scan2.import_json(exported)
+        assert scan2.device_count() == 2
+        dev = scan2.get_device("04:056053")
+        assert dev is not None
+        assert dev.likely_type == "TRV"
+        assert "3150" in dev.codes_seen
+        assert "1060" in dev.codes_seen
+
+    def test_import_clears_dirty(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(make_dto(src="04:056053", code="3150"))
+        assert scan.is_dirty is True
+        scan.import_json(scan.export_json())
+        assert scan.is_dirty is False
+
+    def test_export_sorted_by_device_id(self) -> None:
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(make_dto(src="04:056053", code="3150"))
+        scan._process_packet(make_dto(src="01:145038", code="2E04"))
+        data = json.loads(scan.export_json())
+        ids = [d["device_id"] for d in data["devices"]]
+        assert ids == sorted(ids)
+
+
+# ---------------------------------------------------------------------------
+# Integration: no topology mutation
+# ---------------------------------------------------------------------------
+
+
+class TestNoTopologyMutation:
+    """Verify the scan never mutates topology."""
+
+    def test_no_get_device_calls(self) -> None:
+        """The scan should never call get_device on the registry."""
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(make_dto(src="04:056053", code="3150"))
+        scan._process_packet(make_dto(src="01:145038", code="2E04"))
+        # get_device should never have been called
+        gwy.device_registry.get_device.assert_not_called()
+
+    def test_no_schema_modification(self) -> None:
+        """The scan should not modify the schema."""
+        original_schema = {"01:145038": {}}
+        gwy = make_mock_gateway(schema=original_schema)
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(make_dto(src="04:056053", dst="01:145038", code="3150"))
+        # Schema should be unchanged
+        assert gwy._gwy_config.schema == original_schema
+
+
+# ---------------------------------------------------------------------------
+# Integration: out-of-order discovery (TRV before CTL)
+# ---------------------------------------------------------------------------
+
+
+class TestOutOfOrderDiscovery:
+    """Tests for the out-of-order discovery scenario."""
+
+    def test_trv_seen_before_ctl(self) -> None:
+        """TRV broadcasts to a CTL address before CTL is seen.
+
+        The CTL should be recorded as a referenced-but-unseen device.
+        """
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        # TRV sends to CTL — CTL is dst
+        scan._process_packet(make_dto(src="04:056053", dst="01:145038", code="3150"))
+        # TRV should be discovered with binding info
+        trv = scan.get_device("04:056053")
+        assert trv is not None
+        assert trv.bound_to == "01:145038"
+        assert trv.zone_idx == "02"
+        # CTL should also be recorded (as dst)
+        ctl = scan.get_device("01:145038")
+        assert ctl is not None
+        assert ctl.confidence == "low"  # only seen as dst so far
+
+    def test_ctl_appears_later_enriches(self) -> None:
+        """When CTL starts sending, its confidence should upgrade."""
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        # Phase 1: TRV seen, CTL only as dst
+        scan._process_packet(make_dto(src="04:056053", dst="01:145038", code="3150"))
+        ctl = scan.get_device("01:145038")
+        assert ctl is not None
+        assert ctl.confidence == "low"
+
+        # Phase 2: CTL sends its own traffic
+        scan._process_packet(make_dto(src="01:145038", dst="18:006402", code="2E04"))
+        assert ctl.src_count == 1
+        assert "2E04" in ctl.codes_seen
+        # Confidence should upgrade to medium (src_count >= 1 + codes >= 2)
+        assert ctl.confidence in ("medium", "high")

--- a/tests/tests_rf/test_discovery_scan.py
+++ b/tests/tests_rf/test_discovery_scan.py
@@ -841,3 +841,190 @@ class TestVirtualRfIntegration:
             await gwy.stop()
         finally:
             await rf.stop()
+
+    @pytest.mark.asyncio
+    async def test_resume_after_export_import(self) -> None:
+        """Scan can export its state, a new scan can import it and continue.
+
+        Simulates an HA restart: scan1 discovers devices, exports JSON,
+        scan2 imports the JSON and continues scanning, discovering new
+        devices that appeared after the restart.
+        """
+        from tests_rf.virtual_rf import HgiFwTypes, VirtualRf
+
+        HGI_ID = "18:333333"
+        CTL_ID = "01:145038"
+        TRV_ID = "04:056053"
+        FAN_ID = "32:157747"
+
+        # Phase 1 packets: CTL + TRV
+        phase1_pkts: list[bytes] = [
+            b" I --- 01:145038 18:333333 --:------ 2E04 003 000200\r\n",
+            b" I --- 04:056053 01:145038 --:------ 3150 006 02C800000000\r\n",
+        ]
+
+        # Phase 2 packets: FAN (new device after "restart")
+        phase2_pkts: list[bytes] = [
+            b" I --- 32:157747 --:------ 32:157747 31DA 030 00EF007FFF3A2F04C404E204A904BA68000003C8C80000EFEF20A91F0500\r\n",
+        ]
+
+        rf = VirtualRf(2)
+        try:
+            rf.set_gateway(rf.ports[0], HGI_ID, fw_type=HgiFwTypes.EVOFW3)
+
+            from unittest.mock import patch
+
+            from ramses_rf.gateway import Gateway, GatewayConfig
+            from ramses_tx.config import EngineConfig
+
+            engine_config = EngineConfig(
+                disable_qos=True,
+                enforce_known_list=True,
+                disable_sending=True,
+            )
+            gwy_config = GatewayConfig(
+                disable_discovery=True,
+                enable_eavesdrop=False,
+                engine=engine_config,
+                known_list={HGI_ID: {}},
+                schema={},
+            )
+
+            # --- Phase 1: scan and export ---
+            with patch("ramses_tx.discovery.comports", rf.comports):
+                gwy = Gateway(rf.ports[0], config=gwy_config)
+                await gwy.start()
+
+            scan1 = DiscoveryScan(gwy)
+            scan1.start()
+            for pkt in phase1_pkts:
+                await rf.dump_frames_to_rf([pkt])
+                await asyncio.sleep(0.05)
+            await asyncio.sleep(0.5)
+            scan1.stop()
+
+            devices1 = {d.device_id: d for d in scan1.get_devices()}
+            assert CTL_ID in devices1
+            assert TRV_ID in devices1
+            assert FAN_ID not in devices1  # FAN not seen yet
+
+            # Export state
+            json_state = scan1.export_json()
+            assert CTL_ID in json_state
+            assert TRV_ID in json_state
+
+            await gwy.stop()
+
+            # --- Phase 2: new scan imports state and continues ---
+            with patch("ramses_tx.discovery.comports", rf.comports):
+                gwy2 = Gateway(rf.ports[0], config=gwy_config)
+                await gwy2.start()
+
+            scan2 = DiscoveryScan(gwy2)
+            scan2.import_json(json_state)  # resume from exported state
+
+            # Verify imported devices are present before scanning
+            imported = {d.device_id: d for d in scan2.get_devices()}
+            assert CTL_ID in imported
+            assert TRV_ID in imported
+            assert FAN_ID not in imported  # not yet
+
+            scan2.start()
+            for pkt in phase2_pkts:
+                await rf.dump_frames_to_rf([pkt])
+                await asyncio.sleep(0.05)
+            await asyncio.sleep(0.5)
+            scan2.stop()
+
+            # Verify all devices now present
+            devices2 = {d.device_id: d for d in scan2.get_devices()}
+            assert CTL_ID in devices2  # from import
+            assert TRV_ID in devices2  # from import
+            assert FAN_ID in devices2  # newly discovered
+            assert devices2[FAN_ID].likely_type == "FAN"
+
+            await gwy2.stop()
+        finally:
+            await rf.stop()
+
+    @pytest.mark.asyncio
+    async def test_hvac_co2_and_hum_classification(self) -> None:
+        """Scan correctly classifies CO2 and HUM devices via VC pairs.
+
+        37: prefix is ambiguous (REM, CO2, HUM all use it), so the VC pair
+        must distinguish them:
+        - I 1298 → CO2
+        - I 22F1 → REM
+        - I 31E0 → HUM (if in HVAC_KLASS_BY_VC_PAIR)
+        """
+        from tests_rf.virtual_rf import HgiFwTypes, VirtualRf
+
+        HGI_ID = "18:444444"
+        CO2_ID = "37:111111"
+        REM_ID = "37:222222"
+
+        raw_pkts: list[bytes] = [
+            # CO2 sends air quality (I 1298)
+            b" I --- 37:111111 18:444444 --:------ 1298 013 00EF007FFF3A2F04C404E204A9\r\n",
+            # REM sends fan mode (I 22F1)
+            b" I --- 37:222222 32:157747 --:------ 22F1 003 000107\r\n",
+        ]
+
+        rf = VirtualRf(2)
+        try:
+            rf.set_gateway(rf.ports[0], HGI_ID, fw_type=HgiFwTypes.EVOFW3)
+
+            from unittest.mock import patch
+
+            from ramses_rf.gateway import Gateway, GatewayConfig
+            from ramses_tx.config import EngineConfig
+
+            engine_config = EngineConfig(
+                disable_qos=True,
+                enforce_known_list=True,
+                disable_sending=True,
+            )
+            gwy_config = GatewayConfig(
+                disable_discovery=True,
+                enable_eavesdrop=False,
+                engine=engine_config,
+                known_list={HGI_ID: {}},
+                schema={},
+            )
+
+            with patch("ramses_tx.discovery.comports", rf.comports):
+                gwy = Gateway(rf.ports[0], config=gwy_config)
+                await gwy.start()
+
+            scan = DiscoveryScan(gwy)
+            scan.start()
+            for pkt in raw_pkts:
+                await rf.dump_frames_to_rf([pkt])
+                await asyncio.sleep(0.05)
+            await asyncio.sleep(0.5)
+            scan.stop()
+
+            discovered = {d.device_id: d for d in scan.get_devices()}
+
+            # CO2 should be classified as CO2 (via I 1298 VC pair)
+            assert CO2_ID in discovered, (
+                f"CO2 not discovered: {list(discovered.keys())}"
+            )
+            assert discovered[CO2_ID].likely_type == "CO2", (
+                f"Expected CO2, got {discovered[CO2_ID].likely_type}"
+            )
+
+            # REM should be classified as REM (via I 22F1 VC pair)
+            assert REM_ID in discovered, (
+                f"REM not discovered: {list(discovered.keys())}"
+            )
+            assert discovered[REM_ID].likely_type == "REM", (
+                f"Expected REM, got {discovered[REM_ID].likely_type}"
+            )
+
+            # Both are 37: prefix but different types — VC pair disambiguates
+            assert discovered[CO2_ID].likely_type != discovered[REM_ID].likely_type
+
+            await gwy.stop()
+        finally:
+            await rf.stop()


### PR DESCRIPTION
# PR: Passive device scan engine (ramses_rf)

## Summary

Implements the scan engine for Phase 4 ("Finding devices on a clean
system"). This is the ramses_rf layer only — a read-only observer
that listens to RF traffic, classifies unknown devices, and maintains an
in-memory discovery list. The ramses_cc integration (notifications, schema
writing, persistence) and ramses_extras UI card will follow in separate PRs.

- New module: `src/ramses_rf/discovery_scan.py`
- New CLI command: `ramses_rf scan`
- New `add_raw_pkt_handler` on Gateway/Engine/Protocol (fires before device ID filter)
- 70 tests covering classification, lifecycle, export/import, no-mutation

Full plan: https://github.com/ramses-rf/ramses_cc/issues/762 (detailed Phase 4)
See also: https://github.com/ramses-rf/ramses_cc/issues/627 (parent issue)

## What it does

```
RF traffic → raw_pkt_handler → filter unknown → classify → store (in-memory)
                                                                    ↓
                                                  export_json() / get_devices()
```

The scan registers via `add_raw_pkt_handler` (new method), which fires
**before** the `enforce_known_list` device ID filter. This is essential:
with `enforce_known_list=True` and only the HGI in the known_list, normal
msg_handlers never see packets from unknown devices. The raw handler lets
the scan observe all valid traffic regardless of the filter, while the
gateway still blocks unknown devices from entering the registry.

```
Transport → _pkt_received
              ↓
            raw_pkt_handlers  (scan engine — sees ALL packets)
              ↓
            _is_wanted_addrs  (enforce_known_list filter)
              ↓
            msg_handlers       (gateway, topology builder — filtered)
```

For every packet the scan:
1. Extracts src, dst, addr3 device IDs
2. Skips devices already in known_list, schema, or device registry
3. Classifies unknown devices by:
   - **Address prefix** → likely type (01:=CTL, 04:=TRV, 07:=DHW, 32:=FAN, etc.)
   - **Verb+code pair** → HVAC type (I 31DA→FAN, I 22F1→REM, I 1298→CO2)
   - **CTL-only codes** → if device sends 1030/1F09/313F, it's a CTL
4. Extracts zone_idx from binding telemetry (3150, 30C9, 000C, etc.)
5. Tracks RSSI as running average, battery flag, codes_seen
6. Scores confidence: high (binding telemetry), medium (multiple src packets), low (only seen as dst)

## What it does NOT do

- **No topology mutation** — never calls `get_device()`, never emits `TopologyChangedEvent`. Pure observer. Verified by tests.
- **No disk writes** — everything in-memory. The consumer calls `export_json()` when they decide to persist.
- **No HA dependencies** — plain Python, works in CLI.
- **No entity creation** — devices are classified but not created until the user accepts them (ramses_cc layer).

## CLI usage

```
$ ramses_rf scan /dev/ttyUSB0 --duration 300 --output found.json
Scanning for 300 seconds...
Found 6 devices:

  Device ID    Type   Conf    RSSI  Details
  ------------ ------ ------- ------ ------------------------------
  01:145038    CTL    high      -68
  04:056053    TRV    high      -72  zone=02  bound to 01:145038
  07:046947    DHW    medium    -75  bound to 01:145038
  10:067219    BDR    high      -70  bound to 01:145038
  32:157747    FAN    high      -72
  37:179540    REM    medium    -81  bound to 32:157747

Exported to found.json
```

`--duration 0` scans until interrupted (Ctrl-C).

## API

```python
from ramses_rf.discovery_scan import DiscoveryScan

scan = DiscoveryScan(gwy)
scan.start()                    # register as raw_pkt_handler
# ... traffic flows ...
devices = scan.get_devices(min_confidence="medium")
for dev in devices:
    print(dev.device_id, dev.likely_type, dev.confidence, dev.bound_to)

json_str = scan.export_json()   # for persistence
scan.import_json(json_str)      # resume after restart
scan.stop()                     # unregister
```

## Tested with real packet logs

Fed two packet logs through the scan engine with `enforce_known_list=True`
and only HGI in known_list:

**HVAC log** (ramses_log, 40 lines) → 3 devices:
- 32:153289 FAN (medium, 28 src packets, codes 22F1/31D9/31DA/31E0)
- 37:126776 REM (medium, 1 src packet)
- 37:168270 REM (medium, 11 src packets, sends 22F1 to FAN)

**CH log** (system_1.log, 59 lines) → 11 devices:
- 01:145038 CTL (high), 04:056053/04:189082 TRV (battery), 07:046947 DHW (battery)
- 13:081775/13:120242/13:202850 OTB, 22:140285 THM, 34:092243 RND (battery)
- 32:097710/32:139773 FAN

Registry stayed at 1 device (HGI only) — scan sees everything, creates nothing.

## Files changed

- `src/ramses_rf/discovery_scan.py` — new (scan engine, ~550 lines)
- `src/ramses_tx/protocol/base.py` — added `add_raw_pkt_handler` + raw handler dispatch in `_DeviceIdFilterMixin._pkt_received`
- `src/ramses_tx/engine.py` — added `add_raw_pkt_handler` passthrough
- `src/ramses_rf/gateway.py` — added `add_raw_pkt_handler` passthrough
- `src/ramses_cli/client.py` — added `scan` command + `_print_scan_results` helper
- `tests/tests_rf/test_discovery_scan.py` — new (70 tests)

## Test plan

- [x] 70 unit tests pass (classification, lifecycle, packet handling, export/import round-trip, no-mutation, out-of-order discovery)
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `mypy` passes (0 errors)
- [x] Tested with real packet logs (HVAC + CH)
- [ ] Manual test with live RF traffic (requires hardware)
- [ ] ramses_cc integration (separate PR)
