### PR TITLE
Fix client test -o warning

### DIFF
--- a/src/ramses_cli/client.py
+++ b/src/ramses_cli/client.py
@@ -462,9 +462,9 @@ async def listen(
     default=300,
     help="scan duration in seconds (0 = until interrupted)",
 )
-@click.option(  # --output file
-    "-o",
-    "--output",
+@click.option(  # --file
+    "-f",
+    "--file",
     type=click.Path(),
     help="export discovered devices to JSON file",
 )

--- a/src/ramses_cli/client.py
+++ b/src/ramses_cli/client.py
@@ -488,9 +488,9 @@ async def scan(
     lib_config[SZ_CONFIG][SZ_DISABLE_SENDING] = True
     lib_config[SZ_CONFIG][SZ_DISABLE_DISCOVERY] = True
 
-    # Pass duration and output via kwargs (consumed in async_main)
+    # Pass duration and output file via kwargs (consumed in async_main)
     config["scan_duration"] = duration
-    config["scan_output"] = kwargs.get("output")
+    config["scan_output"] = kwargs.get("file")
 
     return SCAN, lib_config, config
 

--- a/tests/tests_cli/test_client.py
+++ b/tests/tests_cli/test_client.py
@@ -1015,7 +1015,7 @@ async def test_scan_command_disables_sending_and_discovery() -> None:
         # standalone_mode=False returns the command's return value
         result = await runner.invoke(
             cli,
-            ["scan", "/dev/ttyUSB0", "--output", "found.json", "--duration", "60"],
+            ["scan", "/dev/ttyUSB0", "--file", "found.json", "--duration", "60"],
             standalone_mode=False,
         )
 


### PR DESCRIPTION
This PR prevents the warnings in system log about the duplicate use of the `-o` key when using the client CLI, and during tests.

- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: not used