### PR TITLE
fix(protocol): move foreign-HGI exception before block_list check

### DIFF
--- a/src/ramses_tx/protocol/base.py
+++ b/src/ramses_tx/protocol/base.py
@@ -570,27 +570,30 @@ class _DeviceIdFilterMixin(_BaseProtocol):
             self._foreign_gwys_lst.append(dev_id)
 
         for dev_id in dict.fromkeys((src_id, dst_id)):  # removes duplicates
+            # HGI devices (18:) are gateways, not sensors/actuators.
+            # Foreign HGIs communicate with our controller and the controller's
+            # responses (e.g. 0004 zone names, 2349 zone modes) are addressed
+            # to them.  Blocking a foreign HGI would prevent the active gateway
+            # from eavesdropping on those responses (issue 822).
+            #
+            # This check is BEFORE the exclude (block_list) check so that
+            # foreign HGIs are never blocked, even if a caller mistakenly
+            # adds them to the block_list.  HGI_DEV_ADDR (18:000730, the
+            # generic broadcast address) is still subject to the block_list.
+            if dev_id[:2] == "18" and dev_id != HGI_DEV_ADDR.id:
+                if dev_id == self._active_hgi:
+                    continue
+                if self._active_hgi:
+                    warn_foreign_hgi(dev_id)
+                continue
+
             if dev_id in self._exclude:
                 return False
-
-            if dev_id == self._active_hgi:
-                continue
 
             if dev_id in self._include:
                 continue
 
             if sending and dev_id == HGI_DEV_ADDR.id:
-                continue
-
-            # HGI devices (18:) are gateways, not sensors/actuators.
-            # Don't filter out specific foreign HGIs when enforce_include is
-            # True — doing so blocks legitimate traffic to/from foreign HGIs
-            # that appear in captured conversations but haven't been added to
-            # the known_list yet.  HGI_DEV_ADDR (18:000730, the generic
-            # broadcast address) is still filtered.
-            if dev_id[:2] == "18" and dev_id != HGI_DEV_ADDR.id:
-                if self._active_hgi:
-                    warn_foreign_hgi(dev_id)
                 continue
 
             if self.enforce_include:

--- a/tests/tests_tx/protocol/test_base.py
+++ b/tests/tests_tx/protocol/test_base.py
@@ -160,6 +160,42 @@ async def test_is_wanted_addrs_sending_to_hgi(protocol: DummyProtocol) -> None:
     )
 
 
+async def test_is_wanted_addrs_foreign_hgi_not_blocked(protocol: DummyProtocol) -> None:
+    """Foreign HGIs (18:) must not be blocked even if in the exclude list.
+
+    A foreign HGI communicates with our controller and the controller's
+    responses (e.g. 0004 zone names) are addressed to the foreign HGI.
+    Blocking the foreign HGI would prevent the active gateway from
+    eavesdropping on those responses (issue 822).
+    """
+    protocol._active_hgi = DeviceIdT("18:191664")
+    protocol._exclude = [DeviceIdT("18:072981")]  # foreign HGI in block_list
+
+    # Packet from controller to foreign HGI (e.g. 0004 RP zone name)
+    assert (
+        protocol._is_wanted_addrs(DeviceIdT("01:216136"), DeviceIdT("18:072981"))
+        is True
+    )
+    # Packet from foreign HGI to controller (e.g. 0004 RQ)
+    assert (
+        protocol._is_wanted_addrs(DeviceIdT("18:072981"), DeviceIdT("01:216136"))
+        is True
+    )
+
+
+async def test_is_wanted_addrs_hgi_dev_addr_still_blocked(
+    protocol: DummyProtocol,
+) -> None:
+    """HGI_DEV_ADDR (18:000730) is the generic broadcast, not a specific HGI.
+
+    It must still be subject to the block_list — only specific foreign HGIs
+    (18:XXXXXX where XXXXXX != 000730) are exempt.
+    """
+    protocol._exclude = [HGI_DEV_ADDR.id]
+
+    assert protocol._is_wanted_addrs(DeviceIdT("01:216136"), HGI_DEV_ADDR.id) is False
+
+
 # --- INBOUND PACKET TESTS (_pkt_received) ---
 
 


### PR DESCRIPTION
Foreign HGIs (18: devices) communicate with our controller and the controller's responses (e.g. 0004 zone names, 2349 zone modes) are addressed to the foreign HGI.  The active gateway eavesdrops on these responses to populate zone names and other state.

Previously, the foreign-HGI exception in _is_wanted_addrs was placed AFTER the exclude (block_list) check.  If a caller added a foreign HGI to the block_list, the exclude check would return False before the foreign-HGI exception could fire — silently dropping all packets to/from the foreign HGI, including the controller's 0004 zone name responses.

This was the root cause of ramses_cc issue 822: ramses_cc puts foreign devices (_owner != root_owner) in the block_list, which included foreign HGIs.  The 0004 RP packets (zone names) were dropped at the protocol filter, so zone._name stayed None and the device registry showed fallback names like "01:216136_xx".

Now the foreign-HGI exception is checked FIRST, before the exclude check.  This ensures foreign HGIs are never blocked, even if a caller mistakenly adds them to the block_list.  HGI_DEV_ADDR (18:000730, the generic broadcast address) is still subject to the block_list — only specific foreign HGIs (18:XXXXXX where XXXXXX != 000730) are exempt.

This also aligns with multi-gateway support (issue 840): all 18: devices pass the receive filter, the active HGI is identified for sending, and foreign HGIs are listen-only.

see https://github.com/ramses-rf/ramses_cc/issues/822

AI used: GLM 5.2 High
