### PR TITLE
Refactor and restore RX payload decoder regression test (Fixes CI log overflow)

### DIFF
--- a/tests/tests_rf/rx_parity/test_rx_payload_decoder_regression.py
+++ b/tests/tests_rf/rx_parity/test_rx_payload_decoder_regression.py
@@ -14,72 +14,106 @@ FIXTURE_PATH: Path = (
     Path(__file__).parent.parent.parent / "fixtures" / "regression_packets_sorted.txt"
 )
 
+# Baseline metrics for the static fixture file. If these change, a parser
+# has been altered and the regression requires manual review.
+EXPECTED_L2_SKIPS: int = 10
+EXPECTED_SCHEMA_SKIPS: int = 15
 
-def _load_regression_frames() -> list[str]:
+
+def _load_regression_frames() -> list[tuple[int, str]]:
     """Load and sanitize raw packet frames from the regression text file.
 
     Strips out comments and ignores empty lines.
 
-    :raises FileNotFoundError: If the regression file cannot be found at FIXTURE_PATH.
-    :return: A list of sanitized raw frame strings.
+    :raises FileNotFoundError: If the regression file cannot be found at
+        FIXTURE_PATH.
+    :return: A list of tuples containing line numbers and sanitized raw
+        frame strings.
     """
     if not FIXTURE_PATH.exists():
         raise FileNotFoundError(f"Could not find regression file at: {FIXTURE_PATH}")
 
-    frames: list[str] = []
+    frames: list[tuple[int, str]] = []
     with open(FIXTURE_PATH, encoding="utf-8") as file:
-        for line in file:
+        for line_num, line in enumerate(file, start=1):
             raw_frame: str = line.split("#")[0].strip()
             if raw_frame:
-                frames.append(raw_frame)
+                frames.append((line_num, raw_frame))
 
     return frames
 
 
 # Constants initialized after function declaration
-RAW_FRAMES: list[str] = _load_regression_frames()
+RAW_FRAMES: list[tuple[int, str]] = _load_regression_frames()
 
 
-# @pytest.mark.skip(reason="Logging too much in CI")
-# @pytest.mark.parametrize("raw_frame", RAW_FRAMES)
-def no_test_rx_payload_decoder_regression(raw_frame: str) -> None:
-    """Stress-test the decoupled DTO decoder against real-world packet frames.
+def test_rx_payload_decoder_regression() -> None:
+    """Stress-test the decoupled DTO decoder against real-world packet
+    frames.
 
-    Ensures that L3 DTOs successfully cross the OSI boundary into L7 and decode
-    without raising unexpected exceptions.
-
-    :param raw_frame: The raw regression frame string.
+    Ensures that L3 DTOs successfully cross the OSI boundary into L7 and
+    decode without raising unexpected exceptions.
     """
-    if raw_frame[10] == " ":
-        date_str, time_str, pkt_line = raw_frame.split(" ", 2)
-        dtm_str: str = f"{date_str}T{time_str}"
-    else:
-        dtm_str, pkt_line = raw_frame.split(" ", 1)
+    errors: list[str] = []
+    skipped_l2_count: int = 0
+    skipped_schema_count: int = 0
 
-    # 1. Arrange: Construct the raw packet to simulate L2/L3 reception.
-    try:
-        pkt: Any = Packet.from_file(dtm_str, pkt_line)
-    except Exception as err:
-        pytest.skip(f"Skipped due to L2 packet instantiation failure: {err}")
+    for line_num, raw_frame in RAW_FRAMES:
+        if raw_frame[10] == " ":
+            date_str, time_str, pkt_line = raw_frame.split(" ", 2)
+            dtm_str: str = f"{date_str}T{time_str}"
+        else:
+            dtm_str, pkt_line = raw_frame.split(" ", 1)
 
-    # 2. Act: Translate to DTO and push across the boundary to the L7 Decoder.
-    try:
-        dto: Any = pkt.to_dto()
-        new_payload: Any = decode_packet(dto)
-    except PacketPayloadInvalid as err:
-        # The L7 decoder successfully caught a malformed/corrupt RF payload
-        pytest.skip(f"Legitimate schema rejection: {err}")
-    except Exception as err:
-        # A genuine code crash occurred (e.g., KeyError, AttributeError)
-        pytest.fail(
-            f"Decoder crashed on DTO boundary for frame: {raw_frame}\nError: {err}"
-        )
+        # 1. Arrange: Construct the raw packet to simulate L2/L3 reception.
+        try:
+            pkt: Any = Packet.from_file(dtm_str, pkt_line)
+        except Exception:
+            # Skipped due to L2 packet instantiation failure
+            skipped_l2_count += 1
+            continue
 
-    # 3. Assert: Verify the decoder produced a valid output (dict, list, or valid str).
-    assert new_payload is not None, f"Decoder returned None for frame: {raw_frame}"
+        # 2. Act: Translate to DTO and push across the boundary to the L7
+        # Decoder.
+        try:
+            dto: Any = pkt.to_dto()
+            new_payload: Any = decode_packet(dto)
+        except PacketPayloadInvalid:
+            # The L7 decoder successfully caught a malformed/corrupt RF payload
+            skipped_schema_count += 1
+            continue
+        except Exception as err:
+            # A genuine code crash occurred (e.g., KeyError, AttributeError)
+            errors.append(f"Line {line_num} | Frame: {raw_frame} | Error: {err}")
+            continue
 
-    # If the payload is returned as a raw string, ensure it isn't a flagged ERROR state
-    if isinstance(new_payload, str):
-        assert not new_payload.startswith("ERROR"), (
-            f"Decoder returned an ERROR payload state: {new_payload}"
-        )
+        # 3. Assert: Verify the decoder produced a valid output (dict, list,
+        # or valid str).
+        if new_payload is None:
+            errors.append(
+                f"Line {line_num} | Frame: {raw_frame} | Error: Returned None"
+            )
+            continue
+
+        # If the payload is returned as a raw string, ensure it isn't a
+        # flagged ERROR state
+        if isinstance(new_payload, str) and new_payload.startswith("ERROR"):
+            errors.append(
+                f"Line {line_num} | Frame: {raw_frame} | "
+                f"Error: ERROR state {new_payload}"
+            )
+
+    # Final Evaluation: Catch genuine code crashes
+    if errors:
+        error_summary: str = "\n".join(errors)
+        pytest.fail(f"Decoder crashed on {len(errors)} frames:\n{error_summary}")
+
+    # Final Evaluation: Prevent silent regressions on known baselines
+    assert skipped_l2_count == EXPECTED_L2_SKIPS, (
+        f"L2 Exception baseline shifted! Expected {EXPECTED_L2_SKIPS}, "
+        f"got {skipped_l2_count}."
+    )
+    assert skipped_schema_count == EXPECTED_SCHEMA_SKIPS, (
+        f"Schema Rejection baseline shifted! Expected {EXPECTED_SCHEMA_SKIPS}, "
+        f"got {skipped_schema_count}."
+    )


### PR DESCRIPTION
### The Problem:

In PR #767, the `test_rx_payload_decoder_regression` test was disabled because its use of `@pytest.mark.parametrize` across 32,000+ raw packet frames completely overwhelmed the CI logs. Expected L2 and schema rejections were generating thousands of `pytest.skip()` console outputs, and the sheer volume of test nodes was severely skewing the local pytest progress bar.

### Consequences:

By leaving this test disabled, we lose a highly valuable, lightning-fast "smoke test" that ensures the OSI layer boundaries and decoupled DTO translations survive real-world data processing without fatal Python crashes.

### The Fix:

Refactored the parametrised test into a single, high-speed "Bulk Processing Test" loop that silently aggregates errors and validates exact baseline thresholds.

### Technical Implementation:
- Removed `@pytest.mark.parametrize`.
- Updated `_load_regression_frames()` to use `enumerate()`, returning a `list[tuple[int, str]]` so we can track the exact line number of every packet.
- Wrapped the packet processing logic in a native Python `for` loop.
- Handled expected L2 and `PacketPayloadInvalid` exceptions silently by incrementing local counters and using `continue`, entirely eliminating CI log spam.
- Appended genuine crashes to an `errors` list, which is printed in a single, clean `pytest.fail()` summary if populated.
- Added strict baseline assertions (`EXPECTED_L2_SKIPS = 10`, `EXPECTED_SCHEMA_SKIPS = 15`) to immediately fail the test if a parser is altered and the rejection rate changes, preventing silent regressions.

### Testing Performed:

Ran the test locally via `pytest`. The test now registers as a single item on the progress bar, processes all 32,325 frames in approximately 1.2 seconds, and outputs a single green tick with zero console spam.

### Risks of NOT Implementing:

Without this high-speed smoke test active, fundamental crashes at the DTO boundary might slip through basic checks, relying entirely on the slower Syrupy snapshot tests to catch plumbing failures.

### Risks of Implementing:

Because the baseline skip counts are strictly asserted, any future update to the `regression_packets_sorted.txt` fixture file, or any valid improvement to a parser, will cause the test to fail until the constants are manually updated.

### Mitigation Steps:

Added clear comments above the constants explaining that they act as a strict baseline for the static fixture, making it obvious to developers how to update them if the underlying parsing logic is intentionally improved.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.

---
