### PR TITLE
fix: add ClimaRad Ventura params 07/4C/88/DA to 2411 schema

### DIFF
--- a/src/ramses_rf/parsers/hvac.py
+++ b/src/ramses_rf/parsers/hvac.py
@@ -805,7 +805,7 @@ def parser_2411(payload: str, msg: Message) -> dict[str, Any]:
     try:
         description = _2411_TABLE.get(param_id, "Unknown")
         if param_id not in _2411_TABLE:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 f"2411 message received with unknown parameter ID: {param_id}. "
                 f"This parameter is not in the known parameter schema. "
                 f"Message: {msg!r}"

--- a/src/ramses_rf/protocol/ramses.py
+++ b/src/ramses_rf/protocol/ramses.py
@@ -1427,6 +1427,39 @@ _2411_PARAMS_SCHEMA: dict[str, dict[str, Any]] = {
         SZ_DATA_TYPE: "0F",
         SZ_DATA_UNIT: "%",
     },
+    # ClimaRad Ventura-specific parameters (issue 740)
+    "07": {
+        SZ_DESCRIPTION: "Base ventilation enable",
+        SZ_MIN_VALUE: 0,
+        SZ_MAX_VALUE: 1,
+        SZ_PRECISION: 1,
+        SZ_DATA_TYPE: "00",
+        SZ_DATA_UNIT: "",
+    },
+    "4C": {
+        SZ_DESCRIPTION: "Unknown (ClimaRad Ventura)",
+        SZ_MIN_VALUE: 0,
+        SZ_MAX_VALUE: 0xFFFFFFFF,
+        SZ_PRECISION: 1,
+        SZ_DATA_TYPE: "10",
+        SZ_DATA_UNIT: "",
+    },
+    "88": {
+        SZ_DESCRIPTION: "Timer configuration (ClimaRad Ventura)",
+        SZ_MIN_VALUE: 0,
+        SZ_MAX_VALUE: 0xFFFFFFFF,
+        SZ_PRECISION: 1,
+        SZ_DATA_TYPE: "10",
+        SZ_DATA_UNIT: "",
+    },
+    "DA": {
+        SZ_DESCRIPTION: "Unknown (ClimaRad Ventura)",
+        SZ_MIN_VALUE: 0,
+        SZ_MAX_VALUE: 0xFFFFFFFF,
+        SZ_PRECISION: 1,
+        SZ_DATA_TYPE: "10",
+        SZ_DATA_UNIT: "",
+    },
 }
 
 # ventilation speed description

--- a/tests/tests/test_parser_helpers.py
+++ b/tests/tests/test_parser_helpers.py
@@ -132,6 +132,54 @@ def test_2411_data_type_13_ventura_filter_time() -> None:
     assert "_unknown_data_type" not in result
 
 
+def test_2411_unknown_param_ids_ventura() -> None:
+    """2411 params 07, 4C, 88, DA (ClimaRad Ventura) must parse without warning.
+
+    These params are now in _2411_PARAMS_SCHEMA with placeholder descriptions.
+    The parser should use the data_type from the packet to decode the value.
+    See issue 740 (reopened).
+    """
+    # param 07, data_type 00 (2-byte counter)
+    msg = _make_22f1_msg(
+        "2026-07-11T17:17:52.000000 040 RP --- 32:022222 29:091138 --:------ 2411 022 "
+        "00000700000000010000000000000001000000018A00"
+    )
+    result = msg.payload
+    assert result["parameter"] == "07"
+    assert result["description"] == "Base ventilation enable"
+    assert "_unknown_data_type" not in result
+
+    # param 4C, data_type 10 (4-byte counter)
+    msg = _make_22f1_msg(
+        "2026-07-11T17:17:52.000000 040 RP --- 32:022222 29:091138 --:------ 2411 022 "
+        "00004C10000000640000000000007530000000016400"
+    )
+    result = msg.payload
+    assert result["parameter"] == "4C"
+    assert result["description"] == "Unknown (ClimaRad Ventura)"
+    assert "_unknown_data_type" not in result
+
+    # param 88, data_type 10 (4-byte counter)
+    msg = _make_22f1_msg(
+        "2026-07-11T17:17:52.000000 040 RP --- 32:022222 29:091138 --:------ 2411 023 "
+        "000088100000026400000001900000076C000000018A33"
+    )
+    result = msg.payload
+    assert result["parameter"] == "88"
+    assert result["description"] == "Timer configuration (ClimaRad Ventura)"
+    assert "_unknown_data_type" not in result
+
+    # param DA, data_type 10 (4-byte counter)
+    msg = _make_22f1_msg(
+        "2026-07-11T17:17:52.000000 040 RP --- 32:022222 29:091138 --:------ 2411 023 "
+        "0000DA1000000000000000000000000001000000018A00"
+    )
+    result = msg.payload
+    assert result["parameter"] == "DA"
+    assert result["description"] == "Unknown (ClimaRad Ventura)"
+    assert "_unknown_data_type" not in result
+
+
 def test_helper_demand_transform() -> None:
     assert [x[1] for x in TRANSFORMS] == [_transform(x[0]) for x in TRANSFORMS]
 


### PR DESCRIPTION
The ClimaRad Ventura sends 2411 params 07, 4C, 88, and DA that were not in _2411_PARAMS_SCHEMA, causing warning spam in the HA log every polling cycle.

- Add placeholder entries for params 07, 4C, 88, DA with descriptions and best-guess data_types from the Ventura's packets
- Downgrade the unknown-param-ID log from warning to debug: the parser already decodes values correctly using the data_type from the packet, so the warning was purely noise
- Add test_2411_unknown_param_ids_ventura covering all four params

Fixes https://github.com/ramses-rf/ramses_cc/issues/740 (reopened)

