### PR TITLE
Feature/strip traits recursive follow up on 820

### DIFF
--- a/src/ramses_rf/config.py
+++ b/src/ramses_rf/config.py
@@ -156,6 +156,9 @@ def strip_and_map_traits(traits: dict[str, Any]) -> dict[str, Any]:
     this function so that ``config.json`` schemas with ``_``-prefixed
     keys work everywhere — no duplicate stripper needed.
 
+    Recurses into nested dicts (e.g. zones within a TCS) so that
+    ``_name`` inside a zone is also stripped/mapped.
+
     Keys without a ``_`` prefix are passed through unchanged.
 
     :param traits: A device's trait dict, possibly containing
@@ -165,14 +168,46 @@ def strip_and_map_traits(traits: dict[str, Any]) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for key, value in traits.items():
         if not isinstance(key, str) or not key.startswith("_"):
-            # Non-_ key: pass through
-            result[key] = value
+            # Non-_ key: recurse if dict, pass through otherwise
+            if isinstance(value, dict):
+                result[key] = strip_and_map_traits(value)
+            else:
+                result[key] = value
             continue
         # _-prefixed key: map or strip
         native_key = _TRAIT_KEY_MAP.get(key)
         if native_key is not None and native_key not in result:
-            result[native_key] = value
+            # Recurse into mapped value if it's a dict
+            if isinstance(value, dict):
+                result[native_key] = strip_and_map_traits(value)
+            else:
+                result[native_key] = value
         # else: strip (drop the key)
+    return result
+
+
+def strip_traits(traits: dict[str, Any]) -> dict[str, Any]:
+    """Recursively strip all ``_``-prefixed keys from a dict.
+
+    Stage 1 only (no mapping).  Used by ramses_cc's
+    ``_strip_schema_extensions`` to remove all ``_`` keys before passing
+    the schema to ``SCH_GLOBAL_SCHEMAS`` (which does not accept mapped
+    trait names like ``bound`` or ``class`` — those go in the
+    ``known_list``, not the schema).
+
+    Recurses into nested dicts (e.g. zones within a TCS).
+
+    :param traits: A dict possibly containing ``_``-prefixed keys.
+    :return: A new dict with all ``_`` keys removed.
+    """
+    result: dict[str, Any] = {}
+    for key, value in traits.items():
+        if isinstance(key, str) and key.startswith("_"):
+            continue
+        if isinstance(value, dict):
+            result[key] = strip_traits(value)
+        else:
+            result[key] = value
     return result
 
 

--- a/src/ramses_rf/schemas.py
+++ b/src/ramses_rf/schemas.py
@@ -55,6 +55,7 @@ from .config import (
     SZ_SCHEME as SZ_SCHEME,
     strip_and_map_schema as strip_and_map_schema,
     strip_and_map_traits as strip_and_map_traits,
+    strip_traits as strip_traits,
 )
 
 # TODO: deprecate re-exporting (via as) in favour of direct imports

--- a/tests/tests_rf/test_strip_and_map.py
+++ b/tests/tests_rf/test_strip_and_map.py
@@ -9,7 +9,12 @@ These tests verify that ramses_rf's strip+map pipeline correctly:
 
 from __future__ import annotations
 
-from ramses_rf.config import SCH_TRAITS, strip_and_map_schema, strip_and_map_traits
+from ramses_rf.config import (
+    SCH_TRAITS,
+    strip_and_map_schema,
+    strip_and_map_traits,
+    strip_traits,
+)
 
 
 class TestStripAndMapTraits:
@@ -94,6 +99,39 @@ class TestStripAndMapTraits:
         assert result["class"] == "FAN"
         assert result["alias"] == "My Fan"
 
+    def test_recursive_nested_dict_strips_underscore(self) -> None:
+        """_name inside a nested dict (e.g. a zone) is stripped."""
+        traits = {
+            "class": "TCS",
+            "zones": {"01": {"_name": "Living Room", "setpoint": 20.0}},
+        }
+        result = strip_and_map_traits(traits)
+        assert result["zones"]["01"] == {"setpoint": 20.0}
+        assert "_name" not in result["zones"]["01"]
+
+    def test_recursive_nested_dict_maps_underscore(self) -> None:
+        """_bound inside a nested dict is mapped to bound."""
+        traits = {
+            "class": "TCS",
+            "zones": {"01": {"_bound": "32:153001", "setpoint": 20.0}},
+        }
+        result = strip_and_map_traits(traits)
+        assert result["zones"]["01"]["bound"] == "32:153001"
+        assert "_bound" not in result["zones"]["01"]
+
+    def test_recursive_deeply_nested(self) -> None:
+        """Recursion works at arbitrary depth."""
+        traits = {
+            "class": "TCS",
+            "zones": {
+                "01": {"_name": "Zone 1", "sub": {"_disabled": True, "ok": 1}},
+            },
+        }
+        result = strip_and_map_traits(traits)
+        assert "_name" not in result["zones"]["01"]
+        assert "_disabled" not in result["zones"]["01"]["sub"]
+        assert result["zones"]["01"]["sub"] == {"ok": 1}
+
 
 class TestStripAndMapSchema:
     """Unit tests for strip_and_map_schema()."""
@@ -147,3 +185,48 @@ class TestSchTraitsHvacBound:
         """No bound key at all."""
         result = SCH_TRAITS({"class": "FAN", "scheme": "vasco"})
         assert "bound" not in result or result.get("bound") is None
+
+
+class TestStripTraits:
+    """Unit tests for strip_traits() (stage 1 only — strip, no mapping)."""
+
+    def test_strips_underscore_keys(self) -> None:
+        """All _-prefixed keys are removed."""
+        traits = {"_commands": {"on": "22F1"}, "_name": "My REM", "class": "FAN"}
+        result = strip_traits(traits)
+        assert result == {"class": "FAN"}
+
+    def test_does_not_map(self) -> None:
+        """strip_traits does NOT map _bound -> bound (stage 1 only)."""
+        traits = {"_bound": "32:153001", "class": "FAN"}
+        result = strip_traits(traits)
+        assert result == {"class": "FAN"}
+        assert "bound" not in result
+
+    def test_passes_through_non_underscore(self) -> None:
+        """Non-_ keys pass through unchanged."""
+        traits = {"class": "FAN", "bound": "32:153001", "scheme": "vasco"}
+        result = strip_traits(traits)
+        assert result == traits
+
+    def test_empty_dict(self) -> None:
+        """Empty dict returns empty dict."""
+        assert strip_traits({}) == {}
+
+    def test_recursive_nested(self) -> None:
+        """_ keys inside nested dicts are also stripped."""
+        traits = {
+            "class": "TCS",
+            "zones": {"01": {"_name": "Living Room", "setpoint": 20.0}},
+        }
+        result = strip_traits(traits)
+        assert result == {"class": "TCS", "zones": {"01": {"setpoint": 20.0}}}
+
+    def test_recursive_deeply_nested(self) -> None:
+        """Recursion works at arbitrary depth."""
+        traits = {
+            "class": "TCS",
+            "zones": {"01": {"_name": "Z1", "sub": {"_disabled": True, "ok": 1}}},
+        }
+        result = strip_traits(traits)
+        assert result == {"class": "TCS", "zones": {"01": {"sub": {"ok": 1}}}}


### PR DESCRIPTION
This is a follow-up on https://github.com/ramses-rf/ramses_rf/pull/820

## Summary
- Make `strip_and_map_traits()` **recursive** into nested dicts (e.g. zones within a TCS) so `_name` / `_bound` / `_disabled` inside a zone are also stripped/mapped
- Add new `strip_traits()` function: stage 1 only (strip `_` keys, no mapping) — used by ramses_cc's `_strip_schema_extensions` for schemas that go to `SCH_GLOBAL_SCHEMAS` (which does not accept mapped trait names like `bound` or `class`)
- Export `strip_traits` from `schemas.py`
- Add 9 new tests: 3 for recursive `strip_and_map_traits` (strip, map, deep nesting) + 6 for `strip_traits` (strip, no-map, pass-through, empty, recursive, deep)
 
## Context
Follow-up to PR 820 (strip-and-map-pipeline). The original `strip_and_map_traits` was non-recursive, so `_`-prefixed keys inside nested dicts (e.g. a zone's `_name` inside a TCS) were not stripped. This caused schema validation errors in ramses_cc when a config.json contained nested `_` keys.
 
The new `strip_traits()` is needed because `SCH_GLOBAL_SCHEMAS` rejects mapped trait names (`bound`, `class`) — those belong in the `known_list`, not the schema. So ramses_cc needs a stage-1-only stripper that removes all `_` keys without mapping.
 
AI used: GLM 5.2 high