### PR TITLE
Fix cache restore: handle `RawPacket.__dict__` format in `Packet.from_dict`

### DIFF
--- a/src/ramses_tx/packet.py
+++ b/src/ramses_tx/packet.py
@@ -250,9 +250,15 @@ class Packet(Frame):
 
         # Safely extract RSSI, fallback to "...", and guarantee exactly 3 chars
         rssi_val = state.get("rssi")
-        rssi = f"{int(rssi_val):03d}" if rssi_val is not None else "..."
+        try:
+            rssi = f"{int(rssi_val):03d}" if rssi_val is not None else "..."
+        except (ValueError, TypeError):
+            rssi = "..."
 
-        frame = f"{rssi[:3].ljust(3)} {state.get('frame', '')}"
+        # The frame body: prefer 'frame' (Packet.to_dict format), fall back to
+        # 'raw_packet' (RawPacket.__dict__ format used by lifecycle.get_state)
+        frame_body = state.get("frame") or state.get("raw_packet", "")
+        frame = f"{rssi[:3].ljust(3)} {frame_body}"
         return cls(
             dt.fromisoformat(dtm),
             frame,

--- a/tests/tests_tx/test_packet.py
+++ b/tests/tests_tx/test_packet.py
@@ -135,6 +135,42 @@ def test_packet_dto_serialization() -> None:
     assert restored_pkt._frame == pkt._frame
 
 
+def test_from_dict_raw_packet_dict_format() -> None:
+    """Test from_dict with a RawPacket.__dict__ (as used by lifecycle.get_state).
+
+    Regression test for ramses_cc issue 812: cache restore produced
+    'Bad frame: Invalid structure: >>><<<' because RawPacket.__dict__ has
+    'raw_packet' (not 'frame') and rssi can be a non-numeric string like '...'.
+    """
+    dtm_str = DTM.isoformat()
+
+    # Simulate what lifecycle.get_state saves: msg.dto.source_packets[0].__dict__
+    raw_pkt_dict: dict[str, object] = {
+        "raw_packet": " I --- 01:145038 --:------ 01:145038 1F09 003 0004B5",
+        "rssi": "045",
+        "verb": " I",
+        "seq": "---",
+        "device_id_1": "01:145038",
+        "device_id_2": "--:------",
+        "device_id_3": "01:145038",
+        "code": "1F09",
+        "payload_len": "003",
+        "payload": "0004B5",
+    }
+
+    pkt = Packet.from_dict(dtm_str, raw_pkt_dict)
+    assert pkt.rssi == "045"
+    assert pkt.verb == " I"
+    assert pkt.code == "1F09"
+    assert pkt._frame == " I --- 01:145038 --:------ 01:145038 1F09 003 0004B5"
+
+    # Also test with non-numeric rssi (e.g. "..." from file-based packets)
+    raw_pkt_dict["rssi"] = "..."
+    pkt2 = Packet.from_dict(dtm_str, raw_pkt_dict)
+    assert pkt2.rssi == "..."
+    assert pkt2.code == "1F09"
+
+
 def test_pkt_lifespan(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test the packet lifespan calculation logic.
 


### PR DESCRIPTION
This should fix https://github.com/ramses-rf/ramses_cc/issues/812 (_cc).
Also on this one, I can't really test it myself and it might cross @PWhite-Eng his work. But he seems a bit busy atm. Just hope it helps.

lifecycle.get_state serializes packets via msg.dto.source_packets[0].__dict__ (a RawPacket), which has key 'raw_packet' (not 'frame'). Packet.from_dict looked only for 'frame', so state.get('frame', '') returned '' — producing empty frames that fail regex validation: 'Bad frame: Invalid structure: >>><<<'.

This broke cache save/restore since commit f760e101 (Phase 2 OSI migration, May 2026), causing all entities to come up as Unknown on restart and only repopulate as new packets arrive (battery sensors take 24h).

Fix: fall back to 'raw_packet' key when 'frame' is absent, and wrap rssi parsing in try/except to handle non-numeric values like '...'.

Resolves: https://github.com/ramses-rf/ramses_cc/issues/812

AI used: GLM 5.2 high
