### PR TITLE
Remove unused code for device.poller task

### DIFF
--- a/src/ramses_rf/devices/hvac_ventilators.py
+++ b/src/ramses_rf/devices/hvac_ventilators.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
 import logging
 from collections.abc import Callable
 from datetime import timedelta as td
@@ -45,7 +43,6 @@ from ramses_rf.const import (
     Code,
     DevType,
 )
-from ramses_rf.helpers import schedule_task
 from ramses_rf.models import DeviceTraits, HvacState
 from ramses_tx import Command, Packet, Priority
 from ramses_tx.typing import PayloadT
@@ -86,25 +83,6 @@ class FilterChange(DeviceHvac):  # FAN: 10D0
         if not hasattr(self, "hvac_state"):
             self.hvac_state = HvacState()
 
-        self._poller: asyncio.Task[None] | None = None
-        self._start_handle: asyncio.Handle | None = None
-        self._rq_cmd: Command = Command.from_attrs(
-            RQ, self.id, Code._10D0, PayloadT("00")
-        )
-
-        if getattr(
-            self._gwy.config, "disable_discovery", False
-        ):  # discovery will poll for filter
-            try:
-                self._start_handle = asyncio.get_running_loop().call_soon(
-                    self.start_poller
-                )
-            except RuntimeError:
-                # Fallback if instantiated outside of a running event loop context
-                _LOGGER.debug(
-                    "No running event loop; filter_change poller not started."
-                )
-
     def _post_class_promote(self) -> None:
         """Initialize state when promoted from a generic HVAC device."""
         if not hasattr(self, "hvac_state"):
@@ -114,42 +92,13 @@ class FilterChange(DeviceHvac):  # FAN: 10D0
         """Set up the discovery commands for the filter change sensor."""
         super()._setup_discovery_cmds()
 
+        # Note: not all FANs will respond to RQ 10D0 ( they're orphans_hvac in Schema)
+        # Remove once we have discovery_service?
         self.discovery.add_cmd(
-            self._rq_cmd,
+            Command.from_attrs(RQ, self.id, Code._10D0, PayloadT("00")),
             60 * 60 * 24,
             delay=30,
         )
-
-    def start_poller(self) -> None:
-        """
-        Start polling the filter_remaining state of a fan.
-        Messages are cleaned up every 12h, the 10D0 message must be RQd
-        """
-        self._start_handle = None  # call_soon callback has now fired
-
-        if not self._poller:
-            task = asyncio.create_task(
-                self._gwy.async_send_cmd(
-                    self._rq_cmd, num_repeats=2, priority=Priority.HIGH
-                )
-            )
-            self._poller = schedule_task(task, 60 * 60 * 12, delay=120)
-            self._poller.set_name(f"{self.id}_10d0_poller")
-            self._gwy.add_task(self._poller)
-
-    async def stop_poller(self) -> None:
-        """Stop the discovery poller (only if it is running)."""
-        # Cancel any pending call_soon(start_poller) that hasn't fired yet.
-        if self._start_handle:
-            self._start_handle.cancel()
-            self._start_handle = None
-
-        if not self._poller or self._poller.done():
-            return
-
-        self._poller.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await self._poller
 
     async def filter_remaining(self) -> int | None:
         """Return the remaining days until filter change is needed.

--- a/src/ramses_rf/lifecycle.py
+++ b/src/ramses_rf/lifecycle.py
@@ -169,9 +169,6 @@ class GatewayLifecycle:
             if bm:
                 with contextlib.suppress(Exception):
                     bm.cancel()
-            if hasattr(dev, "stop_poller"):
-                with contextlib.suppress(Exception):
-                    await dev.stop_poller()
             disc = getattr(dev, "discovery", None)
             if disc:
                 with contextlib.suppress(Exception):

--- a/tests/tests_rf/test_legacy_eavesdrop_trace.py
+++ b/tests/tests_rf/test_legacy_eavesdrop_trace.py
@@ -136,12 +136,8 @@ async def test_trace_legacy_topology_discovery() -> None:
         print(f"\n\n--- FINAL DEVICES DISCOVERED ---\n{devices}\n")
 
         # Stop any discovery pollers that were auto-started for eavesdropped
-        # devices before stopping the gateway.  Some devices (e.g. FilterChange)
-        # have their own stop_poller() separate from DiscoveryService.stop_poller().
+        # devices before stopping the gateway.
         for dev in gwy.device_registry.devices:
-            if hasattr(dev, "stop_poller"):
-                with contextlib.suppress(Exception):
-                    await dev.stop_poller()
             disc = getattr(dev, "discovery", None)
             if disc:
                 with contextlib.suppress(Exception):

--- a/tests/tests_rf/test_task_cleanup.py
+++ b/tests/tests_rf/test_task_cleanup.py
@@ -152,7 +152,6 @@ async def test_gateway_stop_cancels_binding_managers() -> None:
         # Create a mock binding manager on a device
         dev = MagicMock()
         dev._binding_manager = MagicMock()
-        dev.stop_poller = AsyncMock()
         dev.discovery = MagicMock()
         dev.discovery.stop_poller = AsyncMock()
 
@@ -163,8 +162,6 @@ async def test_gateway_stop_cancels_binding_managers() -> None:
 
         # Binding manager cancel was called
         dev._binding_manager.cancel.assert_called_once()
-        # stop_poller was called
-        dev.stop_poller.assert_awaited_once()
         # discovery stop_poller was called
         dev.discovery.stop_poller.assert_awaited_once()
 
@@ -204,7 +201,7 @@ async def test_gateway_stop_cancels_discovery_pollers() -> None:
         await gwy.stop()
 
         # All discovery pollers were stopped
-        # (may be 0 devices in empty gateway, but the code path ran without error)
+        # (there may be 0 devices in empty gateway, but the code path ran without error)
         assert isinstance(stopped, list)
 
 


### PR DESCRIPTION
This PR completes ramses_cc [issue 794](https://github.com/ramses-rf/ramses_cc/issues/794) by cleaning up non-functional code intended to RQ 10D0.

- Filter_change 10D0 polling is now handled in ramses_cc.
- Discovery of HVAC devices via one-time `RQ 10D0` is left in place (but it will miss any fan that doesn't reply, the orphans_hvac).

- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: not used
