### PR TITLE
fix: re-parent BDR from hotwater_valve to appliance_control (issue 834)

### DIFF
--- a/src/ramses_rf/devices/dev_registry.py
+++ b/src/ramses_rf/devices/dev_registry.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from ramses_rf.address import Address, is_valid_dev_id
 from ramses_rf.config import GatewayConfig
-from ramses_rf.const import SZ_DEVICES
+from ramses_rf.const import FA, FC, SZ_DEVICES
 from ramses_rf.devices.dev_base import DeviceHeat, DeviceHvac, Fakeable
 from ramses_rf.enums import TopologyAction
 from ramses_rf.exceptions import (
@@ -196,6 +196,11 @@ class DeviceRegistry:
                 # 1. FORWARD BINDING (Delegating down to legacy graph mutation
                 # to allow the Old Brain to hydrate itself)
                 child_id_raw = metadata.get("child_id")
+                # Fallback: if domain_id is FC (appliance_control) but
+                # child_id was not explicitly set in the metadata, use FC
+                # so the binding targets the System's appliance_control slot.
+                if child_id_raw is None and metadata.get("domain_id") == FC:
+                    child_id_raw = FC
                 child_dev = self.get_device(
                     event.child_id,
                     parent=cast("Parent", parent),
@@ -538,6 +543,54 @@ class DeviceRegistry:
                     _LOGGER.warning(f"The device is not fakeable: {dev}")
 
         if parent or child_id:
+            # Re-parenting: allow a BDR to be promoted from hotwater_valve
+            # (FA, DhwZone) to appliance_control (FC, System) when a
+            # higher-confidence binding (000C APP, or 3B00/3EF0 eavesdrop)
+            # arrives after the 000C HTG binding incorrectly placed it as
+            # hotwater_valve.  This handles issue 834: systems without DHW
+            # where the controller's binding table has the BDR in the HTG
+            # slot but it is actually the appliance_control.
+            #
+            # Only re-parent when the DhwZone has no DHW sensor — if a
+            # sensor exists, the system genuinely has DHW and the BDR may
+            # truly be the hotwater_valve.
+            old_parent = dev._parent if dev else None
+            if (
+                dev
+                and parent
+                and child_id == FC
+                and old_parent is not None
+                and old_parent is not parent
+                and type(old_parent).__name__ == "DhwZone"
+                and getattr(dev, "_child_id", None) == FA
+                and getattr(old_parent, "_dhw_sensor", None) is None
+            ):
+                _LOGGER.info(
+                    "RE-PARENTING: %s from DhwZone (hotwater_valve) to "
+                    "System (appliance_control)",
+                    device_id,
+                )
+                # Detach from DhwZone
+                old_parent._dhw_valve = None
+                if dev in old_parent.childs:
+                    old_parent.childs.remove(dev)
+                old_parent.child_by_id.pop(dev.id, None)
+                dev._parent = None
+                dev._child_id = None
+                # Clean up the DhwZone if it has no children left
+                tcs = getattr(old_parent, "tcs", None)
+                if (
+                    tcs
+                    and not old_parent.childs
+                    and getattr(old_parent, "_dhw_sensor", None) is None
+                    and getattr(old_parent, "_htg_valve", None) is None
+                ):
+                    tcs._dhw = None
+                    _LOGGER.info(
+                        "RE-PARENTING: removed empty DhwZone from %s",
+                        getattr(tcs, "id", None),
+                    )
+
             try:
                 dev._apply_topology_link(parent, child_id=child_id, is_sensor=is_sensor)
             except (DeviceNotFoundError, SchemaInconsistentError) as err:

--- a/src/ramses_rf/devices/dev_registry.py
+++ b/src/ramses_rf/devices/dev_registry.py
@@ -543,53 +543,7 @@ class DeviceRegistry:
                     _LOGGER.warning(f"The device is not fakeable: {dev}")
 
         if parent or child_id:
-            # Re-parenting: allow a BDR to be promoted from hotwater_valve
-            # (FA, DhwZone) to appliance_control (FC, System) when a
-            # higher-confidence binding (000C APP, or 3B00/3EF0 eavesdrop)
-            # arrives after the 000C HTG binding incorrectly placed it as
-            # hotwater_valve.  This handles issue 834: systems without DHW
-            # where the controller's binding table has the BDR in the HTG
-            # slot but it is actually the appliance_control.
-            #
-            # Only re-parent when the DhwZone has no DHW sensor — if a
-            # sensor exists, the system genuinely has DHW and the BDR may
-            # truly be the hotwater_valve.
-            old_parent = dev._parent if dev else None
-            if (
-                dev
-                and parent
-                and child_id == FC
-                and old_parent is not None
-                and old_parent is not parent
-                and type(old_parent).__name__ == "DhwZone"
-                and getattr(dev, "_child_id", None) == FA
-                and getattr(old_parent, "_dhw_sensor", None) is None
-            ):
-                _LOGGER.info(
-                    "RE-PARENTING: %s from DhwZone (hotwater_valve) to "
-                    "System (appliance_control)",
-                    device_id,
-                )
-                # Detach from DhwZone
-                old_parent._dhw_valve = None
-                if dev in old_parent.childs:
-                    old_parent.childs.remove(dev)
-                old_parent.child_by_id.pop(dev.id, None)
-                dev._parent = None
-                dev._child_id = None
-                # Clean up the DhwZone if it has no children left
-                tcs = getattr(old_parent, "tcs", None)
-                if (
-                    tcs
-                    and not old_parent.childs
-                    and getattr(old_parent, "_dhw_sensor", None) is None
-                    and getattr(old_parent, "_htg_valve", None) is None
-                ):
-                    tcs._dhw = None
-                    _LOGGER.info(
-                        "RE-PARENTING: removed empty DhwZone from %s",
-                        getattr(tcs, "id", None),
-                    )
+            self._maybe_reparent_bdr(dev, parent, child_id)
 
             try:
                 dev._apply_topology_link(parent, child_id=child_id, is_sensor=is_sensor)
@@ -601,6 +555,69 @@ class DeviceRegistry:
                 raise
 
         return dev
+
+    @staticmethod
+    def _maybe_reparent_bdr(
+        dev: Device | None,
+        parent: Parent | None,
+        child_id: str | None,
+    ) -> None:
+        """Re-parent a BDR from hotwater_valve (FA) to appliance_control (FC).
+
+        When the controller's 000C binding table has a BDR in the HTG slot
+        (domain FA = hotwater_valve) but the BDR is actually the
+        appliance_control (domain FC), the 000C HTG binding wins the race
+        and incorrectly binds the BDR as hotwater_valve to a
+        spuriously-created DhwZone.  This method allows re-parenting the
+        BDR from DhwZone.hotwater_valve (FA) to System.appliance_control
+        (FC) when a higher-confidence binding arrives later.
+
+        Re-parenting is suppressed when the DhwZone has a DHW sensor — if
+        a sensor exists, the system genuinely has DHW and the BDR may
+        truly be the hotwater_valve.
+
+        See: https://github.com/ramses-rf/ramses_cc/issues/834
+
+        :param dev: The device being bound (expected to be a BDR).
+        :param parent: The new parent to bind to (expected to be the TCS).
+        :param child_id: The new child_id (must be FC for re-parenting).
+        """
+        if not dev or not parent or child_id != FC:
+            return
+
+        old_parent = dev._parent
+        if old_parent is None or old_parent is parent:
+            return
+
+        # Deferred import to avoid a circular dependency (zones.py imports
+        # from ramses_rf.devices, which imports this module)
+        from ramses_rf.systems.zones import DhwZone
+
+        if not isinstance(old_parent, DhwZone):
+            return
+
+        if getattr(dev, "_child_id", None) != FA:
+            return
+
+        if old_parent.sensor is not None:
+            return  # system genuinely has DHW; BDR may truly be hotwater_valve
+
+        _LOGGER.info(
+            "RE-PARENTING: %s from DhwZone (hotwater_valve) to "
+            "System (appliance_control)",
+            dev.id,
+        )
+
+        # Detach from the DhwZone (encapsulated referential integrity)
+        old_parent._detach_child(dev)
+
+        # Clean up the DhwZone if it is now empty
+        tcs = getattr(old_parent, "tcs", None)
+        if tcs is not None and tcs._remove_dhw_zone():
+            _LOGGER.info(
+                "RE-PARENTING: removed empty DhwZone from %s",
+                getattr(tcs, "id", None),
+            )
 
     async def fake_device(
         self,

--- a/src/ramses_rf/pipeline/topology_builder.py
+++ b/src/ramses_rf/pipeline/topology_builder.py
@@ -571,7 +571,11 @@ class TopologyBuilder:
                 action=TopologyAction.BIND_DEVICE,
                 parent_id=msg.src.id,  # Assume src is the Controller
                 child_id=app_cntrl_id,
-                metadata={"domain_id": "FC", "device_role": "appliance_control"},
+                metadata={
+                    "domain_id": "FC",
+                    "child_id": "FC",
+                    "device_role": "appliance_control",
+                },
                 causation="Rule_Legacy_Appliance_Eavesdrop",
             )
             self._emit(event)

--- a/src/ramses_rf/systems/tcs.py
+++ b/src/ramses_rf/systems/tcs.py
@@ -1204,6 +1204,32 @@ class StoredHw(SystemBase):  # 10A0, 1260, 1F41
             self._dhw._handle_msg(msg)
         return self._dhw
 
+    def _remove_dhw_zone(self) -> bool:
+        """Remove the DhwZone from this system if it is empty.
+
+        A DhwZone is considered empty when it has no sensor, no hotwater
+        valve, no heating valve, and no remaining children.  This is used
+        during re-parenting (e.g. when a BDR is promoted from
+        ``hotwater_valve`` to ``appliance_control``) to clean up a
+        spurious DhwZone that was created by a lower-confidence binding.
+
+        :returns: ``True`` if the DhwZone was removed, ``False`` if it
+            was retained because it still has children.
+        :rtype: bool
+        """
+        if not self._dhw:
+            return False
+
+        if (
+            self._dhw.sensor is None
+            and self._dhw.hotwater_valve is None
+            and self._dhw.heating_valve is None
+            and not self._dhw.childs
+        ):
+            self._dhw = None  # type: ignore[assignment]
+            return True
+        return False
+
     @property
     def dhw(self) -> DhwZone | None:
         """Return the DHW zone instance."""

--- a/src/ramses_rf/topology.py
+++ b/src/ramses_rf/topology.py
@@ -182,6 +182,48 @@ class Parent:
         self.childs.append(child)
         self.child_by_id[child.id] = child
 
+    def _detach_child(self, child: Child) -> None:
+        """Detach a child device from this Parent, maintaining referential integrity.
+
+        This is the inverse of :meth:`_add_child`. It clears the slot the
+        child occupied (sensor, valve, actuator, circuit, or appliance
+        control), removes the child from the ``childs`` list and
+        ``child_by_id`` registry, and clears the child's back-references.
+
+        :param child: The child entity to detach.
+        :type child: Child
+        """
+        # Clear the slot based on identity (not child_id, which may have
+        # been mutated since the child was added)
+        child_id_ = cast("DeviceIdT", getattr(child, "id", None))
+
+        if getattr(self, "_dhw_sensor", None) is child:
+            self._dhw_sensor = None
+        elif getattr(self, "_dhw_valve", None) is child:
+            self._dhw_valve = None
+        elif getattr(self, "_htg_valve", None) is child:
+            self._htg_valve = None
+        elif getattr(self, "_app_cntrl", None) is child:
+            self._app_cntrl = None
+        elif hasattr(self, SZ_SENSOR) and getattr(self, "_sensor", None) is child:
+            self._sensor = None
+        elif hasattr(self, SZ_ACTUATORS) and child in getattr(self, "actuators", []):
+            self.actuators.remove(child)
+            self.actuator_by_id.pop(child_id_, None)
+        elif hasattr(self, SZ_CIRCUITS) and child_id_ in getattr(
+            self, "circuit_by_id", {}
+        ):
+            self.circuit_by_id.pop(child_id_, None)
+
+        # Remove from child registries
+        if child in self.childs:
+            self.childs.remove(child)
+        self.child_by_id.pop(child_id_, None)
+
+        # Clear the child's back-references
+        child._parent = None
+        child._child_id = None
+
 
 class Child:
     """A Device can be the Child of a Parent (System, Zone, or UFH Controller).

--- a/tests/tests_rf/test_bdr_reparent_issue_834.py
+++ b/tests/tests_rf/test_bdr_reparent_issue_834.py
@@ -1,0 +1,190 @@
+"""Tests for BDR re-parenting from hotwater_valve to appliance_control.
+
+Regression tests for issue 834: Evohome schema discovery incorrectly
+categorising a BDR as a hot water control.
+
+When the controller's 000C binding table has a BDR in the HTG slot (domain
+FA = hotwater_valve), but the BDR is actually the appliance_control (domain
+FC), the discovery system must be able to re-parent the BDR from the
+DhwZone to the System when a higher-confidence binding (000C APP, or
+3B00/3EF0 eavesdrop) arrives.
+
+See: https://github.com/ramses-rf/ramses_cc/issues/834
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import tempfile
+
+import pytest
+
+from ramses_rf import Gateway
+from ramses_rf.config import GatewayConfig
+from ramses_rf.const import FA, FC
+from ramses_rf.devices import BdrSwitch, Controller, DhwSensor, OtbGateway
+from ramses_tx.config import EngineConfig
+
+CTL_ID = "01:145038"
+BDR_ID = "13:121025"
+DHW_SENSOR_ID = "07:046947"
+
+
+def _make_gateway(
+    known_list: dict[str, dict[str, str]] | None = None,
+) -> Gateway:
+    """Create a minimal Gateway for topology testing."""
+    if known_list is None:
+        known_list = {
+            CTL_ID: {"class": "CTL"},
+            BDR_ID: {"class": "BDR"},
+        }
+    # Use a temp file as input to satisfy the Engine's port_name/file requirement
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".log") as tmp:
+        tmp_path = tmp.name
+    config = GatewayConfig(
+        disable_discovery=True,
+        known_list=known_list,
+        engine=EngineConfig(
+            disable_sending=True,
+            enforce_known_list=True,
+            input_file=tmp_path,
+        ),
+    )
+    return Gateway(None, config=config)
+
+
+async def _drain_queues(gwy: Gateway) -> None:
+    """Yield to the event loop so any pending callbacks fire."""
+    for _ in range(50):
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_bdr_reparent_from_hotwater_valve_to_appliance_control() -> None:
+    """A BDR bound as hotwater_valve (FA) must be re-parented to
+    appliance_control (FC) when no DHW sensor exists.
+
+    This is the core issue 834 scenario: the 000C HTG binding (FA) arrives
+    first, incorrectly placing the BDR as hotwater_valve.  When the 000C
+    APP binding (FC) or eavesdrop arrives later, the BDR must be moved to
+    the System as appliance_control.
+    """
+    gwy = _make_gateway()
+    await gwy.start(start_discovery=False)
+    await _drain_queues(gwy)
+
+    try:
+        # 1. Get the controller and instantiate its TCS
+        ctl = gwy.device_registry.get_device(CTL_ID)
+        assert isinstance(ctl, Controller)
+        ctl._make_tcs_controller()
+        tcs = ctl.tcs
+        assert tcs is not None
+
+        # 2. Bind the BDR as hotwater_valve (FA) — this creates a DhwZone
+        bdr = gwy.device_registry.get_device(BDR_ID, parent=tcs, child_id=FA)
+        assert isinstance(bdr, BdrSwitch)
+        assert tcs.dhw is not None
+        assert tcs.dhw.hotwater_valve is not None
+        assert tcs.dhw.hotwater_valve.id == BDR_ID
+        assert tcs.appliance_control is None
+
+        # 3. Now bind the same BDR as appliance_control (FC)
+        # This should re-parent the BDR from DhwZone to System
+        bdr2 = gwy.device_registry.get_device(BDR_ID, parent=tcs, child_id=FC)
+        assert bdr2 is bdr
+
+        # 4. Verify the BDR is now appliance_control, NOT hotwater_valve
+        app_cntrl: BdrSwitch | OtbGateway | None = tcs.appliance_control
+        assert app_cntrl is not None
+        assert app_cntrl.id == BDR_ID
+
+        # 5. Verify the DhwZone was cleaned up (no sensor, no valves)
+        assert tcs.dhw is None or tcs.dhw.hotwater_valve is None
+    finally:
+        await gwy.stop()
+
+
+@pytest.mark.asyncio
+async def test_bdr_no_reparent_when_dhw_sensor_exists() -> None:
+    """A BDR must NOT be re-parented from hotwater_valve to
+    appliance_control when a DHW sensor exists.
+
+    If the system genuinely has DHW (sensor present), the BDR may truly be
+    the hotwater_valve, so the re-parenting must be suppressed.
+    """
+    known_list = {
+        CTL_ID: {"class": "CTL"},
+        BDR_ID: {"class": "BDR"},
+        DHW_SENSOR_ID: {"class": "DHW"},
+    }
+    gwy = _make_gateway(known_list=known_list)
+    await gwy.start(start_discovery=False)
+    await _drain_queues(gwy)
+
+    try:
+        # 1. Get the controller and instantiate its TCS
+        ctl = gwy.device_registry.get_device(CTL_ID)
+        assert isinstance(ctl, Controller)
+        ctl._make_tcs_controller()
+        tcs = ctl.tcs
+        assert tcs is not None
+
+        # 2. Bind the DHW sensor first (FA, is_sensor=True)
+        sensor = gwy.device_registry.get_device(
+            DHW_SENSOR_ID, parent=tcs, child_id=FA, is_sensor=True
+        )
+        assert isinstance(sensor, DhwSensor)
+        assert tcs.dhw is not None
+        assert tcs.dhw.sensor is not None
+
+        # 3. Bind the BDR as hotwater_valve (FA)
+        bdr = gwy.device_registry.get_device(BDR_ID, parent=tcs, child_id=FA)
+        assert isinstance(bdr, BdrSwitch)
+        assert tcs.dhw.hotwater_valve is not None
+        assert tcs.dhw.hotwater_valve.id == BDR_ID
+
+        # 4. Attempt to bind the same BDR as appliance_control (FC)
+        # This should NOT re-parent because a DHW sensor exists
+        with contextlib.suppress(Exception):
+            gwy.device_registry.get_device(BDR_ID, parent=tcs, child_id=FC)
+
+        # 5. Verify the BDR is still hotwater_valve (not re-parented)
+        assert tcs.dhw is not None
+        assert tcs.dhw.hotwater_valve is not None
+        assert tcs.dhw.hotwater_valve.id == BDR_ID
+    finally:
+        await gwy.stop()
+
+
+@pytest.mark.asyncio
+async def test_bdr_appliance_control_first_no_dhw_zone() -> None:
+    """When the BDR is bound as appliance_control (FC) first, no DhwZone
+    should be created.
+
+    This verifies the normal (non-race) case: the 000C APP binding arrives
+    before the 000C HTG binding, so the BDR is correctly placed as
+    appliance_control and no spurious DhwZone is created.
+    """
+    gwy = _make_gateway()
+    await gwy.start(start_discovery=False)
+    await _drain_queues(gwy)
+
+    try:
+        ctl = gwy.device_registry.get_device(CTL_ID)
+        assert isinstance(ctl, Controller)
+        ctl._make_tcs_controller()
+        tcs = ctl.tcs
+        assert tcs is not None
+
+        # Bind the BDR directly as appliance_control (FC)
+        bdr = gwy.device_registry.get_device(BDR_ID, parent=tcs, child_id=FC)
+        assert isinstance(bdr, BdrSwitch)
+        assert tcs.appliance_control is not None
+        assert tcs.appliance_control.id == BDR_ID
+        # No DhwZone should exist
+        assert tcs.dhw is None
+    finally:
+        await gwy.stop()


### PR DESCRIPTION
When the controller's 000C binding table has a BDR in the HTG slot (domain FA = hotwater_valve) but the BDR is actually the appliance_control (domain FC), the 000C HTG binding would win the race and incorrectly bind the BDR as hotwater_valve to a spuriously-created DhwZone.  Subsequent 000C APP bindings or 3B00/3EF0 eavesdrop were blocked by the parent-change guard in _apply_topology_link, and the SystemSchemaInconsistent error was silently swallowed.

This fix allows re-parenting a BDR from DhwZone.hotwater_valve (FA) to System.appliance_control (FC) when the DhwZone has no DHW sensor — if a sensor exists, the system genuinely has DHW and the BDR may truly be the hotwater_valve, so re-parenting is suppressed.

Changes:
- topology_builder.py: add child_id=FC to eavesdrop rule metadata so the binding targets the System's appliance_control slot
- dev_registry.py get_device: re-parent BDR from DhwZone (hotwater_valve) to System (appliance_control) when child_id=FC and DhwZone has no sensor; clean up empty DhwZone after detach
- dev_registry.py _handle_bind_device: fallback child_id=FC when domain_id=FC but child_id missing from metadata
- 3 new tests covering re-parenting, no-reparent-when-sensor-exists, and the normal no-race case

Complements PR #856 (discovery_scan domain_id=FC tagging) which handles the scan/classification layer; this fix handles the topology binding layer.


See https://github.com/ramses-rf/ramses_cc/issues/834
AI used: GLM 5.2 high
