### PR TITLE
fix: detect BDR appliance_control via 3B00/3EF0 TPI broadcasts (cc 834)

### DIFF
--- a/src/ramses_rf/discovery_scan.py
+++ b/src/ramses_rf/discovery_scan.py
@@ -112,6 +112,16 @@ _HVAC_PARENT_INFERENCE_CODES: frozenset[str] = frozenset(
     {"22F1", "31E0", "31DA", "10D0"}  # fan_mode, vent_demand, fan_status, outside_temp
 )
 
+# TPI loop codes broadcast by a BDR (13:) or OTB (10:) acting as the
+# appliance_control (boiler relay).  These are sent as I broadcasts at
+# the TPI cycle rate (usu. 6x/hr).  A DHW valve relay does NOT send
+# 3B00/3EF0 — it uses a separate control path.  This is the same
+# signature ramses_rf's eavesdrop_appliance_control (tcs.py) watches for
+# to identify the system relay.  See issue 834: a BDR sending these
+# codes must be classified as appliance_control (FC domain), not as a
+# hotwater_valve.
+_APPLIANCE_CONTROL_CODES: frozenset[str] = frozenset({"3B00", "3EF0"})
+
 # 32: is unambiguous — always a FAN. A FAN sends 22F1 (which maps to REM in
 # HVAC_KLASS_BY_VC_PAIR) but is still a FAN, so the prefix must win.
 # 18: is unambiguous — always an HGI. The HGI relays packets from all device
@@ -152,6 +162,7 @@ class DiscoveredDevice:
     codes_seen: list[str] = field(default_factory=list)  # sorted, deduplicated
     bound_to: str | None = None  # parent device ID (CTL for TRV, FAN for REM)
     zone_idx: str | None = None  # zone index if known from payload
+    domain_id: str | None = None  # domain ID if known (FC=appliance_control)
     rssi: float | None = None  # running average
     confidence: str = "low"  # high, medium, low
     is_battery: bool = False  # seen sending battery info
@@ -301,6 +312,12 @@ class DiscoveryScan:
             _extract_zone_idx(dto.payload) if code in _ZONE_BINDING_CODES else None
         )
 
+        # Detect appliance_control signal: a BDR/OTB broadcasting 3B00/3EF0
+        # as I is the boiler relay (FC domain).  See issue 834.
+        domain_id = (
+            "FC" if _is_appliance_control_signal(src, code, verb, True) else None
+        )
+
         # Process each address in the packet
         # src: high-confidence (device is actively sending)
         if src and _is_valid_address(src):
@@ -310,6 +327,7 @@ class DiscoveryScan:
                 verb=verb,
                 rssi=rssi,
                 zone_idx=zone_idx,
+                domain_id=domain_id,
                 is_src=True,
                 dst=dst,
             )
@@ -322,6 +340,7 @@ class DiscoveryScan:
                 verb=verb,
                 rssi=None,  # RSSI is for the sender, not the receiver
                 zone_idx=zone_idx,
+                domain_id=None,
                 is_src=False,
                 dst=None,
                 src=src,  # who sent this packet (for HVAC reply inference)
@@ -335,6 +354,7 @@ class DiscoveryScan:
                 verb=verb,
                 rssi=None,
                 zone_idx=None,
+                domain_id=None,
                 is_src=False,
                 dst=None,
             )
@@ -347,6 +367,7 @@ class DiscoveryScan:
         verb: str,
         rssi: float | None,
         zone_idx: str | None,
+        domain_id: str | None = None,
         is_src: bool,
         dst: str | None,
         src: str | None = None,
@@ -427,6 +448,7 @@ class DiscoveryScan:
                     is_battery=code in _BATTERY_CODES,
                     src_count=1 if is_src else 0,
                     dst_count=0 if is_src else 1,
+                    domain_id=domain_id if domain_id and is_src else None,
                 )
                 self._devices[dev_id] = dev
                 self._dirty = True
@@ -471,6 +493,13 @@ class DiscoveryScan:
                             zone_idx,
                             dev.bound_to,
                         )
+                # Appliance_control signal for known devices too (issue 834):
+                # a known BDR may not have been seen broadcasting 3B00/3EF0
+                # before it was accepted, so capture the domain_id now.
+                if domain_id and is_src and dev.domain_id != domain_id:
+                    dev.domain_id = domain_id
+                    dev.confidence = "high"
+                    self._dirty = True
             return
 
         now = dt.now().isoformat(timespec="seconds")
@@ -502,6 +531,11 @@ class DiscoveryScan:
                 if dst and _is_valid_address(dst) and dst != dev_id:
                     dev.bound_to = dst
                 dev.confidence = "high"  # binding telemetry = high confidence
+            # Appliance_control signal: a BDR/OTB broadcasting 3B00/3EF0 as
+            # I is the boiler relay (FC domain).  See issue 834.
+            if domain_id and is_src and not is_hgi:
+                dev.domain_id = domain_id
+                dev.confidence = "high"
             # HVAC topology inference: a FAN (32:) sending a directed packet
             # (I or RP) to this device confirms the binding — the FAN is the
             # controller and it's communicating with its paired remote.
@@ -569,6 +603,13 @@ class DiscoveryScan:
             if bound_changed:
                 dev.confidence = "high"
                 changed = True
+
+        # Update appliance_control domain (BDR/OTB broadcasting 3B00/3EF0).
+        # See issue 834: this distinguishes a boiler relay from a DHW valve.
+        if domain_id and is_src and not is_hgi and dev.domain_id != domain_id:
+            dev.domain_id = domain_id
+            dev.confidence = "high"
+            changed = True
 
         # HVAC topology inference: a FAN (32:) sending a directed packet
         # (I or RP) to this device confirms the binding — the FAN is the
@@ -850,3 +891,27 @@ def _extract_zone_idx(payload: str) -> str | None:
     if val > 0x0B:
         return None
     return idx
+
+
+def _is_appliance_control_signal(
+    dev_id: str, code: str, verb: str, is_src: bool
+) -> bool:
+    """Return True if this packet indicates the src is an appliance_control.
+
+    A BDR (13:) or OTB (10:) broadcasting 3B00 or 3EF0 as I is acting as the
+    boiler relay (TPI loop).  DHW valve relays do not send these codes — they
+    use a separate control path.  This is the same signature ramses_rf's
+    eavesdrop_appliance_control (tcs.py) uses to identify the system relay.
+
+    See issue 834: without this signal, a BDR with no zone_idx is misclassified
+    as a hotwater_valve by ramses_cc's generate_schema_entry.
+    """
+    if not is_src:
+        return False
+    if not dev_id.startswith(("13:", "10:")):
+        return False
+    if code not in _APPLIANCE_CONTROL_CODES:
+        return False
+    # 3B00/3EF0 are broadcast as I by the relay; RQ/RP are directed replies
+    # (e.g. 3EF1 RP from the relay to the HGI) and are not the TPI signature.
+    return verb.strip() == "I"

--- a/tests/tests_rf/test_discovery_scan.py
+++ b/tests/tests_rf/test_discovery_scan.py
@@ -29,6 +29,7 @@ from ramses_rf.discovery_scan import (
     _classify,
     _extract_zone_idx,
     _initial_confidence,
+    _is_appliance_control_signal,
     _is_valid_address,
     _recompute_confidence,
 )
@@ -162,6 +163,43 @@ class TestExtractZoneIdx:
     def test_zone_lowercase(self) -> None:
         # Should normalise to uppercase
         assert _extract_zone_idx("0a00") == "0A"
+
+
+class TestIsApplianceControlSignal:
+    """Tests for _is_appliance_control_signal (issue 834)."""
+
+    def test_bdr_3b00_i_is_appliance(self) -> None:
+        # BDR broadcasting 3B00 as I — classic TPI loop signature
+        assert _is_appliance_control_signal("13:121025", "3B00", " I", True) is True
+
+    def test_bdr_3ef0_i_is_appliance(self) -> None:
+        assert _is_appliance_control_signal("13:121025", "3EF0", " I", True) is True
+
+    def test_otb_3b00_i_is_appliance(self) -> None:
+        # OTB (10:) also broadcasts 3B00 as the boiler relay
+        assert _is_appliance_control_signal("10:067219", "3B00", " I", True) is True
+
+    def test_bdr_3b00_rp_not_appliance(self) -> None:
+        # RP is a directed reply, not the broadcast TPI signature
+        assert _is_appliance_control_signal("13:121025", "3B00", "RP", True) is False
+
+    def test_bdr_3b00_rq_not_appliance(self) -> None:
+        assert _is_appliance_control_signal("13:121025", "3B00", "RQ", True) is False
+
+    def test_bdr_3ef1_not_appliance(self) -> None:
+        # 3EF1 is a directed RP from the relay to the HGI, not the TPI broadcast
+        assert _is_appliance_control_signal("13:121025", "3EF1", "RP", True) is False
+
+    def test_trv_3b00_not_appliance(self) -> None:
+        # Only 13: and 10: can be appliance controls
+        assert _is_appliance_control_signal("04:056053", "3B00", " I", True) is False
+
+    def test_bdr_3b00_as_dst_not_appliance(self) -> None:
+        # Must be the src (sender), not dst
+        assert _is_appliance_control_signal("13:121025", "3B00", " I", False) is False
+
+    def test_bdr_other_code_not_appliance(self) -> None:
+        assert _is_appliance_control_signal("13:121025", "1100", " I", True) is False
 
 
 class TestClassify:
@@ -690,6 +728,103 @@ class TestDiscoveryScanPacketHandling:
         # CTL must NOT have zone_idx set
         assert dev.zone_idx is None
         assert dev.bound_to is None
+
+    def test_bdr_3b00_sets_domain_id_fc(self) -> None:
+        """BDR broadcasting 3B00 as I sets domain_id=FC (issue 834).
+
+        A BDR acting as the boiler relay broadcasts 3B00 (TPI state) as I.
+        The scan engine must capture domain_id=FC so ramses_cc can classify
+        it as appliance_control rather than hotwater_valve.
+        """
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(
+            make_dto(src="13:121025", dst="--:------", code="3B00", payload="00C8")
+        )
+        dev = scan.get_device("13:121025")
+        assert dev is not None
+        assert dev.likely_type == "BDR"
+        assert dev.domain_id == "FC"
+        assert dev.confidence == "high"
+
+    def test_bdr_3ef0_sets_domain_id_fc(self) -> None:
+        """BDR broadcasting 3EF0 as I also sets domain_id=FC (issue 834)."""
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(
+            make_dto(src="13:121025", dst="--:------", code="3EF0", payload="0000FF")
+        )
+        dev = scan.get_device("13:121025")
+        assert dev is not None
+        assert dev.domain_id == "FC"
+
+    def test_bdr_3ef1_rp_no_domain_id(self) -> None:
+        """BDR sending 3EF1 RP (directed reply to HGI) is NOT appliance signal."""
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(
+            make_dto(
+                src="13:121025",
+                dst="18:203273",
+                code="3EF1",
+                verb="RP",
+                payload="00011D011D00FF",
+            )
+        )
+        dev = scan.get_device("13:121025")
+        assert dev is not None
+        assert dev.domain_id is None
+
+    def test_bdr_1100_no_domain_id(self) -> None:
+        """BDR sending 1100 (boiler params) does NOT set domain_id.
+
+        1100 is sent by both appliance controls and DHW valve relays, so it
+        is not a reliable appliance_control signal on its own.
+        """
+        gwy = make_mock_gateway()
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(
+            make_dto(
+                src="13:121025",
+                dst="--:------",
+                code="1100",
+                payload="00180400007FFF01",
+            )
+        )
+        dev = scan.get_device("13:121025")
+        assert dev is not None
+        assert dev.domain_id is None
+
+    def test_known_bdr_3b00_sets_domain_id(self) -> None:
+        """A known BDR (in known_list) broadcasting 3B00 gets domain_id=FC.
+
+        This is the issue 834 scenario: the BDR was already in the schema
+        but had no domain_id.  When it broadcasts 3B00, the scan engine
+        must capture the FC domain so the comment and schema entry can be
+        rebuilt correctly.
+        """
+        gwy = make_mock_gateway(known_list={"13:121025": {}})
+        scan = DiscoveryScan(gwy)
+        scan._process_packet(
+            make_dto(src="13:121025", dst="--:------", code="3B00", payload="00C8")
+        )
+        dev = scan.get_device("13:121025")
+        assert dev is not None
+        assert dev.domain_id == "FC"
+
+    def test_domain_id_in_to_dict_round_trip(self) -> None:
+        """domain_id survives to_dict/from_dict round-trip."""
+        dev = DiscoveredDevice(
+            device_id="13:121025",
+            first_seen="2026-07-18T14:36:23",
+            last_seen="2026-07-18T14:36:23",
+            likely_type="BDR",
+            domain_id="FC",
+        )
+        d = dev.to_dict()
+        assert d["domain_id"] == "FC"
+        dev2 = DiscoveredDevice.from_dict(d)
+        assert dev2.domain_id == "FC"
 
     def test_codes_seen_deduplicated_and_sorted(self) -> None:
         gwy = make_mock_gateway()


### PR DESCRIPTION
A BDR (13:) or OTB (10:) broadcasting 3B00/3EF0 as I is the boiler relay (appliance_control, FC domain), not a DHW valve.  The scan engine now captures domain_id=FC from these codes so ramses_cc can classify the BDR correctly instead of defaulting to hotwater_valve.

- Add _APPLIANCE_CONTROL_CODES = {3B00, 3EF0} constant
- Add domain_id field to DiscoveredDevice dataclass
- Add _is_appliance_control_signal() helper (only 13:/10: src, verb I)
- Wire domain_id through _process_packet → _process_device (all paths)
- 15 new tests covering positive, negative, and round-trip cases

see github.com/ramses-rf/ramses_cc/issues/834

AI used: GLM 5.2 high
