### PR TITLE
fix: Gateway.get_state() missing frame key causes cache restore failure

### DIFF
--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -298,6 +298,11 @@ class Gateway(GatewayLifecycle, GatewayInterface):
                     "addr3": msg._addrs[2].id,  # <-- Exact raw addr3
                     "code": str(msg.code),
                     "payload": msg.payload,
+                    # Frame string is required by _restore_cached_packets /
+                    # Packet.from_dict to reconstruct the Packet on warm restart.
+                    # Without it, from_dict gets an empty frame body and raises
+                    # "Bad frame: Invalid structure: >>><<<" (issue 812).
+                    "frame": getattr(msg._pkt, "_frame", ""),
                 }
 
         schema_dict = await self.schema()

--- a/tests/tests_rf/test_phase2_95_get_state_parity.py
+++ b/tests/tests_rf/test_phase2_95_get_state_parity.py
@@ -36,6 +36,7 @@ async def test_get_state_parity() -> None:
     )
     msg_i.code = "1F09"
     msg_i.payload = {"temp": 21.0}
+    msg_i._pkt._frame = " I --- 01:123456 --:------ 01:123456 1F09 003 0004B5"
 
     msg_rp = MagicMock()
     msg_rp.verb = RP
@@ -49,6 +50,7 @@ async def test_get_state_parity() -> None:
     )
     msg_rp.code = "2309"
     msg_rp.payload = {"sync": True}
+    msg_rp._pkt._frame = "RP --- 04:111111 01:123456 04:111111 2309 003 0004B5"
 
     msg_rq = MagicMock()
     msg_rq.verb = RQ
@@ -91,6 +93,7 @@ async def test_get_state_parity() -> None:
         "addr3": "01:123456",
         "code": "1F09",
         "payload": {"temp": 21.0},
+        "frame": " I --- 01:123456 --:------ 01:123456 1F09 003 0004B5",
     }
 
     assert state[dtm_rp] == {
@@ -102,4 +105,48 @@ async def test_get_state_parity() -> None:
         "addr3": "01:123456",
         "code": "2309",
         "payload": {"sync": True},
+        "frame": "RP --- 04:111111 01:123456 04:111111 2309 003 0004B5",
     }
+
+
+@pytest.mark.asyncio
+async def test_get_state_frame_key_enables_restore() -> None:
+    """Regression test for issue 812: get_state() must include a 'frame' key
+    so that Packet.from_dict can reconstruct the packet on warm restart.
+
+    Without the frame key, _restore_cached_packets gets an empty frame body
+    and raises "Bad frame: Invalid structure: >>><<<".
+    """
+    import json
+
+    from ramses_tx.packet import Packet
+
+    gwy = Gateway(port_name="/dev/null")
+    gwy.message_store = MagicMock()
+
+    msg = MagicMock()
+    msg.verb = I_
+    msg.dtm = dt(2023, 1, 1, 12, 0, 0)
+    msg.src.id = "01:123456"
+    msg.dst.id = "01:123456"
+    msg._addrs = (
+        _mock_addr("01:123456"),
+        _mock_addr("--:------"),
+        _mock_addr("01:123456"),
+    )
+    msg.code = "1F09"
+    msg.payload = {"temp": 21.0}
+    msg._pkt._frame = " I --- 01:123456 --:------ 01:123456 1F09 003 0004B5"
+
+    gwy.message_store.state_cache = {"h1": msg}
+
+    _schema, state = await gwy.get_state()
+
+    dtm_str = msg.dtm.isoformat(timespec="microseconds")
+    assert "frame" in state[dtm_str], "get_state() must include 'frame' key"
+
+    # Simulate HA storage: JSON round-trip then Packet.from_dict
+    json_roundtrip = json.loads(json.dumps(state))
+    pkt = Packet.from_dict(dtm_str, json_roundtrip[dtm_str])
+    assert pkt.code == "1F09"
+    assert pkt._frame == " I --- 01:123456 --:------ 01:123456 1F09 003 0004B5"


### PR DESCRIPTION
Gateway.get_state() in gateway.py returns packet dicts with keys {verb, src, dst, addr1, addr2, addr3, code, payload} but NO frame string.  When _restore_cached_packets (lifecycle.py) passes these dicts to Packet.from_dict, it looks for 'frame' or 'raw_packet' — finding neither, the frame body is empty and raises:

  Bad frame: Invalid structure: >>><<<

This is the real root cause of issue 812 (entities not restoring from cache on HA restart).  The earlier fix (52880567) added a fallback from 'frame' to 'raw_packet' in from_dict, but that was addressing the shadowed GatewayLifecycle.get_state() in lifecycle.py — the coordinator calls Gateway.get_state() from gateway.py which never had either key.

Fix: add "frame": msg._pkt._frame to the dict in Gateway.get_state(). The _LegacyPktShim._frame property reconstructs the full frame string from the message's verb/seqn/addrs/code/payload.

Users with existing broken caches (saved without the frame key) should clear their cache once after upgrading — those caches cannot be retroactively restored because the frame string was never persisted.

See: https://github.com/ramses-rf/ramses_cc/issues/812

AI used: GLM 5.2 high