### PR TITLE
Fix: wire `_update_system_state` into dispatcher CQRS ingestion engine

### DIFF
--- a/src/ramses_rf/dispatcher.py
+++ b/src/ramses_rf/dispatcher.py
@@ -29,6 +29,7 @@ from .const import (
     SZ_BYPASS_POSITION,
     SZ_BYPASS_STATE,
     SZ_CO2_LEVEL,
+    SZ_DATETIME,
     SZ_DEVICES,
     SZ_EXHAUST_FAN_SPEED,
     SZ_EXHAUST_FLOW,
@@ -41,6 +42,7 @@ from .const import (
     SZ_HAS_FAULT,
     SZ_INDOOR_HUMIDITY,
     SZ_INDOOR_TEMP,
+    SZ_LANGUAGE,
     SZ_MINUTES,
     SZ_OFFER,
     SZ_OUTDOOR_HUMIDITY,
@@ -55,13 +57,15 @@ from .const import (
     SZ_SUPPLY_FAN_SPEED,
     SZ_SUPPLY_FLOW,
     SZ_SUPPLY_TEMP,
+    SZ_SYSTEM_MODE,
     SZ_TEMPERATURE,
+    SZ_UNTIL,
     W_,
     Code,
     DevType,
 )
 from .messages import Message
-from .models import StateUpdatedEvent
+from .models import StateUpdatedEvent, SystemState
 from .protocol.ramses import (
     CODES_OF_HEAT_DOMAIN,
     CODES_OF_HEAT_DOMAIN_ONLY,
@@ -354,6 +358,17 @@ def _resolve_logical_targets(
             if src_dev.tcs.dhw not in targets:
                 targets.append(src_dev.tcs.dhw)
 
+    # 6. System-level opcodes (2E04/0100/313F) target the TCS directly.
+    #    These packets have no domain_id/zone_idx, so steps 4/5 miss them.
+    if (
+        msg.code in (Code._2E04, Code._0100, Code._313F)
+        and src_dev
+        and hasattr(src_dev, "tcs")
+        and src_dev.tcs
+        and src_dev.tcs not in targets
+    ):
+        targets.append(src_dev.tcs)
+
     return targets
 
 
@@ -464,6 +479,54 @@ def _update_faultlog_state(target: Any, p: dict[str, Any], msg: Message) -> None
             correlation_id=getattr(msg, "correlation_id", uuid.uuid4()),
             causation_id=getattr(msg, "message_id", uuid.uuid4()),
         )
+        target.apply_state_update(event)
+
+
+def _update_system_state(target: Any, p: dict[str, Any], msg: Message) -> None:
+    """Translate system configuration opcodes into SystemState.
+
+    Handles 2E04 (system_mode), 0100 (language), and 313F (datetime).
+
+    :param target: The target entity (TCS/Evohome) to update.
+    :param p: The parsed message payload dictionary.
+    :param msg: The immutable Message L7 envelope.
+    """
+    if not hasattr(target, "system_state"):
+        return
+
+    updates: dict[str, Any] = {}
+    if msg.code == Code._0100:
+        if SZ_LANGUAGE in p:
+            updates["language"] = p[SZ_LANGUAGE]
+    elif msg.code == Code._2E04:
+        if SZ_SYSTEM_MODE in p:
+            updates["system_mode"] = p[SZ_SYSTEM_MODE]
+        if SZ_UNTIL in p:
+            updates["until"] = p[SZ_UNTIL]
+    elif msg.code == Code._313F:
+        if SZ_DATETIME in p:
+            updates["datetime"] = p[SZ_DATETIME]
+    else:
+        return
+
+    if not updates:
+        return
+
+    dtm = getattr(msg, "dtm", getattr(msg, "timestamp", None))
+    if dtm:
+        updates["last_updated"] = dtm
+
+    current_state = target.system_state or SystemState()
+    new_state = dataclasses.replace(current_state, **updates)
+    target.system_state = new_state
+
+    event = StateUpdatedEvent(
+        entity_id=getattr(target, "id", "unknown"),
+        state=new_state,
+        correlation_id=getattr(msg, "correlation_id", uuid.uuid4()),
+        causation_id=getattr(msg, "message_id", uuid.uuid4()),
+    )
+    if hasattr(target, "apply_state_update"):
         target.apply_state_update(event)
 
 
@@ -594,6 +657,7 @@ def _cqrs_ingestion_engine(gwy: Gateway, msg: Message) -> None:
         targets = _resolve_logical_targets(gwy, msg, p)
         for target in targets:
             with contextlib.suppress(AttributeError, TypeError, ValueError):
+                _update_system_state(target, p, msg)
                 _update_hvac_state(target, p, msg)
                 _update_temperature_state(target, p, msg)
                 _update_demand_state(target, p, msg)

--- a/tests/tests_rf/test_tcs_hydration.py
+++ b/tests/tests_rf/test_tcs_hydration.py
@@ -14,6 +14,7 @@ import pytest
 
 from ramses_rf.const import SZ_SYSTEM_MODE
 from ramses_rf.devices import Controller
+from ramses_rf.dispatcher import _update_system_state
 from ramses_rf.systems.tcs import Evohome
 
 
@@ -95,3 +96,50 @@ async def test_system_mode_uses_hot_cqrs_state_when_available() -> None:
 
     # Verify we did NOT hit the network
     mock_gwy.async_send_cmd.assert_not_called()
+
+
+def test_update_system_state_hydrates_from_2e04_packet() -> None:
+    """Test that _update_system_state hydrates system_state from a 2E04 packet.
+
+    This is the critical ingestion path: when a 2E04 RP/I packet arrives from
+    the controller, the dispatcher's CQRS engine must update the TCS's
+    system_state so that the async system_mode() getter returns a value
+    instead of None.
+
+    Regression test for issue 800 (ramses_cc): system_mode/preset_mode stuck
+    at None because _cqrs_ingestion_engine did not call _update_system_state.
+    """
+
+    # Arrange — create an Evohome TCS with empty system_state
+    mock_gwy = MagicMock()
+    mock_gwy.config.enable_eavesdrop = False
+    mock_gwy.device_registry.system_by_id = {}
+    mock_gwy.async_send_cmd = AsyncMock()
+
+    mock_ctl = MagicMock(spec=Controller)
+    mock_ctl.id = "01:123456"
+    mock_ctl._gwy = mock_gwy
+
+    tcs = Evohome(mock_ctl)
+    # system_state.system_mode starts as None (the dataclass default)
+
+    # Simulate a parsed 2E04 RP packet payload (system_mode=heat_off)
+    mock_msg = MagicMock()
+    mock_msg.code = "2E04"
+    mock_msg.dtm = None
+    mock_msg.timestamp = None
+    payload = {SZ_SYSTEM_MODE: "heat_off", "until": None}
+
+    # Act — call the dispatcher's ingestion function directly
+    _update_system_state(tcs, payload, mock_msg)
+
+    # Assert — system_state is now hydrated
+    assert tcs.system_state.system_mode == "heat_off"
+    assert tcs.system_state.until is None
+
+    # The async getter should now return the hydrated value
+    import asyncio
+
+    result = asyncio.run(tcs.system_mode())
+    assert result is not None
+    assert result[SZ_SYSTEM_MODE] == "heat_off"


### PR DESCRIPTION
I've trying to get this list of issues a bit shorter, and the assistant that is currently available to me for free, seems to be quite good at analyzing, so I let it rumble a bit on 
[_cc 800
](https://github.com/ramses-rf/ramses_cc/issues/800)

It found some issues, and a fix, BUT...I'm not sure if this PR is crossing any work @PWhite-Eng is doing on this. So, maybe this is just for ref. and/or may save some time...Hope it helps.

Root cause: PR 786 removed the self-hydrating RQ dispatch from SysMode.system_mode() getter to prevent unbounded task creation, but the dispatcher's _cqrs_ingestion_engine was never wired to call _update_system_state.  This left system_state.system_mode permanently None — the async getter always returned None, and ramses_cc's resolve_async_attr cached that None forever.

The ingestion logic existed in pipeline/ingestion.py (StateProjector), but that engine is not started (Phase 2.75 async cutover is paused). The active engine in dispatcher.py only handled hvac, temperature, demand, and faultlog states — system_state was silently dropped.

Symptoms (ramses_cc issue 800):
- Evohome controller entity shows wrong state and system_mode
- preset_mode stuck at 'none' even when changed
- 2E04 RP packets are received and parsed correctly, but never reach the CQRS read-model

Fix (3 changes in dispatcher.py):
1. Add _update_system_state() — ports the 2E04/0100/313F ingestion logic from pipeline/ingestion.py into the active dispatcher engine
2. Update _resolve_logical_targets() — route system-level opcodes (2E04/0100/313F) to the TCS, since they lack domain_id/zone_idx keys that the existing routing steps rely on
3. Call _update_system_state() from _cqrs_ingestion_engine()

Regression test added to test_tcs_hydration.py verifying that a 2E04 packet payload hydrates system_state via the dispatcher path.

Resolves: https://github.com/ramses-rf/ramses_cc/issues/800

