### PR TITLE
fix(830): add data_type 80 (bool32) for 2411 param 07

### DIFF
--- a/src/ramses_rf/parsers/hvac.py
+++ b/src/ramses_rf/parsers/hvac.py
@@ -790,6 +790,14 @@ def parser_2411(payload: str, msg: Message) -> dict[str, Any]:
     def centile(x: str) -> float:
         return int(x, 16) / 10
 
+    def bool32(x: str) -> int | None:
+        # 4-byte boolean: 0=False, 1=True, anything else (e.g. 000000FF,
+        # FFFFFFFF) is a sentinel meaning "not available" (issue 830).
+        val = int(x, 16)
+        if val in (0, 1):
+            return val
+        return None
+
     _2411_DATA_TYPES = {
         "00": (2, counter),  # 4E (0-1), 54 (15-60)
         "01": (2, centile),  # 52 (0.0-25.0) (%)
@@ -798,6 +806,7 @@ def parser_2411(payload: str, msg: Message) -> dict[str, Any]:
         "11": (4, counter),  # DA - Orcon/ClimaRad Ventura (data_type variant)
         "13": (4, counter),  # 31 - ClimaRad Ventura filter time (variant)
         "20": (4, counter),  # 01 - Support parameter
+        "80": (4, bool32),  # 07 - ClimaRad MiniBox: 0/1, FFFFFFFF/000000FF = N/A
         "90": (4, counter),  # 3E - Away mode Exhaust fan rate (%)
         "92": (4, hex_to_temp),  # 75 (0-30) (C)
     }

--- a/tests/tests/test_parser_helpers.py
+++ b/tests/tests/test_parser_helpers.py
@@ -200,6 +200,49 @@ def test_2411_unknown_param_ids_ventura() -> None:
     assert "_unknown_data_type" not in result
 
 
+def test_2411_data_type_80_minibox_param_07() -> None:
+    """2411 param 07 with data_type 80 (ClimaRad MiniBox) must parse without warning.
+
+    The MiniBox FAN does not support this parameter and signals this by
+    returning sentinel values (0x000000FF for value, 0xFFFFFFFF for min).
+    data_type 80 is a 4-byte boolean: 0=False, 1=True, anything else=None.
+    See issue 830.
+    """
+    msg = _make_22f1_msg(
+        "2026-07-16T07:51:23.626000 078 RP --- 29:099029 29:123150 --:------ 2411 022 "
+        "0000071F80000000FFFFFFFFFF000000010000000120"
+    )
+    result = msg.payload
+    assert result["parameter"] == "07"
+    assert result["description"] == "Base ventilation enable"
+    assert result["value"] is None  # 0x000000FF = not available
+    assert result["min_value"] is None  # 0xFFFFFFFF = not available
+    assert result["max_value"] == 1
+    assert result["precision"] == 1
+    assert "_unknown_data_type" not in result
+
+
+def test_2411_data_type_80_bool_values() -> None:
+    """2411 data_type 80 must decode 0=False, 1=True for supported devices."""
+    # value = 0x00000000 (False)
+    msg = _make_22f1_msg(
+        "2026-07-16T07:51:23.626000 078 RP --- 29:099029 29:123150 --:------ 2411 022 "
+        "0000071F8000000000FFFFFFFF000000010000000120"
+    )
+    result = msg.payload
+    assert result["value"] == 0
+    assert "_unknown_data_type" not in result
+
+    # value = 0x00000001 (True)
+    msg = _make_22f1_msg(
+        "2026-07-16T07:51:23.626000 078 RP --- 29:099029 29:123150 --:------ 2411 022 "
+        "0000071F8000000001FFFFFFFF000000010000000120"
+    )
+    result = msg.payload
+    assert result["value"] == 1
+    assert "_unknown_data_type" not in result
+
+
 def test_helper_demand_transform() -> None:
     assert [x[1] for x in TRANSFORMS] == [_transform(x[0]) for x in TRANSFORMS]
 


### PR DESCRIPTION
ClimaRad MiniBox FAN returns data_type 80 for param 07 (Base ventilation enable). The MiniBox does not support this parameter and signals this with sentinel values (0x000000FF for value, 0xFFFFFFFF for min).

Add a bool32 parser: 0=False, 1=True, anything else=None (consistent with hex_to_bool's FF=N/A convention). Register data_type 80 in _2411_DATA_TYPES alongside the existing 4-byte variants (10/11/13/20/90).

Includes regression tests using the actual packet from issue 830 plus bool 0/1 value decoding tests.

see https://github.com/ramses-rf/ramses_rf/issues/830

AI used: GLM 5.2 high