### PR TITLE
Fix issue 813: add 000A to zone binding codes for THM discovery

### DIFF
--- a/src/ramses_rf/discovery_scan.py
+++ b/src/ramses_rf/discovery_scan.py
@@ -92,8 +92,12 @@ _BATTERY_CODES: frozenset[str] = frozenset({"1060", "1FC9"})
 # NOTE: 30C9 (Room Setpoint) is excluded - its payload is 00{setpoint}
 # where the first byte is always 00 (a constant), not a zone index.
 # 3150 (Actuator State) and 12B0 (Window Open) have the real zone_idx.
+# 000A (Zone Info) is sent by THMs (22:) with their zone_idx as payload —
+# e.g. RQ 000A 001 01 means the THM is asking about zone 01 (its zone).
+# The CTL and HGI also send 000A, but the HGI is excluded by is_hgi and
+# the CTL's zone_idx is unused (it gets main_tcs, not a zone placement).
 _ZONE_BINDING_CODES: frozenset[str] = frozenset(
-    {"3150", "000C", "2309", "2349", "10A0", "1260", "12B0", "1F09"}
+    {"3150", "000C", "2309", "2349", "10A0", "1260", "12B0", "1F09", "000A"}
 )
 
 # HVAC codes sent by REMs/CO2s to their parent FAN (32:).  These are

--- a/tests/tests_rf/test_discovery_scan.py
+++ b/tests/tests_rf/test_discovery_scan.py
@@ -644,6 +644,24 @@ class TestDiscoveryScanPacketHandling:
         assert dev.bound_to == "01:145038"
         assert dev.confidence == "high"
 
+    def test_thm_zone_binding_via_000a(self) -> None:
+        """THM (22:) sends RQ 000A with its zone_idx as payload (issue 813).
+
+        A room thermostat like 22:012299 sends ``RQ 000A 001 01`` to the CTL,
+        where ``01`` is the zone index.  The scan engine should extract this
+        and set zone_idx on the THM.
+        """
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(
+            make_dto(src="22:012299", dst="01:216136", code="000A", payload="01")
+        )
+        dev = scan.get_device("22:012299")
+        assert dev is not None
+        assert dev.zone_idx == "01"
+        assert dev.bound_to == "01:216136"
+        assert dev.confidence == "high"
+
     def test_codes_seen_deduplicated_and_sorted(self) -> None:
         gwy = make_mock_gateway()
         scan = DiscoveryScan(gwy)


### PR DESCRIPTION
Room thermostats (22:) send RQ 000A with their zone_idx as payload (e.g. RQ 000A 001 01 means zone 01).  000A was missing from _ZONE_BINDING_CODES, so the scan engine never extracted the zone assignment for THMs — causing them to stay in orphans_heat indefinitely.

The CTL and HGI also send 000A, but the HGI is excluded by is_hgi and the CTL's zone_idx is unused (it gets main_tcs, not a zone).

fix for https://github.com/ramses-rf/ramses_cc/issues/813

AI used: GLM 5.2 high
