### PR TITLE
feat: improve HVAC discovery with FAN reply inference + broadcast filtering

### DIFF
--- a/src/ramses_rf/discovery.py
+++ b/src/ramses_rf/discovery.py
@@ -12,7 +12,7 @@ import asyncio
 import contextlib
 import logging
 import random
-from datetime import datetime as dt, timedelta as td
+from datetime import UTC, datetime as dt, timedelta as td
 from typing import TYPE_CHECKING, Any, cast
 
 from ramses_rf.protocol.opentherm import OPENTHERM_MESSAGES
@@ -42,6 +42,13 @@ _SZ_INTERVAL: str = "interval"
 _SZ_COMMAND: str = "command"
 
 _DBG_ENABLE_DISCOVERY_BACKOFF: bool = False
+
+
+def _ensure_aware(dtm: dt) -> dt:
+    """Ensure datetime is timezone-aware, using UTC if naive."""
+    if dtm.tzinfo is None:
+        return dtm.replace(tzinfo=UTC)
+    return dtm
 
 
 class DiscoveryService:
@@ -390,10 +397,12 @@ class DiscoveryService:
             dt_now = dt.now().astimezone()
 
             msg = await find_latest_msg(hdr, task)
-            if msg and (task[_SZ_NEXT_DUE] < msg.dtm + task[_SZ_INTERVAL]):
+            if msg and (
+                task[_SZ_NEXT_DUE] < _ensure_aware(msg.dtm) + task[_SZ_INTERVAL]
+            ):
                 task[_SZ_FAILURES] = 0
                 task[_SZ_LAST_PKT] = msg._pkt
-                task[_SZ_NEXT_DUE] = msg.dtm + task[_SZ_INTERVAL]
+                task[_SZ_NEXT_DUE] = _ensure_aware(msg.dtm) + task[_SZ_INTERVAL]
 
             if task[_SZ_NEXT_DUE] > dt_now:
                 continue
@@ -413,7 +422,7 @@ class DiscoveryService:
             if pkt := await send_disc_cmd(hdr, task):
                 task[_SZ_FAILURES] = 0
                 task[_SZ_LAST_PKT] = pkt
-                task[_SZ_NEXT_DUE] = pkt.dtm + task[_SZ_INTERVAL]
+                task[_SZ_NEXT_DUE] = _ensure_aware(pkt.dtm) + task[_SZ_INTERVAL]
             else:
                 task[_SZ_FAILURES] += 1
                 task[_SZ_LAST_PKT] = None

--- a/src/ramses_rf/discovery_scan.py
+++ b/src/ramses_rf/discovery_scan.py
@@ -86,6 +86,17 @@ _ZONE_BINDING_CODES: frozenset[str] = frozenset(
     {"3150", "30C9", "000C", "2309", "2349", "10A0", "1260", "12B0", "1F09"}
 )
 
+# HVAC codes sent by REMs/CO2s to their parent FAN (32:).  These are
+# NOT binding protocol codes (binding uses 1FC9, done once with FAN off).
+# They are operational commands.  A REM sending 22F1 to a FAN doesn't
+# prove binding — the REM could be a neighbour's remote broadcasting.
+# The real proof is when the FAN **answers** the REM (RP from 32: to
+# the REM).  See schema_architecture.md: "How HVAC topology COULD be
+# derived from traffic".
+_HVAC_PARENT_INFERENCE_CODES: frozenset[str] = frozenset(
+    {"22F1", "31E0", "31DA", "10D0"}  # fan_mode, vent_demand, fan_status, outside_temp
+)
+
 # 32: is unambiguous — always a FAN. A FAN sends 22F1 (which maps to REM in
 # HVAC_KLASS_BY_VC_PAIR) but is still a FAN, so the prefix must win.
 # 37: is ambiguous (REM, CO2, or HUM all use 37:) — needs the VC pair to
@@ -283,6 +294,7 @@ class DiscoveryScan:
                 zone_idx=zone_idx,
                 is_src=False,
                 dst=None,
+                src=src,  # who sent this packet (for HVAC reply inference)
             )
 
         # addr3: lowest-confidence (broadcast target or relay)
@@ -307,6 +319,7 @@ class DiscoveryScan:
         zone_idx: str | None,
         is_src: bool,
         dst: str | None,
+        src: str | None = None,
     ) -> None:
         """Update or create a discovery entry for a single device."""
         # Skip if already known to the gateway
@@ -336,6 +349,19 @@ class DiscoveryScan:
                 dev.zone_idx = zone_idx
                 dev.bound_to = dst
                 dev.confidence = "high"  # binding telemetry = high confidence
+            # HVAC topology inference: a FAN (32:) replying (RP) to this
+            # device confirms the binding — the FAN acknowledges the REM/CO2
+            # as a paired remote.  A REM just sending 22F1 to a FAN is NOT
+            # proof (could be a neighbour's remote broadcasting).
+            elif (
+                not is_src
+                and src
+                and _is_valid_address(src)
+                and src.startswith("32:")
+                and verb == "RP"
+                and code in _HVAC_PARENT_INFERENCE_CODES
+            ):
+                dev.bound_to = src
             self._devices[dev_id] = dev
             self._dirty = True
             _LOGGER.info(
@@ -381,6 +407,22 @@ class DiscoveryScan:
                 dev.bound_to = dst
                 dev.confidence = "high"
                 changed = True
+
+        # HVAC topology inference: a FAN (32:) replying (RP) to this
+        # device confirms the binding — the FAN acknowledges the REM/CO2
+        # as a paired remote.  Infer bound_to from the reply source if
+        # not already set (e.g. by zone binding telemetry).
+        if (
+            not dev.bound_to
+            and not is_src
+            and src
+            and _is_valid_address(src)
+            and src.startswith("32:")
+            and verb == "RP"
+            and code in _HVAC_PARENT_INFERENCE_CODES
+        ):
+            dev.bound_to = src
+            changed = True
 
         # Upgrade confidence based on accumulated evidence
         new_conf = _recompute_confidence(dev)

--- a/src/ramses_rf/discovery_scan.py
+++ b/src/ramses_rf/discovery_scan.py
@@ -479,13 +479,13 @@ class DiscoveryScan:
 def _is_valid_address(dev_id: str) -> bool:
     """Quick check if a device ID looks valid (N.N:NNNNNN or N:NNNNNN).
 
-    Filters out broadcast addresses (18:73030, 18:14803), placeholder
-    addresses (--:------), and corrupt IDs.
+    Filters out broadcast addresses (18:73030, 18:14803, 18:000730,
+    63:262142), placeholder addresses (--:------), and corrupt IDs.
     """
     if not dev_id or len(dev_id) < 8:
         return False
     # Skip broadcast/multicast addresses
-    if dev_id in ("18:73030", "18:14803", "18:000730"):
+    if dev_id in ("18:73030", "18:14803", "18:000730", "63:262142"):
         return False
     # Skip placeholder/empty addresses (e.g. "--:------")
     if dev_id.startswith("-") or dev_id.startswith("00:------"):

--- a/src/ramses_rf/discovery_scan.py
+++ b/src/ramses_rf/discovery_scan.py
@@ -194,7 +194,14 @@ class DiscoveryScan:
         """Check if a device is already known to the gateway.
 
         A device is "known" if it's the gateway itself, in the known_list,
-        schema, or already in the device registry.
+        or in the schema.  The device_registry is **not** consulted here:
+        under the Schema-as-Source-of-Truth architecture (ramses_cc issue
+        767, Invariant 1), the schema + derived known_list represent
+        declared intent, while the device_registry is derived state that
+        is populated from the schema at gateway creation and mutated at
+        runtime.  When they disagree, intent wins — a device removed from
+        the schema must be re-discoverable even if the running gateway's
+        registry still holds a stale entry.
         """
         # The gateway's own HGI is never a "discovered" device.
         # Check the active HGI ID from the transport directly — the device
@@ -212,15 +219,11 @@ class DiscoveryScan:
         if self._gwy.hgi and self._gwy.hgi.id == dev_id:
             return True
 
-        # Check device registry (already created devices)
-        if dev_id in self._gwy.device_registry.device_by_id:
-            return True
-
-        # Check known_list
+        # Check known_list (declared intent, derived from schema)
         if dev_id in self._gwy._gwy_config.known_list:
             return True
 
-        # Check schema keys (CTL IDs are top-level keys)
+        # Check schema keys (CTL IDs are top-level keys — declared intent)
         return dev_id in self._gwy._gwy_config.schema
 
     # -- packet handler ------------------------------------------------------

--- a/src/ramses_rf/messages/application.py
+++ b/src/ramses_rf/messages/application.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from datetime import UTC, datetime as dt, timedelta as td
 from typing import TYPE_CHECKING, Any
 
+from ramses_tx.const import VerbT
 from ramses_tx.dtos import PacketDTO
 
 from ..const import RQ, Code
@@ -75,7 +76,7 @@ class ApplicationMessage(Message):
             return td(minutes=60 * 24)
 
         if self.code == Code._1F09:
-            return td(seconds=360) if self.verb == " I" else td(seconds=0)
+            return td(seconds=360) if self.verb == VerbT.I_ else td(seconds=0)
 
         if self.code == Code._1FC9 and self.verb == "RP":
             return td(minutes=60 * 24)

--- a/src/ramses_tx/helpers.py
+++ b/src/ramses_tx/helpers.py
@@ -8,7 +8,7 @@ import sys
 import time
 from collections.abc import Iterable, Mapping
 from datetime import date, datetime as dt
-from typing import TYPE_CHECKING, Final, Literal, TypeAlias, cast
+from typing import TYPE_CHECKING, Final, Literal, TypeAlias
 
 from ramses_rf.protocol.ramses import _31DA_FAN_INFO
 
@@ -53,7 +53,7 @@ from .const import (
 )
 
 if TYPE_CHECKING:
-    from .typing import LogIdxT, PayDictT
+    from .typing import PayDictT
 
 # Sensor faults
 SZ_UNRELIABLE: Final = "unreliable"
@@ -429,7 +429,7 @@ def parse_fault_log_entry(
 
     # these are only useful for I_, not RP
     if (timestamp := hex_to_dts(payload[18:30])) is None:
-        return {"_log_idx": cast(LogIdxT, payload[4:6])}
+        return {f"_{SZ_LOG_IDX}": payload[4:6]}  # type: ignore[return-value]
 
     result: PayDictT.FAULT_LOG_ENTRY = {
         f"_{SZ_LOG_IDX}": payload[4:6],  # type: ignore[misc]

--- a/src/ramses_tx/helpers.py
+++ b/src/ramses_tx/helpers.py
@@ -8,7 +8,7 @@ import sys
 import time
 from collections.abc import Iterable, Mapping
 from datetime import date, datetime as dt
-from typing import TYPE_CHECKING, Final, Literal, TypeAlias
+from typing import TYPE_CHECKING, Final, Literal, TypeAlias, cast
 
 from ramses_rf.protocol.ramses import _31DA_FAN_INFO
 
@@ -53,7 +53,7 @@ from .const import (
 )
 
 if TYPE_CHECKING:
-    from .typing import PayDictT
+    from .typing import LogIdxT, PayDictT
 
 # Sensor faults
 SZ_UNRELIABLE: Final = "unreliable"
@@ -429,7 +429,7 @@ def parse_fault_log_entry(
 
     # these are only useful for I_, not RP
     if (timestamp := hex_to_dts(payload[18:30])) is None:
-        return {f"_{SZ_LOG_IDX}": payload[4:6]}  # type: ignore[misc,return-value]
+        return {"_log_idx": cast(LogIdxT, payload[4:6])}
 
     result: PayDictT.FAULT_LOG_ENTRY = {
         f"_{SZ_LOG_IDX}": payload[4:6],  # type: ignore[misc]

--- a/src/ramses_tx/transport/port.py
+++ b/src/ramses_tx/transport/port.py
@@ -203,7 +203,7 @@ class PortTransport(_FullTransport, _PortTransportAbstractor):  # type: ignore[m
             self._leak_sem(), name="PortTransport._leak_sem()"
         )
 
-        self._loop.create_task(
+        self._conn_task: asyncio.Task[None] | None = self._loop.create_task(
             self._create_connection(),
             name="PortTransport._create_connection()",
         )
@@ -350,6 +350,8 @@ class PortTransport(_FullTransport, _PortTransportAbstractor):  # type: ignore[m
             self._init_task.cancel()
         if hasattr(self, "_leaker_task") and self._leaker_task:
             self._leaker_task.cancel()
+        if conn_task := getattr(self, "_conn_task", None):
+            conn_task.cancel()
 
     def _close(  # type: ignore[override]
         self, exc: exc.RamsesException | None = None
@@ -362,3 +364,6 @@ class PortTransport(_FullTransport, _PortTransportAbstractor):  # type: ignore[m
 
         if leaker_task := getattr(self, "_leaker_task", None):
             leaker_task.cancel()
+
+        if conn_task := getattr(self, "_conn_task", None):
+            conn_task.cancel()

--- a/tests/tests_rf/test_discovery_scan.py
+++ b/tests/tests_rf/test_discovery_scan.py
@@ -408,11 +408,16 @@ class TestDiscoveryScanPacketHandling:
         scan._process_packet(make_dto(src="01:145038", code="2E04"))
         assert scan.get_device("01:145038") is None
 
-    def test_known_in_registry_skipped(self) -> None:
+    def test_known_in_registry_only_not_skipped(self) -> None:
+        """A device in the device_registry but NOT in known_list/schema
+        must be re-discoverable (Schema-as-Source-of-Truth, issue 767).
+        The registry is derived state; declared intent (schema/known_list)
+        wins."""
         gwy = make_mock_gateway(device_by_id={"04:056053": MagicMock()})
         scan = DiscoveryScan(gwy)
         scan._process_packet(make_dto(src="04:056053", code="3150"))
-        assert scan.get_device("04:056053") is None
+        # Registry-only device → NOT known → should be discovered
+        assert scan.get_device("04:056053") is not None
 
     def test_rssi_running_average(self) -> None:
         gwy = make_mock_gateway()

--- a/tests/tests_rf/test_discovery_scan.py
+++ b/tests/tests_rf/test_discovery_scan.py
@@ -96,6 +96,9 @@ class TestIsValidAddress:
     def test_broadcast_address_rejected(self) -> None:
         assert _is_valid_address("18:73030") is False
 
+    def test_all_device_broadcast_rejected(self) -> None:
+        assert _is_valid_address("63:262142") is False
+
     def test_empty_rejected(self) -> None:
         assert _is_valid_address("") is False
 

--- a/tests/tests_rf/test_discovery_scan.py
+++ b/tests/tests_rf/test_discovery_scan.py
@@ -1036,3 +1036,202 @@ class TestVirtualRfIntegration:
             await gwy.stop()
         finally:
             await rf.stop()
+
+
+# ---------------------------------------------------------------------------
+# HVAC topology inference — FAN reply (RP) to REM/CO2 confirms binding
+# ---------------------------------------------------------------------------
+
+FAN_ID = "32:153289"
+REM_29 = "29:176861"  # real REM (29: prefix)
+CO2_37 = "37:126776"  # CO2 sensor that also sends 31E0
+
+
+class TestHvacParentInference:
+    """Tests for inferring bound_to from HVAC operational traffic.
+
+    A REM sending 22F1 to a FAN is NOT proof of binding — the REM could
+    be a neighbour's remote broadcasting.  The real proof is when the
+    FAN **answers** the REM (RP from 32: to the REM).  This confirms
+    the FAN acknowledges the REM as a paired remote.
+
+    See schema_architecture.md: "How HVAC topology COULD be derived
+    from traffic".
+    """
+
+    async def test_fan_reply_infers_parent(self) -> None:
+        """A FAN (32:) replying RP to a REM should set bound_to on the
+        REM."""
+        scan = DiscoveryScan(gwy=make_mock_gateway())
+        scan.start()
+        try:
+            # REM sends RQ to FAN
+            dto1 = make_dto(
+                src=REM_29,
+                dst=FAN_ID,
+                code="31DA",
+                verb="RQ",
+                payload="00",
+            )
+            scan._process_packet(dto1)
+            dev = scan.get_device(REM_29)
+            assert dev is not None
+            assert dev.bound_to is None  # not yet confirmed
+
+            # FAN replies RP to REM — this confirms binding
+            dto2 = make_dto(
+                src=FAN_ID,
+                dst=REM_29,
+                code="31DA",
+                verb="RP",
+                payload="00EF007FFF424A084807A8082E075E6800C803C8C80000EFEF208A208A00",
+            )
+            scan._process_packet(dto2)
+            dev = scan.get_device(REM_29)
+            assert dev is not None
+            assert dev.bound_to == FAN_ID
+        finally:
+            scan.stop()
+
+    async def test_rem_sending_to_fan_does_not_infer(self) -> None:
+        """A REM sending I|22F1 to a FAN should NOT set bound_to — the
+        FAN hasn't confirmed the binding."""
+        scan = DiscoveryScan(gwy=make_mock_gateway())
+        scan.start()
+        try:
+            dto = make_dto(
+                src=REM_29,
+                dst=FAN_ID,
+                code="22F1",
+                verb=" I",
+                payload="000404",
+            )
+            scan._process_packet(dto)
+            dev = scan.get_device(REM_29)
+            assert dev is not None
+            assert dev.bound_to is None  # NOT confirmed
+        finally:
+            scan.stop()
+
+    async def test_fan_reply_to_co2_infers_parent(self) -> None:
+        """A FAN (32:) replying RP to a CO2 should set bound_to."""
+        scan = DiscoveryScan(gwy=make_mock_gateway())
+        scan.start()
+        try:
+            # FAN replies RP to CO2
+            dto = make_dto(
+                src=FAN_ID,
+                dst=CO2_37,
+                code="31DA",
+                verb="RP",
+                payload="00EF007FFF424A084807A8082E075E6800C803C8C80000EFEF208A208A00",
+            )
+            scan._process_packet(dto)
+            dev = scan.get_device(CO2_37)
+            assert dev is not None
+            assert dev.bound_to == FAN_ID
+        finally:
+            scan.stop()
+
+    async def test_non_rp_verb_does_not_infer(self) -> None:
+        """A FAN sending I (not RP) to a REM should NOT infer bound_to."""
+        scan = DiscoveryScan(gwy=make_mock_gateway())
+        scan.start()
+        try:
+            dto = make_dto(
+                src=FAN_ID,
+                dst=REM_29,
+                code="31DA",
+                verb=" I",  # not RP
+                payload="00EF007FFF424A",
+            )
+            scan._process_packet(dto)
+            dev = scan.get_device(REM_29)
+            assert dev is not None
+            assert dev.bound_to is None
+        finally:
+            scan.stop()
+
+    async def test_non_32_src_does_not_infer(self) -> None:
+        """A non-FAN (not 32:) replying RP should NOT infer bound_to."""
+        scan = DiscoveryScan(gwy=make_mock_gateway())
+        scan.start()
+        try:
+            dto = make_dto(
+                src="37:168270",  # not a FAN
+                dst=REM_29,
+                code="31DA",
+                verb="RP",
+                payload="00EF007FFF424A",
+            )
+            scan._process_packet(dto)
+            dev = scan.get_device(REM_29)
+            assert dev is not None
+            assert dev.bound_to is None
+        finally:
+            scan.stop()
+
+    async def test_zone_binding_takes_precedence(self) -> None:
+        """If zone binding sets bound_to first, HVAC inference must not
+        overwrite it."""
+        scan = DiscoveryScan(gwy=make_mock_gateway())
+        scan.start()
+        try:
+            # First: zone binding to a different FAN
+            dto1 = make_dto(
+                src=REM_29,
+                dst="32:999999",
+                code="000C",
+                verb=" I",
+                payload="00FFFF02C8",
+            )
+            scan._process_packet(dto1)
+            dev = scan.get_device(REM_29)
+            assert dev.bound_to == "32:999999"
+
+            # Then: FAN replies RP to REM — should NOT overwrite
+            dto2 = make_dto(
+                src=FAN_ID,
+                dst=REM_29,
+                code="31DA",
+                verb="RP",
+                payload="00EF007FFF424A",
+            )
+            scan._process_packet(dto2)
+            dev = scan.get_device(REM_29)
+            assert dev.bound_to == "32:999999"  # zone binding wins
+        finally:
+            scan.stop()
+
+    async def test_fan_reply_enriches_existing_device(self) -> None:
+        """If a REM is discovered without bound_to, a later FAN reply
+        should enrich it with bound_to."""
+        scan = DiscoveryScan(gwy=make_mock_gateway())
+        scan.start()
+        try:
+            # First: REM discovered via a non-HVAC code (no bound_to)
+            dto1 = make_dto(
+                src=REM_29,
+                dst="63:262142",
+                code="10E0",
+                verb=" I",
+                payload="00",
+            )
+            scan._process_packet(dto1)
+            dev = scan.get_device(REM_29)
+            assert dev is not None
+            assert dev.bound_to is None
+
+            # Then: FAN replies RP to REM — should set bound_to
+            dto2 = make_dto(
+                src=FAN_ID,
+                dst=REM_29,
+                code="31DA",
+                verb="RP",
+                payload="00EF007FFF424A",
+            )
+            scan._process_packet(dto2)
+            dev = scan.get_device(REM_29)
+            assert dev.bound_to == FAN_ID
+        finally:
+            scan.stop()

--- a/tests/tests_rf/test_discovery_scan.py
+++ b/tests/tests_rf/test_discovery_scan.py
@@ -1187,6 +1187,7 @@ class TestHvacParentInference:
             )
             scan._process_packet(dto1)
             dev = scan.get_device(REM_29)
+            assert dev is not None
             assert dev.bound_to == "32:999999"
 
             # Then: FAN replies RP to REM — should NOT overwrite
@@ -1199,6 +1200,7 @@ class TestHvacParentInference:
             )
             scan._process_packet(dto2)
             dev = scan.get_device(REM_29)
+            assert dev is not None
             assert dev.bound_to == "32:999999"  # zone binding wins
         finally:
             scan.stop()
@@ -1232,6 +1234,7 @@ class TestHvacParentInference:
             )
             scan._process_packet(dto2)
             dev = scan.get_device(REM_29)
+            assert dev is not None
             assert dev.bound_to == FAN_ID
         finally:
             scan.stop()


### PR DESCRIPTION
The broadcast/multicast address 63:262142 (hex FFFFFE) was not filtered by _is_valid_address, causing it to appear as a "discovered device" when HVAC devices broadcast `10E0` (OEM info) to it. This is not a real device — it is the RAMSES 'sentinel' equivalent of 255.255.255.255.

Added `63:262142` to the broadcast address filter alongside the existing 18:73030, 18:14803, 18:000730 entries.

---

- [x] AI Coding Assistance disclosure: GLM 5.2 high
