### PR TITLE
Fix CQRS hydration for controller system_mode (Issue _cc 769)

### DIFF
--- a/src/ramses_rf/systems/tcs.py
+++ b/src/ramses_rf/systems/tcs.py
@@ -1048,10 +1048,15 @@ class SysMode(SystemBase):  # 2E04
         cmd = Command.get_system_mode(self.id)
         self.discovery.add_cmd(cmd, 60 * 5, delay=5)
 
-    @property
-    def system_mode(self) -> dict[str, Any] | None:  # 2E04
-        """Return the system mode synchronously from Hot State RAM."""
+    async def system_mode(self) -> dict[str, Any] | None:  # 2E04
+        """Return the system mode asynchronously from Hot State RAM.
+
+        If the state is unpopulated (e.g., after boot), an explicit RQ is
+        dispatched to the network to hydrate the CQRS model.
+        """
         if self.system_state.system_mode is None:
+            cmd = Command.get_system_mode(self.id)
+            await self._gwy.async_send_cmd(cmd)
             return None
         return {
             SZ_SYSTEM_MODE: self.system_state.system_mode,
@@ -1083,7 +1088,7 @@ class SysMode(SystemBase):  # 2E04
 
     async def params(self) -> dict[str, Any]:
         params = await super().params()
-        params[SZ_SYSTEM][SZ_SYSTEM_MODE] = self.system_mode
+        params[SZ_SYSTEM][SZ_SYSTEM_MODE] = await self.system_mode()
         return params
 
 

--- a/tests/tests_rf/test_system_heat.py
+++ b/tests/tests_rf/test_system_heat.py
@@ -221,10 +221,10 @@ async def test_logbook_setup_discovery_creates_task(
 
 
 @pytest.mark.asyncio
-async def test_sysmode_system_mode_sync_cache_lookup(
+async def test_sysmode_system_mode_async_cache_lookup(
     fake_evofw3: Gateway,
 ) -> None:
-    """Verify system_mode retrieves state synchronously from CQRS read-model."""
+    """Verify system_mode retrieves state asynchronously from CQRS read-model."""
     gwy = fake_evofw3
     pkt = Packet.from_port(dt.now(), PKT_3150)
     gwy._engine._protocol.pkt_received(pkt)
@@ -235,7 +235,7 @@ async def test_sysmode_system_mode_sync_cache_lookup(
 
     tcs.system_state = replace(tcs.system_state, system_mode="01", until=None)
 
-    # Call the new synchronous @property lookup
-    result = tcs.system_mode
+    # Call the newly refactored async method lookup
+    result = await tcs.system_mode()
 
     assert result == {"system_mode": "01", "until": None}

--- a/tests/tests_rf/test_tcs_hydration.py
+++ b/tests/tests_rf/test_tcs_hydration.py
@@ -1,0 +1,96 @@
+"""Tests for the CQRS-compliant self-hydrating system_mode getter."""
+
+from __future__ import annotations
+
+import dataclasses
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ramses_rf.const import SZ_SYSTEM_MODE
+from ramses_rf.devices import Controller
+from ramses_rf.systems.tcs import Evohome
+from ramses_tx.command import Command
+
+
+@pytest.mark.asyncio
+async def test_system_mode_triggers_network_rq_when_cqrs_empty() -> None:
+    """Test that system_mode triggers a physical network RQ if CQRS state is empty.
+
+    Arrange: An Evohome controller with an empty hot CQRS state.
+    Act: Retrieve the system mode via the async getter.
+    Assert: An explicit network RQ (2E04) is dispatched.
+    """
+
+    # Arrange
+    mock_gwy = MagicMock()
+    mock_gwy.config.enable_eavesdrop = False
+    mock_gwy.device_registry.system_by_id = {}
+    mock_gwy.async_send_cmd = AsyncMock()
+
+    # Pass spec=Controller to satisfy the strict isinstance() guard in tcs.py
+    mock_ctl = MagicMock(spec=Controller)
+    mock_ctl.id = "01:123456"
+    mock_ctl._gwy = mock_gwy
+
+    tcs = Evohome(mock_ctl)
+
+    # Simulate an empty CQRS state (typical boot scenario before telemetry arrives)
+    tcs.system_state = dataclasses.replace(
+        tcs.system_state, system_mode=None, until=None
+    )
+
+    # Act
+    await tcs.system_mode()
+
+    # Assert
+    # Verify that an active network request was dispatched to hydrate the state
+    mock_gwy.async_send_cmd.assert_called_once()
+
+    # Extract the command passed to async_send_cmd
+    cmd: Command = mock_gwy.async_send_cmd.call_args[0][0]
+
+    assert cmd.verb == "RQ"
+    assert cmd.code == "2E04"
+    assert cmd.dst.id == mock_ctl.id
+
+
+@pytest.mark.asyncio
+async def test_system_mode_uses_hot_cqrs_state_when_available() -> None:
+    """Test that system_mode prefers the hot CQRS state without network I/O.
+
+    Arrange: An Evohome controller with a populated hot CQRS state.
+    Act: Retrieve the system mode via the async getter.
+    Assert: Returns the state instantly without dispatching an RQ.
+    """
+
+    # Arrange
+    mock_gwy = MagicMock()
+    mock_gwy.config.enable_eavesdrop = False
+    mock_gwy.device_registry.system_by_id = {}
+    mock_gwy.async_send_cmd = AsyncMock()
+
+    # Pass spec=Controller to satisfy the strict isinstance() guard in tcs.py
+    mock_ctl = MagicMock(spec=Controller)
+    mock_ctl.id = "01:123456"
+    mock_ctl._gwy = mock_gwy
+
+    tcs = Evohome(mock_ctl)
+
+    # Populate the hot CQRS state (simulating normal operation post-boot)
+    tcs.system_state = dataclasses.replace(
+        tcs.system_state,
+        system_mode="02",  # AUTO
+        until="2024-01-01T12:00:00",
+    )
+
+    # Act
+    result = await tcs.system_mode()
+
+    # Assert
+    assert result is not None
+    assert result[SZ_SYSTEM_MODE] == "02"
+    assert result["until"] == "2024-01-01T12:00:00"
+
+    # Verify we did NOT hit the network
+    mock_gwy.async_send_cmd.assert_not_called()


### PR DESCRIPTION
### **The Problem:**
Since migrating to the new CQRS event-sourced architecture, the Evohome controller's `preset_mode` and `system_mode` (derived from the 2E04 packet) are not actively populated upon system boot. They default to 'Unknown' until a new state change is organically broadcast over the RF network (Issue ramses-rf/ramses_cc#769).

### **Consequences:**
If left unfixed, Home Assistant will boot with 'Unknown' values for the climate entity's preset and hvac modes. This causes visual user confusion and actively breaks automations that rely on evaluating the system state shortly after a reboot.

### **The Fix:**
Refactored the passive `system_mode` property into an active, self-hydrating asynchronous method that automatically requests the state over the network if the internal CQRS model is currently empty.

### Technical Implementation:
- Removed the `@property` decorator from `SysMode.system_mode` in `tcs.py` and converted it to an `async def` method.
- Added a conditional check: if `self.system_state.system_mode` is `None`, it uses `self._gwy.async_send_cmd()` to dispatch a `2E04 RQ` packet to the physical controller.
- Updated `SysMode.params()` to correctly `await` the new async method.
- Note: No changes were required in `ramses_cc`'s `climate.py` because it retrieves this data via `resolve_async_attr()`, which natively supports both synchronous properties and asynchronous methods.

### Testing Performed:
- Created `tests/tests_rf/test_tcs_hydration.py`.
- Wrote an Arrange, Act, Assert (AAA) test simulating an empty CQRS state, verifying that `mock_gwy.async_send_cmd` is called with the correct `2E04 RQ` command.
- Wrote a secondary test simulating a populated CQRS state, verifying that the cached state is returned instantly without dispatching unnecessary network traffic.
- Updated `test_system_heat.py` to `await` the refactored method, ensuring a fully clean `mypy --strict` pass.

### Risks of NOT Implementing:
Automations triggering on Home Assistant restarts will fail, and users will lose trust in the integration's reported boot states.

### Risks of Implementing:
Any downstream custom scripts or heavily modified forks that directly access `tcs.system_mode` as a synchronous property without using the `ramses_cc` helper methods will encounter a coroutine error.

### Mitigation Steps:
We verified that the official `ramses_cc` Home Assistant integration already abstracts property/async accesses via the `resolve_async_attr` helper, meaning this change is entirely backwards-compatible for the primary user base. Comprehensive TDD and strict Mypy checks ensure the logic is sound.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.  
