### PR TITLE
fix(608): set_temperature must update local state and tolerate send tout

### DIFF
--- a/src/ramses_rf/devices/heat_sensors.py
+++ b/src/ramses_rf/devices/heat_sensors.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
+import dataclasses
+import logging
 from typing import TYPE_CHECKING, Any, Final, cast
 
 from ramses_rf.const import FA, SZ_TEMPERATURE, Code, DevType
 from ramses_rf.exceptions import DeviceNotFaked
 from ramses_rf.models import DeviceTraits
 from ramses_tx import Command, Packet, Priority
+from ramses_tx.exceptions import ProtocolSendFailed
 from ramses_tx.typing import PayDictT
 
 from .dev_base import BatteryState, DeviceHeat, Fakeable
+
+_LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from ..messages import Message
@@ -28,10 +33,18 @@ class Weather(DeviceHeat):  # 0002
         if not self.is_faked:
             raise DeviceNotFaked(f"{self}: Faking is not enabled")
 
+        # Update local state immediately so the temperature is available
+        # even if the RF command times out (e.g. faked devices on a simulator)
+        self.temp_state = dataclasses.replace(self.temp_state, temperature=value)
+
         cmd = Command.put_outdoor_temp(self.id, value)
-        return await self._gwy.async_send_cmd(
-            cmd, num_repeats=2, priority=Priority.HIGH
-        )
+        try:
+            return await self._gwy.async_send_cmd(
+                cmd, num_repeats=2, priority=Priority.HIGH
+            )
+        except ProtocolSendFailed:  # noqa: PERF203
+            _LOGGER.warning("%s: send failed (timeout), state already updated", self)
+            return None
 
     async def status(self) -> dict[str, Any]:
         base_status = await super().status()
@@ -53,10 +66,18 @@ class DhwTemperature(DeviceHeat):  # 1260
         if not self.is_faked:
             raise DeviceNotFaked(f"{self}: Faking is not enabled")
 
+        # Update local state immediately so the temperature is available
+        # even if the RF command times out (e.g. faked devices on a simulator)
+        self.temp_state = dataclasses.replace(self.temp_state, temperature=value)
+
         cmd = Command.put_dhw_temp(self.id, value)
-        return await self._gwy.async_send_cmd(
-            cmd, num_repeats=2, priority=Priority.HIGH
-        )
+        try:
+            return await self._gwy.async_send_cmd(
+                cmd, num_repeats=2, priority=Priority.HIGH
+            )
+        except ProtocolSendFailed:  # noqa: PERF203
+            _LOGGER.warning("%s: send failed (timeout), state already updated", self)
+            return None
 
     async def status(self) -> dict[str, Any]:
         base_status = await super().status()
@@ -79,10 +100,18 @@ class Temperature(DeviceHeat):  # 30C9
         if not self.is_faked:
             raise DeviceNotFaked(f"{self}: Faking is not enabled")
 
+        # Update local state immediately so the temperature is available
+        # even if the RF command times out (e.g. faked devices on a simulator)
+        self.temp_state = dataclasses.replace(self.temp_state, temperature=value)
+
         cmd = Command.put_sensor_temp(self.id, value)
-        return await self._gwy.async_send_cmd(
-            cmd, num_repeats=2, priority=Priority.HIGH
-        )
+        try:
+            return await self._gwy.async_send_cmd(
+                cmd, num_repeats=2, priority=Priority.HIGH
+            )
+        except ProtocolSendFailed:  # noqa: PERF203
+            _LOGGER.warning("%s: send failed (timeout), state already updated", self)
+            return None
 
     async def status(self) -> dict[str, Any]:
         base_status = await super().status()


### PR DESCRIPTION
The async refactor changed temperature from a sync property setter to an async set_temperature() method that sends an RF command. Two problems:

1. The local temp_state was not updated before sending, so the temperature was only available after the RF round-trip completed. For faked devices on a simulator (no echo), the state was never updated.

2. async_send_cmd raises ProtocolTimeoutError when the faked device cannot echo the command back (e.g. on a simulator), which propagated as a 500 error to the HA service call.

Fix: update temp_state via dataclasses.replace() before sending, and catch ProtocolSendFailed so the service call succeeds even if the RF send times out. The local state is already correct in that case.


see https://github.com/ramses-rf/ramses_cc/issues/608

AI used: GLM-5.2 high