### PR TITLE
fix(2411): add data_type 11 for param DA (Orcon/ClimaRad Ventura)

### DIFF
--- a/src/ramses_rf/parsers/hvac.py
+++ b/src/ramses_rf/parsers/hvac.py
@@ -795,6 +795,7 @@ def parser_2411(payload: str, msg: Message) -> dict[str, Any]:
         "01": (2, centile),  # 52 (0.0-25.0) (%)
         "0F": (2, hex_to_percent),  # xx (0.0-1.0) (%)
         "10": (4, counter),  # 31 (0-1800) (days)
+        "11": (4, counter),  # DA - Orcon/ClimaRad Ventura (data_type variant)
         "13": (4, counter),  # 31 - ClimaRad Ventura filter time (variant)
         "20": (4, counter),  # 01 - Support parameter
         "90": (4, counter),  # 3E - Away mode Exhaust fan rate (%)

--- a/tests/tests/test_parser_helpers.py
+++ b/tests/tests/test_parser_helpers.py
@@ -132,6 +132,26 @@ def test_2411_data_type_13_ventura_filter_time() -> None:
     assert "_unknown_data_type" not in result
 
 
+def test_2411_data_type_11_ventura_param_da() -> None:
+    """2411 param DA with data_type 11 (Orcon/ClimaRad Ventura) must parse without warning.
+
+    The Orcon and ClimaRad Ventura send data_type 11 for param DA.
+    This is a 4-byte counter variant (same shape as data_type 10 and 13).
+    """
+    msg = _make_22f1_msg(
+        "2026-07-15T16:14:33.612000 040 RP --- 32:153289 37:168270 --:------ 2411 023 "
+        "0000DAC111000003E8000000000000138800000001CB52"
+    )
+    result = msg.payload
+    assert result["parameter"] == "DA"
+    assert result["description"] == "Unknown (ClimaRad Ventura)"
+    assert result["value"] == 1000  # 0x000003E8 = 1000
+    assert result["min_value"] == 0
+    assert result["max_value"] == 5000  # 0x00001388
+    assert result["precision"] == 1
+    assert "_unknown_data_type" not in result
+
+
 def test_2411_unknown_param_ids_ventura() -> None:
     """2411 params 07, 4C, 88, DA (ClimaRad Ventura) must parse without warning.
 


### PR DESCRIPTION
The 2411 parser was missing data_type 11 in _2411_DATA_TYPES, causing repeated warnings for param DA packets from Orcon and ClimaRad Ventura fans. Data_type 11 is a 4-byte counter, same shape as the existing data_type 10 and 13 variants.

Test added using a real prod packet from an Orcon fan (param DA, value=1000, min=0, max=5000).

Encountered this when testing the latest releases on my prod.

AI used: GLM 5.2. high