### PR TITLE
fix: remove `0004` from `HIGH_VOLUME_STATUS_CODES`

### DIFF
--- a/src/ramses_rf/const.py
+++ b/src/ramses_rf/const.py
@@ -156,8 +156,12 @@ DONT_UPDATE_ENTITIES: Final[int] = 1
 
 SCHED_REFRESH_INTERVAL: Final[int] = 3  # minutes
 
+# 0004 (zone_name) is intentionally excluded: it is low-volume (sent
+# every ~6h) and carries semi-static state (zone names).  Classifying it
+# as high-volume caused cached 0004 packets older than 1h to be skipped
+# during _restore_cached_packets, so zone names were lost on restart.
+# See https://github.com/ramses-rf/ramses_cc/issues/822
 HIGH_VOLUME_STATUS_CODES: Final = (
-    Code._0004,
     Code._1060,
     Code._2309,
     Code._2349,


### PR DESCRIPTION
0004 (zone_name) is low-volume — sent by the controller every ~6h and carrying semi-static state (zone names).  Classifying it as high-volume caused _restore_cached_packets to silently skip any cached 0004 packet older than 1 hour, so zone names were lost on every restart.

This was the root cause of the regression reported in https://github.com/ramses-rf/ramses_cc/issues/822 where Evohome zone names defaulted to "01:216136_xx" after the cache-restore fix.

see https://github.com/ramses-rf/ramses_cc/issues/822

AI used: GLM 5.2 high