### PR TITLE
fix discovery scan on HGIs

### DIFF
--- a/src/ramses_rf/discovery_scan.py
+++ b/src/ramses_rf/discovery_scan.py
@@ -245,7 +245,10 @@ class DiscoveryScan:
         Delegates to the sync ``_process_packet`` so tests can call it
         directly without an event loop.
         """
-        self._process_packet(dto)
+        try:
+            self._process_packet(dto)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.error("DiscoveryScan: error processing packet %s: %s", dto, err)
 
     def _process_packet(self, dto: PacketDTO) -> None:
         """Classify packet, update in-memory dict. No disk I/O.
@@ -322,8 +325,34 @@ class DiscoveryScan:
         src: str | None = None,
     ) -> None:
         """Update or create a discovery entry for a single device."""
-        # Skip if already known to the gateway
-        if self._is_known(dev_id):
+        # 18: devices are HGI gateways — track them (so we know they're on
+        # the network and can include them in the schema as HGI type), but
+        # don't process zone bindings or heating topology for them.
+        is_hgi = dev_id.startswith("18:")
+
+        # For known devices, still update zone bindings (they may have been
+        # accepted before the scan engine captured zone_idx from broadcast
+        # traffic).  Skip full processing (classification, confidence, etc.)
+        # since the device is already known.
+        if self._is_known(dev_id) and not is_hgi:
+            dev = self._devices.get(dev_id)
+            if dev is not None and zone_idx and is_src:
+                bound_changed = dev.zone_idx != zone_idx
+                dev.zone_idx = zone_idx
+                if dst and _is_valid_address(dst) and dst != dev_id:
+                    if dev.bound_to != dst:
+                        dev.bound_to = dst
+                        bound_changed = True
+                if bound_changed:
+                    dev.confidence = "high"
+                    self._dirty = True
+                    _LOGGER.debug(
+                        "DiscoveryScan: updated zone binding for known "
+                        "device %s (zone=%s, bound_to=%s)",
+                        dev_id,
+                        zone_idx,
+                        dev.bound_to,
+                    )
             return
 
         now = dt.now().isoformat(timespec="seconds")
@@ -345,16 +374,22 @@ class DiscoveryScan:
                 dst_count=0 if is_src else 1,
             )
             # Set binding info if available
-            if zone_idx and dst and _is_valid_address(dst):
+            # zone_idx is extracted from the payload and is valid even for
+            # broadcasts (dst == --:------).  bound_to requires a valid dst.
+            # Skip for HGI gateways — they don't have zone bindings.
+            if zone_idx and is_src and not is_hgi:
                 dev.zone_idx = zone_idx
-                dev.bound_to = dst
+                if dst and _is_valid_address(dst) and dst != dev_id:
+                    dev.bound_to = dst
                 dev.confidence = "high"  # binding telemetry = high confidence
             # HVAC topology inference: a FAN (32:) replying (RP) to this
             # device confirms the binding — the FAN acknowledges the REM/CO2
             # as a paired remote.  A REM just sending 22F1 to a FAN is NOT
             # proof (could be a neighbour's remote broadcasting).
+            # Skip for HGI gateways — they don't have HVAC parent bindings.
             elif (
-                not is_src
+                not is_hgi
+                and not is_src
                 and src
                 and _is_valid_address(src)
                 and src.startswith("32:")
@@ -401,10 +436,18 @@ class DiscoveryScan:
             changed = True
 
         # Update zone binding (prefer src packets with zone_idx)
-        if zone_idx and is_src and dst and _is_valid_address(dst):
-            if dev.zone_idx != zone_idx or dev.bound_to != dst:
-                dev.zone_idx = zone_idx
-                dev.bound_to = dst
+        # zone_idx is extracted from the payload and is valid even for
+        # broadcasts (dst == --:------).  bound_to requires a valid dst
+        # that is different from the device itself.
+        # Skip for HGI gateways — they don't have zone bindings.
+        if zone_idx and is_src and not is_hgi:
+            bound_changed = dev.zone_idx != zone_idx
+            dev.zone_idx = zone_idx
+            if dst and _is_valid_address(dst) and dst != dev_id:
+                if dev.bound_to != dst:
+                    dev.bound_to = dst
+                    bound_changed = True
+            if bound_changed:
                 dev.confidence = "high"
                 changed = True
 
@@ -412,8 +455,10 @@ class DiscoveryScan:
         # device confirms the binding — the FAN acknowledges the REM/CO2
         # as a paired remote.  Infer bound_to from the reply source if
         # not already set (e.g. by zone binding telemetry).
+        # Skip for HGI gateways — they don't have HVAC parent bindings.
         if (
-            not dev.bound_to
+            not is_hgi
+            and not dev.bound_to
             and not is_src
             and src
             and _is_valid_address(src)
@@ -601,8 +646,8 @@ def _initial_confidence(is_src: bool, code: str, verb: str) -> str:
 
 def _recompute_confidence(dev: DiscoveredDevice) -> str:
     """Recompute confidence based on accumulated evidence."""
-    # High: has binding info (zone_idx + bound_to)
-    if dev.zone_idx and dev.bound_to:
+    # High: has zone binding info (zone_idx, with or without bound_to)
+    if dev.zone_idx:
         return "high"
 
     # High: sends CTL-only codes

--- a/src/ramses_rf/discovery_scan.py
+++ b/src/ramses_rf/discovery_scan.py
@@ -96,18 +96,28 @@ _ZONE_BINDING_CODES: frozenset[str] = frozenset(
 # NOT binding protocol codes (binding uses 1FC9, done once with FAN off).
 # They are operational commands.  A REM sending 22F1 to a FAN doesn't
 # prove binding — the REM could be a neighbour's remote broadcasting.
-# The real proof is when the FAN **answers** the REM (RP from 32: to
-# the REM).  See schema_architecture.md: "How HVAC topology COULD be
-# derived from traffic".
+# But a FAN sending a directed packet (I or RP) to a specific 37: device
+# IS strong evidence of binding — the FAN is the controller and it's
+# communicating with its paired remote.  See schema_architecture.md:
+# "How HVAC topology COULD be derived from traffic".
 _HVAC_PARENT_INFERENCE_CODES: frozenset[str] = frozenset(
     {"22F1", "31E0", "31DA", "10D0"}  # fan_mode, vent_demand, fan_status, outside_temp
 )
 
 # 32: is unambiguous — always a FAN. A FAN sends 22F1 (which maps to REM in
 # HVAC_KLASS_BY_VC_PAIR) but is still a FAN, so the prefix must win.
-# 37: is ambiguous (REM, CO2, or HUM all use 37:) — needs the VC pair to
+# 18: is unambiguous — always an HGI. The HGI relays packets from all device
+# types (22F1, 31DA, etc.) but is still a gateway, not a REM or FAN.
+# 37: is ambiguous (REM, CO2, HUM, or DIS all use 37:) — needs the VC pair to
 # distinguish, so it's NOT in this set.
-_UNAMBIGUOUS_HVAC_PREFIXES: frozenset[str] = frozenset({"32"})
+_UNAMBIGUOUS_HVAC_PREFIXES: frozenset[str] = frozenset({"18", "32"})
+
+# Valid HVAC types per prefix — constrains VC pair matching so a 37: device
+# sending 31D9 I (which maps to FAN) is NOT classified as FAN (FAN is 32: only).
+# Without this, the VC pair would override the prefix and misclassify devices.
+_AMBIGUOUS_HVAC_PREFIX_TYPES: dict[str, frozenset[DevType]] = {
+    "37": frozenset({DevType.REM, DevType.CO2, DevType.HUM, DevType.DIS}),
+}
 
 
 # ---------------------------------------------------------------------------
@@ -336,6 +346,53 @@ class DiscoveryScan:
         # don't process zone bindings or heating topology for them.
         is_hgi = dev_id.startswith("18:")
 
+        # For known HGI devices, create a minimal entry if not yet tracked,
+        # or just update last_seen if already tracked.  Don't re-classify
+        # or mark as dirty — the HGI is already known (in the known_list)
+        # and should not trigger discovery notifications.
+        if is_hgi and self._is_known(dev_id):
+            now = dt.now().isoformat(timespec="seconds")
+            dev = self._devices.get(dev_id)
+            if dev is None:
+                # First time seeing this known HGI — create a minimal entry
+                # so it appears in scan results, but don't mark dirty (no
+                # discovery notification needed for a known device).
+                dev = DiscoveredDevice(
+                    device_id=dev_id,
+                    first_seen=now,
+                    last_seen=now,
+                    likely_type=DevType.HGI,
+                    codes_seen=[code] if code else [],
+                    rssi=rssi,
+                    confidence="high",
+                    is_battery=False,
+                    src_count=1 if is_src else 0,
+                    dst_count=0 if is_src else 1,
+                )
+                self._devices[dev_id] = dev
+                self._dirty = True  # persist the new entry
+                _LOGGER.debug(
+                    "DiscoveryScan: tracking known HGI %s (not a new discovery)",
+                    dev_id,
+                )
+            else:
+                dev.last_seen = now
+                if is_src:
+                    dev.src_count += 1
+                else:
+                    dev.dst_count += 1
+                if code and code not in dev.codes_seen:
+                    dev.codes_seen.append(code)
+                    dev.codes_seen.sort()
+                    self._dirty = True  # persist updated codes
+                if rssi is not None and is_src:
+                    if dev.rssi is None:
+                        dev.rssi = rssi
+                    else:
+                        dev.rssi = (dev.rssi + rssi) / 2
+                    self._dirty = True  # persist updated RSSI
+            return
+
         # For known devices, still update zone bindings (they may have been
         # accepted before the scan engine captured zone_idx from broadcast
         # traffic).  Skip full processing (classification, confidence, etc.)
@@ -388,10 +445,9 @@ class DiscoveryScan:
                 if dst and _is_valid_address(dst) and dst != dev_id:
                     dev.bound_to = dst
                 dev.confidence = "high"  # binding telemetry = high confidence
-            # HVAC topology inference: a FAN (32:) replying (RP) to this
-            # device confirms the binding — the FAN acknowledges the REM/CO2
-            # as a paired remote.  A REM just sending 22F1 to a FAN is NOT
-            # proof (could be a neighbour's remote broadcasting).
+            # HVAC topology inference: a FAN (32:) sending a directed packet
+            # (I or RP) to this device confirms the binding — the FAN is the
+            # controller and it's communicating with its paired remote.
             # Skip for HGI gateways — they don't have HVAC parent bindings.
             elif (
                 not is_hgi
@@ -399,7 +455,7 @@ class DiscoveryScan:
                 and src
                 and _is_valid_address(src)
                 and src.startswith("32:")
-                and verb == "RP"
+                and verb in (" I", "RP")
                 and code in _HVAC_PARENT_INFERENCE_CODES
             ):
                 dev.bound_to = src
@@ -457,10 +513,10 @@ class DiscoveryScan:
                 dev.confidence = "high"
                 changed = True
 
-        # HVAC topology inference: a FAN (32:) replying (RP) to this
-        # device confirms the binding — the FAN acknowledges the REM/CO2
-        # as a paired remote.  Infer bound_to from the reply source if
-        # not already set (e.g. by zone binding telemetry).
+        # HVAC topology inference: a FAN (32:) sending a directed packet
+        # (I or RP) to this device confirms the binding — the FAN is the
+        # controller and it's communicating with its paired remote.
+        # Infer bound_to from the packet source if not already set.
         # Skip for HGI gateways — they don't have HVAC parent bindings.
         if (
             not is_hgi
@@ -469,7 +525,7 @@ class DiscoveryScan:
             and src
             and _is_valid_address(src)
             and src.startswith("32:")
-            and verb == "RP"
+            and verb in (" I", "RP")
             and code in _HVAC_PARENT_INFERENCE_CODES
         ):
             dev.bound_to = src
@@ -624,10 +680,16 @@ def _classify(
             if verb in ctl_verbs:
                 return DevType.CTL
 
-    # 3. Check verb+code pair (HVAC domain, for non-HVAC prefixes)
+    # 3. Check verb+code pair (HVAC domain)
+    #    For ambiguous HVAC prefixes (e.g. 37:), only accept VC pairs that
+    #    map to a type valid for that prefix (e.g. 31D9 I→FAN is rejected
+    #    for 37: because FAN is 32: only).
     vc_key = (verb, code)
     if vc_key in _VC_TO_TYPE:
-        return _VC_TO_TYPE[vc_key]
+        vc_type = _VC_TO_TYPE[vc_key]
+        valid_types = _AMBIGUOUS_HVAC_PREFIX_TYPES.get(prefix)
+        if valid_types is None or vc_type in valid_types:
+            return vc_type
 
     # 4. Check accumulated codes if we have a dev
     if dev and is_src:
@@ -644,10 +706,13 @@ def _classify(
                 if verb in ctl_verbs:
                     return DevType.CTL
         # Check HVAC codes from accumulated data
+        valid_types = _AMBIGUOUS_HVAC_PREFIX_TYPES.get(prefix)
         for c in dev.codes_seen:
             for v in (" I", "RP", "RQ", " W"):
                 if (v, c) in _VC_TO_TYPE:
-                    return _VC_TO_TYPE[(v, c)]
+                    vc_type = _VC_TO_TYPE[(v, c)]
+                    if valid_types is None or vc_type in valid_types:
+                        return vc_type
 
     # 5. CH prefix fallback
     if prefix in _PREFIX_TO_TYPE:

--- a/src/ramses_rf/discovery_scan.py
+++ b/src/ramses_rf/discovery_scan.py
@@ -75,7 +75,13 @@ _VC_TO_TYPE: dict[tuple[str, str], DevType] = {
 
 # Codes that only a CTL sends (from CODES_ONLY_FROM_CTL).
 # If a device sends one of these, it's definitely a CTL.
-_CTL_ONLY_CODES: frozenset[str] = frozenset({"1030", "1F09", "313F"})
+# NOTE: 313F (datetime) is only CTL-only when sent as I/RP (broadcasting
+# the time).  TRVs send 313F as RQ (requesting the time), so we track
+# the verb separately.
+_CTL_ONLY_CODES: frozenset[str] = frozenset({"1030", "1F09"})
+_CTL_ONLY_CODES_WITH_VERB: dict[str, frozenset[str]] = {
+    "313F": frozenset({" I", "RP"}),  # I/RP = CTL broadcasts time; RQ = TRV asks
+}
 
 # Codes that indicate battery-powered devices.
 _BATTERY_CODES: frozenset[str] = frozenset({"1060", "1FC9"})
@@ -609,8 +615,14 @@ def _classify(
         return _PREFIX_TO_TYPE[prefix]
 
     # 2. CTL-only codes (only if this device is the sender)
-    if is_src and code in _CTL_ONLY_CODES:
-        return DevType.CTL
+    #    Some codes are CTL-only depending on verb (e.g. 313F I=CTL, RQ=TRV)
+    if is_src:
+        if code in _CTL_ONLY_CODES:
+            return DevType.CTL
+        if code in _CTL_ONLY_CODES_WITH_VERB:
+            ctl_verbs = _CTL_ONLY_CODES_WITH_VERB[code]
+            if verb in ctl_verbs:
+                return DevType.CTL
 
     # 3. Check verb+code pair (HVAC domain, for non-HVAC prefixes)
     vc_key = (verb, code)
@@ -622,6 +634,15 @@ def _classify(
         for c in dev.codes_seen:
             if c in _CTL_ONLY_CODES:
                 return DevType.CTL
+        # Check verb-aware CTL codes from accumulated data
+        for c in dev.codes_seen:
+            if c in _CTL_ONLY_CODES_WITH_VERB:
+                ctl_verbs = _CTL_ONLY_CODES_WITH_VERB[c]
+                # Check if any verb in the accumulated data matches
+                # We don't track per-code verbs, so be conservative:
+                # only classify as CTL if the current verb matches
+                if verb in ctl_verbs:
+                    return DevType.CTL
         # Check HVAC codes from accumulated data
         for c in dev.codes_seen:
             for v in (" I", "RP", "RQ", " W"):
@@ -652,6 +673,9 @@ def _recompute_confidence(dev: DiscoveredDevice) -> str:
 
     # High: sends CTL-only codes
     if any(c in _CTL_ONLY_CODES for c in dev.codes_seen):
+        return "high"
+    # High: sends verb-aware CTL-only codes (e.g. 313F I/RP)
+    if any(c in _CTL_ONLY_CODES_WITH_VERB for c in dev.codes_seen):
         return "high"
 
     # Medium: seen as src multiple times

--- a/tests/tests_rf/test_discovery_scan.py
+++ b/tests/tests_rf/test_discovery_scan.py
@@ -170,9 +170,14 @@ class TestClassify:
         assert _classify("32:157747", "22F1", " I", is_src=True) == DevType.FAN
 
     def test_vc_pair_for_non_hvac_prefix(self) -> None:
-        """A non-HVAC prefix sending an HVAC code should use the VC pair."""
-        # 18: is HGI, but if it sends I 31DA it's acting as FAN
-        assert _classify("18:123456", "31DA", " I", is_src=True) == DevType.FAN
+        """A non-HVAC prefix sending an HVAC code should use the VC pair.
+
+        Note: 18: (HGI) is now unambiguous — it's always HGI regardless of
+        codes sent (it relays packets from all device types).  Use a different
+        prefix to test VC pair override on non-HVAC prefixes.
+        """
+        # 30: is RFG, but if it sends I 31DA the VC pair should win → FAN
+        assert _classify("30:123456", "31DA", " I", is_src=True) == DevType.FAN
 
     def test_ctl_only_code(self) -> None:
         """A device sending 1030 (CTL-only code) is classified as CTL."""
@@ -218,6 +223,43 @@ class TestClassify:
         """313F RQ from unknown prefix should not be classified as CTL."""
         result = _classify("99:999999", "313F", "RQ", is_src=True)
         assert result == DevType.DEV
+
+    def test_37_313f_rq_is_not_ctl(self) -> None:
+        """313F RQ from 37: should not be CTL — falls back to REM (prefix)."""
+        result = _classify("37:154519", "313F", "RQ", is_src=True)
+        assert result == DevType.REM
+
+    def test_37_31d9_is_not_fan(self) -> None:
+        """37: sending 31D9 I should NOT be FAN — FAN is 32: only.
+
+        31D9 I maps to FAN in HVAC_KLASS_BY_VC_PAIR, but 37: is ambiguous
+        (REM/CO2/HUM/DIS) and FAN is not a valid type for 37:.
+        """
+        result = _classify("37:154519", "31D9", " I", is_src=True)
+        assert result != DevType.FAN
+        # Should fall back to prefix (REM)
+        assert result == DevType.REM
+
+    def test_32_31d9_is_fan(self) -> None:
+        """32: sending 31D9 I should be FAN (unambiguous prefix)."""
+        assert _classify("32:153289", "31D9", " I", is_src=True) == DevType.FAN
+
+    def test_37_22f1_is_rem(self) -> None:
+        """37: sending 22F1 I should be REM (VC pair matches valid type)."""
+        assert _classify("37:168270", "22F1", " I", is_src=True) == DevType.REM
+
+    def test_37_1298_is_co2(self) -> None:
+        """37: sending 1298 I should be CO2 (VC pair matches valid type)."""
+        assert _classify("37:123456", "1298", " I", is_src=True) == DevType.CO2
+
+    def test_18_is_hgi_regardless_of_codes(self) -> None:
+        """18: is always HGI — it relays packets from all device types."""
+        # 22F1 I maps to REM, but 18: is a gateway, not a REM
+        assert _classify("18:130236", "22F1", " I", is_src=True) == DevType.HGI
+        # 31DA I maps to FAN, but 18: is a gateway, not a FAN
+        assert _classify("18:130236", "31DA", " I", is_src=True) == DevType.HGI
+        # 31D9 I maps to FAN, but 18: is a gateway, not a FAN
+        assert _classify("18:130236", "31D9", " I", is_src=True) == DevType.HGI
 
 
 class TestConfidence:
@@ -420,6 +462,46 @@ class TestDiscoveryScanPacketHandling:
         scan = DiscoveryScan(gwy)
         scan._process_packet(make_dto(src="04:056053", code="3150"))
         assert scan.get_device("04:056053") is None
+
+    def test_known_hgi_not_rediscovered(self) -> None:
+        """A known HGI (18:) should be tracked but not re-discovered.
+
+        HGIs are in the known_list but not in ramses_rf's schema (they're
+        stripped by _strip_schema_extensions).  The scan engine should
+        track them (so they appear in scan results) but not mark them as
+        new discoveries (no discovery notification).
+        """
+        gwy = make_mock_gateway(known_list={"18:130236": {"class": "HGI"}})
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(make_dto(src="18:130236", code="22F1"))
+        # Should be tracked (appears in scan results)
+        dev = scan.get_device("18:130236")
+        assert dev is not None
+        assert dev.likely_type == DevType.HGI
+        # Second packet — should update, not re-create
+        scan.clear_dirty()
+        scan._process_packet(make_dto(src="18:130236", code="10E0"))
+        assert scan.get_device("18:130236") is dev  # same object
+        assert dev.src_count == 2
+        assert "10E0" in dev.codes_seen
+
+    def test_unknown_hgi_tracked(self) -> None:
+        """An unknown HGI (e.g. neighbour's) should be tracked but not
+        re-discovered after the first sighting."""
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        # First packet — should create a discovery entry
+        scan._process_packet(make_dto(src="18:999999", code="22F1"))
+        dev = scan.get_device("18:999999")
+        assert dev is not None
+        assert dev.likely_type == DevType.HGI
+        first_seen = dev.first_seen
+        # Second packet — should update, not re-create
+        scan._process_packet(make_dto(src="18:999999", code="10E0"))
+        dev2 = scan.get_device("18:999999")
+        assert dev2 is not None
+        assert dev2.first_seen == first_seen  # same entry, not re-created
+        assert dev2.src_count == 2
 
     def test_known_in_schema_skipped(self) -> None:
         gwy = make_mock_gateway(schema={"01:145038": {}})
@@ -1152,8 +1234,14 @@ class TestHvacParentInference:
         finally:
             scan.stop()
 
-    async def test_non_rp_verb_does_not_infer(self) -> None:
-        """A FAN sending I (not RP) to a REM should NOT infer bound_to."""
+    async def test_i_verb_from_fan_infers_binding(self) -> None:
+        """A FAN sending I (directed) to a REM should infer bound_to.
+
+        A directed I packet from the FAN to a specific REM is strong evidence
+        of binding — the FAN is the controller and it's communicating with
+        its paired remote.  This is different from a REM broadcasting to a
+        FAN (which doesn't prove binding).
+        """
         scan = DiscoveryScan(gwy=make_mock_gateway())
         scan.start()
         try:
@@ -1161,13 +1249,13 @@ class TestHvacParentInference:
                 src=FAN_ID,
                 dst=REM_29,
                 code="31DA",
-                verb=" I",  # not RP
+                verb=" I",  # directed I from FAN
                 payload="00EF007FFF424A",
             )
             scan._process_packet(dto)
             dev = scan.get_device(REM_29)
             assert dev is not None
-            assert dev.bound_to is None
+            assert dev.bound_to == FAN_ID
         finally:
             scan.stop()
 

--- a/tests/tests_rf/test_discovery_scan.py
+++ b/tests/tests_rf/test_discovery_scan.py
@@ -200,6 +200,25 @@ class TestClassify:
         result = _classify("01:145038", "0001", " I", is_src=True, dev=dev)
         assert result == DevType.CTL
 
+    def test_313f_i_is_ctl(self) -> None:
+        """313F I (datetime broadcast) is CTL-only."""
+        assert _classify("01:145038", "313F", " I", is_src=True) == DevType.CTL
+
+    def test_313f_rp_is_ctl(self) -> None:
+        """313F RP (datetime reply) is CTL-only."""
+        assert _classify("01:145038", "313F", "RP", is_src=True) == DevType.CTL
+
+    def test_313f_rq_is_not_ctl(self) -> None:
+        """313F RQ (datetime request) is NOT CTL-only — TRVs send RQ too."""
+        # A 04: TRV sending 313F RQ should stay TRV, not become CTL
+        result = _classify("04:056053", "313F", "RQ", is_src=True)
+        assert result == DevType.TRV
+
+    def test_313f_rq_unknown_prefix_is_not_ctl(self) -> None:
+        """313F RQ from unknown prefix should not be classified as CTL."""
+        result = _classify("99:999999", "313F", "RQ", is_src=True)
+        assert result == DevType.DEV
+
 
 class TestConfidence:
     """Tests for confidence scoring."""


### PR DESCRIPTION
HGI's showed up with zone bindings/HVAC parents, but they will be be discovered so they can be added to the schema in _cc