### PR TITLE
Fix DIS misclassification: only check current verb in accumulated codes

### DIFF
--- a/src/ramses_rf/discovery_scan.py
+++ b/src/ramses_rf/discovery_scan.py
@@ -753,14 +753,23 @@ def _classify(
                 # only classify as CTL if the current verb matches
                 if verb in ctl_verbs:
                     return DevType.CTL
-        # Check HVAC codes from accumulated data
+        # Check HVAC codes from accumulated data — but only with the
+        # current verb.  Trying all verbs (I, RP, RQ, W) caused
+        # misclassification: a DIS sending RQ 31DA (requesting fan status
+        # from a FAN) was classified as FAN because (I, 31DA) maps to FAN
+        # in _VC_TO_TYPE.  The device never sent I 31DA — it only sent
+        # RQ 31DA — but the loop tried all verbs regardless.
+        #
+        # By only checking the current verb, we ensure:
+        # - RQ 31DA (DIS asking FAN for status) → not in _VC_TO_TYPE → skip
+        # - I 31DA (FAN broadcasting status) → FAN
+        # - RP 31DA (FAN responding to request) → FAN
         valid_types = _AMBIGUOUS_HVAC_PREFIX_TYPES.get(prefix)
         for c in dev.codes_seen:
-            for v in (" I", "RP", "RQ", " W"):
-                if (v, c) in _VC_TO_TYPE:
-                    vc_type = _VC_TO_TYPE[(v, c)]
-                    if valid_types is None or vc_type in valid_types:
-                        return vc_type
+            if (verb, c) in _VC_TO_TYPE:
+                vc_type = _VC_TO_TYPE[(verb, c)]
+                if valid_types is None or vc_type in valid_types:
+                    return vc_type
 
     # 5. CH prefix fallback
     if prefix in _PREFIX_TO_TYPE:

--- a/tests/tests_rf/test_discovery_scan.py
+++ b/tests/tests_rf/test_discovery_scan.py
@@ -302,6 +302,39 @@ class TestClassify:
         # 31D9 I maps to FAN, but 18: is a gateway, not a FAN
         assert _classify("18:130236", "31D9", " I", is_src=True) == DevType.HGI
 
+    def test_37_rq_31da_is_not_fan(self) -> None:
+        """37: sending RQ 31DA should NOT be FAN — it's a DIS requesting status.
+
+        31DA maps to FAN for I (broadcast) and RP (response), but RQ is a
+        request.  A DIS (display remote) sends RQ 31DA to the FAN to ask
+        for fan status — it's not a FAN broadcasting its own status.
+        """
+        # Direct RQ 31DA — not in _VC_TO_TYPE (only I and RP are)
+        result = _classify("37:169161", "31DA", "RQ", is_src=True)
+        assert result != DevType.FAN
+
+    def test_37_rq_31da_with_accumulated_codes_not_fan(self) -> None:
+        """37: with 31DA in codes_seen, sending RQ 31DA, should NOT be FAN.
+
+        The accumulated-codes check must not try all verbs — only the
+        current verb.  RQ 31DA is not in _VC_TO_TYPE, so it should not
+        classify as FAN even though (I, 31DA) maps to FAN.
+        """
+        dev = DiscoveredDevice(
+            device_id="37:169161",
+            first_seen="2026-07-01T10:00:00",
+            last_seen="2026-07-01T10:00:00",
+            likely_type="DEV",
+            codes_seen=["31DA", "1470", "313F"],
+        )
+        result = _classify("37:169161", "31DA", "RQ", is_src=True, dev=dev)
+        assert result != DevType.FAN
+
+    def test_37_i_31da_is_fan(self) -> None:
+        """37: sending I 31DA (broadcast) IS FAN — it's broadcasting status."""
+        result = _classify("37:169161", "31DA", " I", is_src=True)
+        assert result == DevType.FAN
+
 
 class TestConfidence:
     """Tests for confidence scoring."""


### PR DESCRIPTION
The _classify function's accumulated-codes check (step 4) tried all verbs (I, RP, RQ, W) for each code in codes_seen. This caused misclassification of display remotes (DIS) as FANs:

- A DIS sends RQ 31DA (requesting fan status from a FAN)
- The scan engine sees 31DA in codes_seen
- Step 4 tries (I, 31DA) → maps to FAN → returns FAN
- But the device never sent I 31DA — it only sent RQ 31DA

Fix: only check the current verb in step 4. This way:
- RQ 31DA (DIS asking FAN for status) → not in _VC_TO_TYPE → skip
- I 31DA (FAN broadcasting status) → FAN
- RP 31DA (FAN responding to request) → FAN

AI: yes