### PR TITLE
Fix: Zone-level window_open state aggregation from child actuators (#771)

### DIFF
--- a/src/ramses_rf/systems/zones.py
+++ b/src/ramses_rf/systems/zones.py
@@ -950,7 +950,24 @@ class Zone(ZoneSchedule):
 
     async def window_open(self) -> bool | None:  # 12B0
         """Return an estimate of the zone's current window_open state."""
-        return self.trv_state.window_open
+        if not self.actuators:
+            return self.trv_state.window_open
+
+        states: list[bool | None] = []
+        for act in self.actuators:
+            if isinstance(act, TrvActuator):
+                states.append(await act.window_open())
+
+        if not states:
+            return self.trv_state.window_open
+
+        if any(state is True for state in states):
+            return True
+
+        if any(state is None for state in states):
+            return None
+
+        return False
 
     async def _get_temp(self) -> Packet | None:
         """Get the zone's latest temp from the Controller."""

--- a/tests/tests_rf/test_zone_window_open.py
+++ b/tests/tests_rf/test_zone_window_open.py
@@ -1,0 +1,114 @@
+"""Tests for Zone-level window_open state aggregation."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ramses_rf.devices import TrvActuator
+from ramses_rf.systems.zones import Zone
+
+
+def _create_mock_zone() -> Zone:
+    """Create an isolated Zone instance for testing."""
+    mock_tcs = MagicMock()
+    mock_tcs.id = "01:123456"
+    mock_tcs._gwy = MagicMock()
+    mock_tcs.zone_by_idx = {}
+    mock_tcs._max_zones = 12
+    mock_tcs.ctl = MagicMock()
+
+    return Zone(mock_tcs, "00")
+
+
+def _create_mock_trv(state: bool | None) -> MagicMock:
+    """Create a mock TRV actuator returning a specific window state."""
+    trv = MagicMock(spec=TrvActuator)
+    trv.window_open = AsyncMock(return_value=state)
+    return trv
+
+
+@pytest.mark.asyncio
+async def test_window_open_no_actuators() -> None:
+    """Test zone window state when no actuators are present."""
+
+    # Arrange
+    zone = _create_mock_zone()
+    zone.actuators = []
+
+    # Act
+    result = await zone.window_open()
+
+    # Assert
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_window_open_all_closed() -> None:
+    """Test zone window state when all TRVs report closed."""
+
+    # Arrange
+    zone = _create_mock_zone()
+    zone.actuators = [
+        _create_mock_trv(False),
+        _create_mock_trv(False),
+    ]
+
+    # Act
+    result = await zone.window_open()
+
+    # Assert
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_window_open_one_open() -> None:
+    """Test zone window state when at least one TRV reports open."""
+
+    # Arrange
+    zone = _create_mock_zone()
+    zone.actuators = [
+        _create_mock_trv(False),
+        _create_mock_trv(True),
+    ]
+
+    # Act
+    result = await zone.window_open()
+
+    # Assert
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_window_open_mixed_unknown_and_closed() -> None:
+    """Test zone window state with unknown and closed TRVs."""
+
+    # Arrange
+    zone = _create_mock_zone()
+    zone.actuators = [
+        _create_mock_trv(None),
+        _create_mock_trv(False),
+    ]
+
+    # Act
+    result = await zone.window_open()
+
+    # Assert
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_window_open_mixed_unknown_and_open() -> None:
+    """Test zone window state with unknown and open TRVs."""
+
+    # Arrange
+    zone = _create_mock_zone()
+    zone.actuators = [
+        _create_mock_trv(None),
+        _create_mock_trv(True),
+    ]
+
+    # Act
+    result = await zone.window_open()
+
+    # Assert
+    assert result is True


### PR DESCRIPTION
### The Problem:

In the new 0.57.x CQRS architecture, the `Zone.window_open` property was hardcoded to return a static, unpopulated state (`self.trv_state.window_open`). It completely ignored the real-time status of its child `TrvActuator` devices. (Fixes #771).

### Consequences:

Users and upstream integrations (such as Home Assistant) see the Zone's window state as 'Unknown' (`None`) indefinitely. This renders downstream automations based on room-level window states impossible, even when the underlying TRVs are successfully reporting their correct status.

### The Fix:

Refactored the `Zone.window_open` getter to dynamically compute and aggregate the window states of its associated child actuators.

### Technical Implementation:

Replaced the static return with an asynchronous loop iterating over `self.actuators`. I utilised explicit type narrowing (`isinstance(act, TrvActuator)`) to satisfy strict Mypy constraints and access the actuator's `window_open()` method. The logic evaluates the list of gathered states: it returns `True` if `any()` are open, `None` if `any()` are unknown, and falls through to `False` if all are explicitly closed. The original static getter is retained as a safe fallback for zones with zero mapped actuators.

### Testing Performed:

Created an isolated TDD test suite (`tests/tests_rf/test_zone_window_open.py`) using `AsyncMock` to simulate `TrvActuator` objects without requiring a full Gateway loop. Tested all edge cases: empty actuators, all closed, at least one open, mixed unknown and closed, and mixed unknown and open. The full `pytest` suite passes, and `mypy --strict` reports zero errors.

### Risks of NOT Implementing:

A persistent loss of core functional parity in the 0.57.x branch, leading to user frustration due to broken climate automations relying on window detection.

### Risks of Implementing:

The primary risk is a highly marginal performance overhead when iterating over multiple TRVs synchronously within the property getter, although this is practically negligible as the underlying TRV states are cached locally in memory.

### Mitigation Steps:

Kept the aggregation loop tight, utilised fast, in-memory `isinstance` checks, and ensured the logic safely bails out (returning the fallback state) if no actuators are present.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.