### PR TITLE
Don't log empty packets

### DIFF
--- a/src/ramses_tx/packet.py
+++ b/src/ramses_tx/packet.py
@@ -99,7 +99,8 @@ class Packet(Frame):
 
             super()._validate(strict_checking=strict_checking)  # no RSSI
 
-            PKT_LOGGER.info("", extra=self.__dict__)  # the packet.log line
+            if len(self.__dict__) > 0:  # don't log empty packets
+                PKT_LOGGER.info("", extra=self.__dict__)  # the packet.log line
 
         except PacketInvalid as err:  # incl. InvalidAddrSetError
             if getattr(self, "_frame", "") or self.error_text:


### PR DESCRIPTION
This PR fixes a small issue where empty packets in tests were logged INFO without any data, filling up terminal and CI error reports

- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: not used