### PR TITLE
fix(821): reject null device type 63: in Passive Device Scan

### DIFF
--- a/src/ramses_rf/discovery_scan.py
+++ b/src/ramses_rf/discovery_scan.py
@@ -688,13 +688,20 @@ class DiscoveryScan:
 def _is_valid_address(dev_id: str) -> bool:
     """Quick check if a device ID looks valid (N.N:NNNNNN or N:NNNNNN).
 
-    Filters out broadcast addresses (18:73030, 18:14803, 18:000730,
-    63:262142), placeholder addresses (--:------), and corrupt IDs.
+    Filters out broadcast addresses (18:73030, 18:14803, 18:000730),
+    the null/broadcast device type 63: (NUL — e.g. 63:262142=0xFFFFFE,
+    63:262143=0xFFFFFF, the latter also used by the HGI80 to disguise its
+    own address), placeholder addresses (--:------), and corrupt IDs.
     """
     if not dev_id or len(dev_id) < 8:
         return False
     # Skip broadcast/multicast addresses
-    if dev_id in ("18:73030", "18:14803", "18:000730", "63:262142"):
+    if dev_id in ("18:73030", "18:14803", "18:000730"):
+        return False
+    # Skip the null/broadcast device type 63: (NUL) — no real device uses
+    # type 63; both 63:262142 (0xFFFFFE) and 63:262143 (0xFFFFFF) are
+    # sentinels, and the HGI80 emits 63:262143 as a self-disguise address
+    if dev_id.startswith("63:"):
         return False
     # Skip placeholder/empty addresses (e.g. "--:------")
     if dev_id.startswith("-") or dev_id.startswith("00:------"):

--- a/tests/tests_rf/test_discovery_scan.py
+++ b/tests/tests_rf/test_discovery_scan.py
@@ -99,6 +99,15 @@ class TestIsValidAddress:
     def test_all_device_broadcast_rejected(self) -> None:
         assert _is_valid_address("63:262142") is False
 
+    def test_null_device_type_all_ones_rejected(self) -> None:
+        # 63:262143 = 0xFFFFFF, the all-ones sentinel (HGI80 self-disguise)
+        assert _is_valid_address("63:262143") is False
+
+    def test_all_null_device_type_rejected(self) -> None:
+        # No real device uses type 63 (NUL) — reject the whole prefix
+        assert _is_valid_address("63:000000") is False
+        assert _is_valid_address("63:999999") is False
+
     def test_empty_rejected(self) -> None:
         assert _is_valid_address("") is False
 


### PR DESCRIPTION
_is_valid_address() only filtered the exact string 63:262142, so 63:262143 (0xFFFFFF, the all-ones sentinel) slipped through and was registered as a phantom DEV device.

Type 63 is NUL — a synthetic sentinel type with no entry in the DevType enum; no real device uses it. Both 63:262142 (0xFFFFFE) and 63:262143 (0xFFFFFF) are broadcast/null sentinels, and the HGI80 emits 63:262143 as a self-disguise address (see tests/tests_rf/test_use_regex.py).

Reject the whole 63: prefix instead of the single exact match. Tests
added for 63:262143 and the full 63: prefix.

see: https://github.com/ramses-rf/ramses_cc/issues/821

AI used: GLM 5.2 high
