### PR TITLE
Fix HVAC classification for 29: and 37: prefixes

### DIFF
--- a/src/ramses_rf/discovery_scan.py
+++ b/src/ramses_rf/discovery_scan.py
@@ -62,6 +62,7 @@ _PREFIX_TO_TYPE: dict[str, DevType] = {
     "23": DevType.PRG,
     "30": DevType.RFG,
     "31": DevType.JST,
+    "29": DevType.FAN,  # ambiguous: FAN/CO2/HUM/REM — VC pair resolves, FAN is default fallback
     "32": DevType.FAN,
     "34": DevType.RND,
     "37": DevType.REM,
@@ -116,10 +117,13 @@ _HVAC_PARENT_INFERENCE_CODES: frozenset[str] = frozenset(
 _UNAMBIGUOUS_HVAC_PREFIXES: frozenset[str] = frozenset({"18", "32"})
 
 # Valid HVAC types per prefix — constrains VC pair matching so a 37: device
-# sending 31D9 I (which maps to FAN) is NOT classified as FAN (FAN is 32: only).
-# Without this, the VC pair would override the prefix and misclassify devices.
+# sending 31D9 I (which maps to FAN) is only classified as FAN if FAN is in
+# the allowed set for that prefix.  29: and 37: are both ambiguous: they can
+# be FAN, REM, CO2, HUM, or DIS depending on the VC pair.  32: is unambiguous
+# (always FAN) and handled in _UNAMBIGUOUS_HVAC_PREFIXES above.
 _AMBIGUOUS_HVAC_PREFIX_TYPES: dict[str, frozenset[DevType]] = {
-    "37": frozenset({DevType.REM, DevType.CO2, DevType.HUM, DevType.DIS}),
+    "29": frozenset({DevType.FAN, DevType.CO2, DevType.HUM, DevType.REM, DevType.DIS}),
+    "37": frozenset({DevType.FAN, DevType.REM, DevType.CO2, DevType.HUM, DevType.DIS}),
 }
 
 
@@ -700,10 +704,11 @@ def _classify(
     """Classify a device based on prefix, verb/code, and accumulated evidence.
 
     Priority:
-    1. HVAC prefix (32:=FAN, 37:=REM) — unambiguous, takes precedence over
-       verb/code pairs (a FAN sends 22F1, but that doesn't make it a REM)
+    1. Unambiguous HVAC prefix (32:=FAN) — takes precedence over verb/code
+       pairs (a FAN sends 22F1, but that doesn't make it a REM)
     2. CTL-only codes — if device sends these, it's a CTL
-    3. Verb+code pair (HVAC) — for non-HVAC prefixes that send HVAC codes
+    3. Verb+code pair (HVAC) — for ambiguous HVAC prefixes (29:, 37:), only
+       accept VC pairs that map to a type valid for that prefix
     4. CH prefix — fallback for heating domain devices
     5. Accumulated codes — re-evaluate with full evidence
     """

--- a/tests/tests_rf/test_discovery_scan.py
+++ b/tests/tests_rf/test_discovery_scan.py
@@ -255,16 +255,14 @@ class TestClassify:
         result = _classify("37:154519", "313F", "RQ", is_src=True)
         assert result == DevType.REM
 
-    def test_37_31d9_is_not_fan(self) -> None:
-        """37: sending 31D9 I should NOT be FAN — FAN is 32: only.
+    def test_37_31d9_is_fan(self) -> None:
+        """37: sending 31D9 I should be FAN — some FANs use 37: prefix.
 
-        31D9 I maps to FAN in HVAC_KLASS_BY_VC_PAIR, but 37: is ambiguous
-        (REM/CO2/HUM/DIS) and FAN is not a valid type for 37:.
+        31D9 I maps to FAN in HVAC_KLASS_BY_VC_PAIR, and 37: is ambiguous
+        (FAN/REM/CO2/HUM/DIS) so FAN is a valid type for 37:.
         """
         result = _classify("37:154519", "31D9", " I", is_src=True)
-        assert result != DevType.FAN
-        # Should fall back to prefix (REM)
-        assert result == DevType.REM
+        assert result == DevType.FAN
 
     def test_32_31d9_is_fan(self) -> None:
         """32: sending 31D9 I should be FAN (unambiguous prefix)."""
@@ -273,6 +271,23 @@ class TestClassify:
     def test_37_22f1_is_rem(self) -> None:
         """37: sending 22F1 I should be REM (VC pair matches valid type)."""
         assert _classify("37:168270", "22F1", " I", is_src=True) == DevType.REM
+
+    def test_29_31d9_is_fan(self) -> None:
+        """29: sending 31D9 I should be FAN (VC pair matches valid type)."""
+        assert _classify("29:146052", "31D9", " I", is_src=True) == DevType.FAN
+
+    def test_29_22f1_is_rem(self) -> None:
+        """29: sending 22F1 I should be REM (VC pair matches valid type)."""
+        assert _classify("29:181813", "22F1", " I", is_src=True) == DevType.REM
+
+    def test_29_1298_is_co2(self) -> None:
+        """29: sending 1298 I should be CO2 (VC pair matches valid type)."""
+        assert _classify("29:123456", "1298", " I", is_src=True) == DevType.CO2
+
+    def test_29_no_vc_falls_back_to_fan(self) -> None:
+        """29: with no matching VC pair should default to FAN (prefix fallback)."""
+        # 2411 is not in HVAC_KLASS_BY_VC_PAIR
+        assert _classify("29:123150", "2411", " I", is_src=True) == DevType.FAN
 
     def test_37_1298_is_co2(self) -> None:
         """37: sending 1298 I should be CO2 (VC pair matches valid type)."""


### PR DESCRIPTION
29: prefix was missing from _PREFIX_TO_TYPE, causing 29: devices to fall through to DevType.DEV (orphans_heat).  Added 29: as FAN (default fallback) and to _AMBIGUOUS_HVAC_PREFIX_TYPES so VC pairs can resolve the actual type (FAN/CO2/HUM/REM/DIS).

37: prefix had FAN excluded from allowed types, so 37: devices sending 31D9/31DA (FAN codes) were misclassified as REM.  Added FAN to the allowed types for 37:.

Updated test_37_31d9_is_not_fan → test_37_31d9_is_fan and added tests for 29: prefix classification.

AI used: GLM 5.2 high