### PR TITLE
fix(802): guard call_soon_threadsafe against closed event loop

### DIFF
--- a/src/ramses_tx/transport/base.py
+++ b/src/ramses_tx/transport/base.py
@@ -115,9 +115,15 @@ class _ReadTransport(_BaseTransport, TransportInterface):
             return
         self._closing = True
 
-        self.loop.call_soon_threadsafe(
-            functools.partial(self._protocol.connection_lost, exc)
-        )
+        if self.loop.is_closed():
+            _LOGGER.debug("Event loop already closed, cannot notify protocol")
+            return
+        try:
+            self.loop.call_soon_threadsafe(
+                functools.partial(self._protocol.connection_lost, exc)
+            )
+        except RuntimeError:
+            _LOGGER.debug("Event loop closed during _close(), cannot notify protocol")
 
     def close(self) -> None:
         """Close the transport gracefully."""
@@ -139,9 +145,15 @@ class _ReadTransport(_BaseTransport, TransportInterface):
         """Register the connection with the protocol."""
         self._extra[SZ_ACTIVE_HGI] = gwy_id  # or HGI_DEV_ADDR.id
 
-        self.loop.call_soon_threadsafe(
-            functools.partial(self._protocol.connection_made, self, ramses=True)
-        )
+        if self.loop.is_closed():
+            _LOGGER.debug("Event loop closed, cannot make connection")
+            return
+        try:
+            self.loop.call_soon_threadsafe(
+                functools.partial(self._protocol.connection_made, self, ramses=True)
+            )
+        except RuntimeError:
+            _LOGGER.debug("Event loop closed during _make_connection()")
 
     def _frame_read(self, dtm_str: str, frame: str) -> None:
         """Make a Packet from the Frame and process it."""
@@ -166,8 +178,15 @@ class _ReadTransport(_BaseTransport, TransportInterface):
         if self._closing is True:
             raise exc.TransportError("Transport is closing or has closed")
 
+        if self.loop.is_closed():
+            raise exc.TransportError("Event loop is closed")
+
         try:
             self.loop.call_soon_threadsafe(self._protocol.pkt_received, pkt)
+        except RuntimeError as err:
+            # Event loop may close between the is_closed() check and this
+            # call when the paho-mqtt thread races asyncio teardown (issue 802)
+            raise exc.TransportError(f"Event loop is closed: {err}") from err
         except AssertionError as err:
             _LOGGER.exception("%s < exception from msg layer: %s", pkt, err)
         except exc.ProtocolError as err:

--- a/src/ramses_tx/transport/mqtt.py
+++ b/src/ramses_tx/transport/mqtt.py
@@ -294,7 +294,11 @@ class MqttTransport(_FullTransport, _MqttTransportAbstractor):
 
         if self._connected:
             _LOGGER.info("MQTT device came back online - resuming writing")
-            self._loop.call_soon_threadsafe(self._protocol.resume_writing)
+            if not self._loop.is_closed():
+                try:
+                    self._loop.call_soon_threadsafe(self._protocol.resume_writing)
+                except RuntimeError:
+                    _LOGGER.debug("Event loop closed, cannot resume writing")
             return
 
         _LOGGER.info("MQTT device is online - establishing connection")
@@ -408,7 +412,7 @@ class MqttTransport(_FullTransport, _MqttTransportAbstractor):
         try:
             self._frame_read(dtm.isoformat(), _normalise(payload["msg"]))
         except exc.TransportError:
-            if not self._closing:
+            if not self._closing and not self.loop.is_closed():
                 raise
 
     async def write_frame(self, frame: str, disable_tx_limits: bool = False) -> None:

--- a/tests/tests_tx/test_transport.py
+++ b/tests/tests_tx/test_transport.py
@@ -234,3 +234,119 @@ async def test_is_hgi80_async_file_check() -> None:
 
         # Assert: os.path.exists was called
         mock_exists.assert_called_once_with(test_port)
+
+
+# --- Event-loop-closed guards (issue 802) ---
+
+
+def _make_read_transport(loop: asyncio.AbstractEventLoop) -> Any:
+    """Create a minimal _ReadTransport for testing _pkt_read/_close."""
+    from ramses_tx.transport.base import _ReadTransport
+
+    transport = _ReadTransport.__new__(_ReadTransport)
+    transport._loop = loop
+    transport._protocol = Mock()
+    transport._closing = False
+    transport._reading = False
+    transport._this_pkt = None
+    transport._prev_pkt = None
+    transport._extra = {}
+    transport._evofw_flag = None
+    return transport
+
+
+async def test_pkt_read_raises_transport_error_when_loop_closed() -> None:
+    """_pkt_read raises TransportError (not RuntimeError) when loop is closed.
+
+    This is the fix for issue 802: the paho-mqtt thread receives a message
+    after the asyncio loop has been closed, and call_soon_threadsafe would
+    raise RuntimeError('Event loop is closed').
+    """
+    loop = asyncio.get_event_loop()
+    transport = _make_read_transport(loop)
+
+    # Simulate a closed loop
+    with patch.object(type(loop), "is_closed", return_value=True):
+        from ramses_tx import Packet
+
+        pkt = Packet.from_file(
+            "2026-07-13T04:40:36",
+            "045  I --- 18:130140 32:022222 --:------ 22F2 001 00",
+        )
+        with pytest.raises(exc.TransportError, match="Event loop is closed"):
+            transport._pkt_read(pkt)
+
+
+async def test_pkt_read_raises_transport_error_on_runtime_error() -> None:
+    """_pkt_read catches RuntimeError from call_soon_threadsafe and wraps it.
+
+    Even if is_closed() returns False, the loop may close between the check
+    and the call (race condition). The RuntimeError is caught and re-raised
+    as TransportError so the MQTT _on_message handler can suppress it.
+    """
+    loop = asyncio.get_event_loop()
+    transport = _make_read_transport(loop)
+
+    from ramses_tx import Packet
+
+    pkt = Packet.from_file(
+        "2026-07-13T04:40:36", "045  I --- 18:130140 32:022222 --:------ 22F2 001 00"
+    )
+
+    # is_closed() returns False, but call_soon_threadsafe raises RuntimeError
+    with (
+        patch.object(type(loop), "is_closed", return_value=False),
+        patch.object(
+            loop,
+            "call_soon_threadsafe",
+            side_effect=RuntimeError("Event loop is closed"),
+        ),
+        pytest.raises(exc.TransportError, match="Event loop is closed"),
+    ):
+        transport._pkt_read(pkt)
+
+
+async def test_close_does_not_crash_when_loop_closed() -> None:
+    """_close() does not raise when the event loop is already closed."""
+    loop = asyncio.get_event_loop()
+    transport = _make_read_transport(loop)
+
+    with patch.object(type(loop), "is_closed", return_value=True):
+        # Should not raise
+        transport._close(None)
+
+    assert transport._closing is True
+    # protocol.connection_lost should NOT have been called
+    transport._protocol.connection_lost.assert_not_called()
+
+
+async def test_close_catches_runtime_error_from_call_soon() -> None:
+    """_close() catches RuntimeError if loop closes between check and call."""
+    loop = asyncio.get_event_loop()
+    transport = _make_read_transport(loop)
+
+    with (
+        patch.object(type(loop), "is_closed", return_value=False),
+        patch.object(
+            loop,
+            "call_soon_threadsafe",
+            side_effect=RuntimeError("Event loop is closed"),
+        ),
+    ):
+        # Should not raise
+        transport._close(None)
+
+    assert transport._closing is True
+
+
+async def test_make_connection_does_not_crash_when_loop_closed() -> None:
+    """_make_connection() does not raise when the event loop is closed."""
+    loop = asyncio.get_event_loop()
+    transport = _make_read_transport(loop)
+
+    with patch.object(type(loop), "is_closed", return_value=True):
+        # Should not raise
+        transport._make_connection("18:130140")
+
+    # protocol.connection_made should NOT have been called
+    transport._protocol.connection_made.assert_not_called()


### PR DESCRIPTION
The paho-mqtt client thread can receive messages after the asyncio event loop has been closed during HA shutdown, causing RuntimeError: Event loop is closed in call_soon_threadsafe.

- base.py: check loop.is_closed() before call_soon_threadsafe in _pkt_read, _close, and _make_connection; catch RuntimeError as fallback for race conditions
- mqtt.py: suppress TransportError in _on_message when loop is closed (not just when _closing is set); guard resume_writing call
- test_transport.py: 5 new tests for event-loop-closed guards

fix for https://github.com/ramses-rf/ramses_cc/issues/802
see also: https://github.com/ramses-rf/ramses_cc/pull/820

AI used: GLM 5.2 high
