### PR TITLE
Fix/851 fan 2411 routing

### DIFF
--- a/src/ramses_rf/dispatcher.py
+++ b/src/ramses_rf/dispatcher.py
@@ -712,6 +712,49 @@ def _update_dhw_state(target: Any, p: dict[str, Any], msg: Message) -> None:
         target.apply_state_update(event)
 
 
+def _route_2411_to_fan(gwy: Gateway, msg: Message) -> None:
+    """Route a 2411 parameter message to its FAN aggregate root.
+
+    Phase 2.95 removed the ``HvacVentilator._handle_msg`` override that
+    previously invoked ``_handle_2411_message`` (which sets
+    ``_supports_2411`` and stores the parameter) and
+    ``_handle_initialized_callback`` (which fires the ramses_cc entity
+    creation callback).  Without this routing, FAN devices never advertise
+    2411 support, so ramses_cc never creates the ~15 parameter ``number``
+    entities (comfort temperature, etc.) — see ramses_cc issue 851.
+
+    This re-wires the 2411 handling into the CQRS ingestion pipeline (where
+    issue 639 wants domain logic to live) instead of restoring the leaky
+    ``_handle_msg`` override.  ``_handle_2411_message`` reads
+    ``msg.payload`` directly, so it is invoked once per FAN target, outside
+    the per-payload loop in ``_cqrs_ingestion_engine``.
+    """
+    registry = getattr(gwy, "device_registry", None)
+    if registry is None:
+        return
+
+    candidates: list[Any] = []
+    src_dev = registry.device_by_id.get(msg.src.id)
+    dst_dev = registry.device_by_id.get(msg.dst.id)
+    if src_dev is not None:
+        candidates.append(src_dev)
+    if dst_dev is not None and dst_dev is not src_dev:
+        candidates.append(dst_dev)
+
+    for dev in candidates:
+        # Duck-type HvacVentilator: it carries _SLUG == FAN and the two
+        # handler methods.  Avoids a circular import of HvacVentilator.
+        if getattr(dev, "_SLUG", "") != DevType.FAN:
+            continue
+        handler = getattr(dev, "_handle_2411_message", None)
+        init_cb = getattr(dev, "_handle_initialized_callback", None)
+        if not callable(handler) or not callable(init_cb):
+            continue
+        with contextlib.suppress(AttributeError, TypeError, ValueError):
+            handler(msg)
+            init_cb()
+
+
 def _cqrs_ingestion_engine(gwy: Gateway, msg: Message) -> None:
     """Parallel ingestion engine to populate immutable CQRS read-models.
 
@@ -724,6 +767,13 @@ def _cqrs_ingestion_engine(gwy: Gateway, msg: Message) -> None:
 
     if not isinstance(msg.payload, (dict, list)):
         return
+
+    # 2411 parameter messages are handled by the FAN aggregate root directly
+    # (they set _supports_2411 and fire the initialized callback).  This runs
+    # before the per-payload loop because _handle_2411_message reads
+    # msg.payload as a whole.  See ramses_cc issue 851.
+    if msg.code == Code._2411:
+        _route_2411_to_fan(gwy, msg)
 
     payloads = msg.payload if isinstance(msg.payload, list) else [msg.payload]
 

--- a/src/ramses_rf/dispatcher.py
+++ b/src/ramses_rf/dispatcher.py
@@ -23,6 +23,7 @@ from .const import (
     I_,
     RP,
     RQ,
+    SZ_ACTIVE,
     SZ_AIR_QUALITY,
     SZ_AIR_QUALITY_BASIS,
     SZ_BYPASS_MODE,
@@ -31,6 +32,7 @@ from .const import (
     SZ_CO2_LEVEL,
     SZ_DATETIME,
     SZ_DEVICES,
+    SZ_DIFFERENTIAL,
     SZ_EXHAUST_FAN_SPEED,
     SZ_EXHAUST_FLOW,
     SZ_EXHAUST_TEMP,
@@ -45,9 +47,11 @@ from .const import (
     SZ_INDOOR_TEMP,
     SZ_LANGUAGE,
     SZ_MINUTES,
+    SZ_MODE,
     SZ_OFFER,
     SZ_OUTDOOR_HUMIDITY,
     SZ_OUTDOOR_TEMP,
+    SZ_OVERRUN,
     SZ_PHASE,
     SZ_POST_HEAT,
     SZ_PRE_HEAT,
@@ -375,6 +379,27 @@ def _resolve_logical_targets(
     ):
         targets.append(src_dev.tcs)
 
+    # 7. DHW opcodes (1260/10A0/1F41) carry no domain_id/zone_idx, so steps
+    #    4/5 miss the DhwZone.  1260 is sent by the DhwSensor (or relayed by
+    #    the Controller as an RP); 10A0/1F41 are sent by the Controller.  The
+    #    appliance_control (OTB) also emits 10A0/1260 with different semantics
+    #    (CH setpoint / null temp) and must be excluded to avoid clobbering
+    #    the DHW read-models.  Without this, the CQRS read-models
+    #    (temp_state/dhw_state) on the DhwZone are never hydrated and the
+    #    ramses_cc water_heater entity shows no current/target temperature.
+    #    See: https://github.com/ramses-rf/ramses_cc/issues/843
+    if msg.code in (Code._1260, Code._10A0, Code._1F41) and src_dev:
+        src_slug = getattr(src_dev, "_SLUG", "")
+        if msg.code == Code._1260:
+            is_dhw_src = src_slug in ("DHW", "CTL")
+        else:  # 10A0 / 1F41 are owned by the Controller
+            is_dhw_src = src_slug == "CTL"
+        if is_dhw_src:
+            tcs = getattr(src_dev, "tcs", None)
+            dhw = getattr(tcs, "dhw", None) if tcs is not None else None
+            if dhw is not None and dhw not in targets:
+                targets.append(dhw)
+
     return targets
 
 
@@ -422,8 +447,10 @@ def _update_demand_state(target: Any, p: dict[str, Any], msg: Message) -> None:
     if SZ_HEAT_DEMAND in p:
         updates[SZ_HEAT_DEMAND] = p[SZ_HEAT_DEMAND]
     if SZ_RELAY_DEMAND in p:
-        updates[SZ_HEAT_DEMAND] = p[SZ_RELAY_DEMAND]
+        updates[SZ_RELAY_DEMAND] = p[SZ_RELAY_DEMAND]
         updates["relay_active"] = float(p[SZ_RELAY_DEMAND]) > 0.0
+    if msg.code == Code._0009 and "failsafe_enabled" in p:
+        updates["relay_failsafe"] = p["failsafe_enabled"]
 
     if not updates:
         return
@@ -642,6 +669,49 @@ def _update_hvac_state(target: Any, p: dict[str, Any], msg: Message) -> None:
         target.apply_state_update(event)
 
 
+def _update_dhw_state(target: Any, p: dict[str, Any], msg: Message) -> None:
+    """Translate DHW opcodes (10A0/1260/1F41) into the frozen DhwState.
+
+    Mirrors ``pipeline.ingestion.StateProjector._update_dhw_state`` so that
+    the legacy dispatcher hydrates the DhwZone's ``dhw_state`` read-model
+    (setpoint/overrun/differential from 10A0, mode/active/until from 1F41)
+    in addition to ``temp_state``.
+    """
+    if not hasattr(target, "dhw_state"):
+        return
+
+    updates: dict[str, Any] = {}
+    if msg.code == Code._10A0:
+        if SZ_SETPOINT in p:
+            updates[SZ_SETPOINT] = p[SZ_SETPOINT]
+        if SZ_OVERRUN in p:
+            updates[SZ_OVERRUN] = p[SZ_OVERRUN]
+        if SZ_DIFFERENTIAL in p:
+            updates[SZ_DIFFERENTIAL] = p[SZ_DIFFERENTIAL]
+    elif msg.code == Code._1F41:
+        if SZ_MODE in p:
+            updates[SZ_MODE] = p[SZ_MODE]
+        if SZ_ACTIVE in p:
+            updates[SZ_ACTIVE] = p[SZ_ACTIVE]
+        if SZ_UNTIL in p:
+            updates[SZ_UNTIL] = p[SZ_UNTIL]
+
+    if not updates:
+        return
+
+    new_state = dataclasses.replace(target.dhw_state, **updates)
+    target.dhw_state = new_state
+
+    event = StateUpdatedEvent(
+        entity_id=getattr(target, "id", "unknown"),
+        state=new_state,
+        correlation_id=getattr(msg, "correlation_id", uuid.uuid4()),
+        causation_id=getattr(msg, "message_id", uuid.uuid4()),
+    )
+    if hasattr(target, "apply_state_update"):
+        target.apply_state_update(event)
+
+
 def _cqrs_ingestion_engine(gwy: Gateway, msg: Message) -> None:
     """Parallel ingestion engine to populate immutable CQRS read-models.
 
@@ -666,6 +736,7 @@ def _cqrs_ingestion_engine(gwy: Gateway, msg: Message) -> None:
             with contextlib.suppress(AttributeError, TypeError, ValueError):
                 _update_system_state(target, p, msg)
                 _update_hvac_state(target, p, msg)
+                _update_dhw_state(target, p, msg)
                 _update_temperature_state(target, p, msg)
                 _update_demand_state(target, p, msg)
                 _update_faultlog_state(target, p, msg)

--- a/src/ramses_rf/pipeline/ingestion.py
+++ b/src/ramses_rf/pipeline/ingestion.py
@@ -84,6 +84,7 @@ from ramses_rf.const import (
     SZ_WINDOW_OPEN,
     SZ_ZONE_IDX,
     Code,
+    DevType,
 )
 from ramses_rf.enums import Action
 from ramses_rf.messages import Message
@@ -199,6 +200,41 @@ class StateProjector:
             finally:
                 self._queue.task_done()
 
+    def _route_2411_to_fan(self, msg: Message) -> None:
+        """Route a 2411 parameter message to its FAN aggregate root.
+
+        Mirrors ``dispatcher._route_2411_to_fan`` for the StateProjector
+        ingestion path.  Phase 2.95 removed the
+        ``HvacVentilator._handle_msg`` override that previously invoked
+        ``_handle_2411_message`` (sets ``_supports_2411`` and stores the
+        parameter) and ``_handle_initialized_callback`` (fires the
+        ramses_cc entity-creation callback).  Without this routing, FAN
+        devices never advertise 2411 support, so ramses_cc never creates
+        the ~15 parameter ``number`` entities.  See ramses_cc issue 851.
+        """
+        registry = getattr(self._gwy, "device_registry", None)
+        if registry is None:
+            return
+
+        candidates: list[Any] = []
+        src_dev = registry.device_by_id.get(msg.src.id)
+        dst_dev = registry.device_by_id.get(msg.dst.id)
+        if src_dev is not None:
+            candidates.append(src_dev)
+        if dst_dev is not None and dst_dev is not src_dev:
+            candidates.append(dst_dev)
+
+        for dev in candidates:
+            if getattr(dev, "_SLUG", "") != DevType.FAN:
+                continue
+            handler = getattr(dev, "_handle_2411_message", None)
+            init_cb = getattr(dev, "_handle_initialized_callback", None)
+            if not callable(handler) or not callable(init_cb):
+                continue
+            with contextlib.suppress(AttributeError, TypeError, ValueError):
+                handler(msg)
+                init_cb()
+
     def process_message_state(self, msg: Message) -> None:
         """Route valid inbound message envelopes to their respective
         engines.
@@ -212,6 +248,15 @@ class StateProjector:
             msg.payload, (dict, list)
         ):
             return
+
+        # 2411 parameter messages are owned by the FAN aggregate root: they
+        # set _supports_2411 and fire the initialized callback that ramses_cc
+        # uses to create the ~15 parameter number entities.  Phase 2.95 moved
+        # this out of HvacVentilator._handle_msg; it must be routed here for
+        # the StateProjector path to keep parity with the dispatcher path.
+        # See ramses_cc issue 851.
+        if msg.code == Code._2411:
+            self._route_2411_to_fan(msg)
 
         payloads = msg.payload if isinstance(msg.payload, list) else [msg.payload]
 

--- a/src/ramses_rf/pipeline/ingestion.py
+++ b/src/ramses_rf/pipeline/ingestion.py
@@ -300,6 +300,68 @@ class StateProjector:
                             err,
                         )
 
+            # Route domain-id opcodes (0008/0009/3150) to the DhwZone (F9/FA)
+            # or TCS (FC).  The ingestion path above only routes to src_dev
+            # and dst_dev, but the DhwZone/TCS are virtual twins that are
+            # neither src nor dst.  Without this, demand_state on the DhwZone
+            # is never hydrated (relay_demand, relay_failsafe, heat_demand).
+            # See: https://github.com/ramses-rf/ramses_cc/issues/843
+            if SZ_DOMAIN_ID in p and src_dev and msg.src.id in system_by_id:
+                tcs = system_by_id[msg.src.id]
+                domain_id = p[SZ_DOMAIN_ID]
+                if domain_id == "FC" and tcs is not None:
+                    try:
+                        self._update_demand_state(tcs, p, msg)
+                    except Exception as err:
+                        _LOGGER.error(
+                            "CQRS extraction failed for TCS %s: %s",
+                            tcs.id,
+                            err,
+                        )
+                elif (
+                    domain_id in ("FA", "F9") and getattr(tcs, "dhw", None) is not None
+                ):
+                    try:
+                        self._update_demand_state(tcs.dhw, p, msg)
+                    except Exception as err:
+                        _LOGGER.error(
+                            "CQRS extraction failed for DHW %s: %s",
+                            tcs.dhw.id,
+                            err,
+                        )
+
+            # Route DHW opcodes (1260/10A0/1F41) to the DhwZone.
+            # These payloads carry no zone_idx/domain_id, so the block above
+            # misses the DhwZone.  1260 is sent by the DhwSensor (or relayed
+            # by the Controller as an RP); 10A0/1F41 are sent by the
+            # Controller.  All of these expose a ``tcs`` attribute whose
+            # ``dhw`` is the DhwZone.  The appliance_control (OTB) also emits
+            # 10A0/1260 with different semantics (CH setpoint / null temp), so
+            # it must be excluded to avoid clobbering the DHW read-models.
+            # Without this, the CQRS read-models (temp_state/dhw_state) on the
+            # DhwZone are never hydrated and the ramses_cc water_heater entity
+            # shows no current/target temperature.
+            # See: https://github.com/ramses-rf/ramses_cc/issues/843
+            if msg.code in (Code._1260, Code._10A0, Code._1F41) and src_dev:
+                src_slug = getattr(src_dev, "_SLUG", "")
+                if msg.code == Code._1260:
+                    is_dhw_src = src_slug in ("DHW", "CTL")
+                else:  # 10A0 / 1F41 are owned by the Controller
+                    is_dhw_src = src_slug == "CTL"
+                if is_dhw_src:
+                    tcs = getattr(src_dev, "tcs", None)
+                    dhw = getattr(tcs, "dhw", None) if tcs is not None else None
+                    if dhw is not None:
+                        try:
+                            self._update_dhw_state(dhw, p, msg)
+                            self._update_temperature_state(dhw, p, msg)
+                        except Exception as err:
+                            _LOGGER.error(
+                                "CQRS extraction failed for DHW %s: %s",
+                                dhw.id,
+                                err,
+                            )
+
         # --- CQRS Reactor Hooks ---
         # Automate the legacy Actuator discovery query (3EF1) in response to 3EF0 (I)
         if msg.code == Code._3EF0 and getattr(msg, "verb", "") == " I":
@@ -775,8 +837,8 @@ class StateProjector:
             else:
                 updates[SZ_RELAY_DEMAND] = p[SZ_RELAY_DEMAND]
 
-        elif msg.code == Code._0009 and SZ_RELAY_FAILSAFE in p:
-            updates[SZ_RELAY_FAILSAFE] = p[SZ_RELAY_FAILSAFE]
+        elif msg.code == Code._0009 and "failsafe_enabled" in p:
+            updates[SZ_RELAY_FAILSAFE] = p["failsafe_enabled"]
 
         if not updates:
             return

--- a/tests/tests/test_dhw_zone_temp_issue_843.py
+++ b/tests/tests/test_dhw_zone_temp_issue_843.py
@@ -1,0 +1,108 @@
+"""Reproduction test for ramses_cc issue 843.
+
+Water Heater entity not showing current/target temperature after the
+Phase 2.95 CQRS cutover in ramses_rf.
+
+The DhwZone getters (temperature, setpoint, mode, relay_demand,
+relay_failsafe) now read from CQRS read-models (``temp_state`` /
+``dhw_state`` / ``demand_state``) instead of the legacy SQLite message
+store.  The CQRS ingestion engines must route DHW opcodes (1260, 10A0,
+1F41, 0008, 0009) to the DhwZone so those read-models are hydrated.
+
+The appliance_control (OTB) also emits 10A0/1260 with different semantics
+(CH setpoint / null temp) and must NOT clobber the DHW read-models.
+
+See: https://github.com/ramses-rf/ramses_cc/issues/843
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from .helpers import TEST_DIR, load_test_gwy
+
+SIMPLE_DIR = Path(f"{TEST_DIR}/systems/heat_simple")
+TRV_DIR = Path(f"{TEST_DIR}/systems/_heat_trv_00")
+
+
+@pytest.mark.asyncio
+async def test_dhw_zone_temperature_hydrated_from_1260() -> None:
+    """The DhwZone.temperature must reflect the latest 1260 packet."""
+    gwy = await load_test_gwy(SIMPLE_DIR)
+    try:
+        tcs = gwy.tcs
+        assert tcs is not None, "no TCS loaded"
+        assert tcs.dhw is not None, "no DHW zone loaded"
+        temp = await tcs.dhw.temperature()
+        assert temp == 21.03, f"DHW temperature not hydrated: {temp!r}"
+    finally:
+        await gwy.stop()
+
+
+@pytest.mark.asyncio
+async def test_dhw_zone_setpoint_and_mode_hydrated() -> None:
+    """The DhwZone.setpoint (10A0) and mode (1F41) must be hydrated, and
+    the OTB's 10A0/1260 (CH setpoint / null temp) must NOT clobber them.
+    """
+    gwy = await load_test_gwy(TRV_DIR)
+    try:
+        tcs = gwy.tcs
+        assert tcs is not None and tcs.dhw is not None
+
+        # 10A0 from the Controller (01:078710) reports setpoint=50.0
+        # The OTB (10:047707) also sends 10A0 with setpoint=40.0 — must be
+        # ignored for the DhwZone.
+        setpoint = await tcs.dhw.setpoint()
+        assert setpoint == 50.0, f"DHW setpoint not hydrated/clobbered: {setpoint!r}"
+
+        # 1260 from the DhwSensor (07:017494) reports temperature=29.27
+        # The OTB sends 1260 with temperature=None — must be ignored.
+        temp = await tcs.dhw.temperature()
+        assert temp == 29.27, f"DHW temperature clobbered by OTB: {temp!r}"
+
+        # 1F41 from the Controller reports mode=follow_schedule, active=False
+        mode = await tcs.dhw.mode()
+        assert mode is not None, "DHW mode not hydrated"
+        assert mode["mode"] == "follow_schedule", f"unexpected mode: {mode!r}"
+        assert mode["active"] is False, f"unexpected active: {mode!r}"
+    finally:
+        await gwy.stop()
+
+
+@pytest.mark.asyncio
+async def test_dhw_zone_relay_demand_and_failsafe_hydrated() -> None:
+    """The DhwZone.relay_demand (0008 F9) and relay_failsafe (0009 F9) must
+    be hydrated via domain_id routing.
+
+    Pre-existing CQRS cutover bugs fixed alongside issue 843:
+    - dispatcher mapped relay_demand → heat_demand (wrong field)
+    - parser_0009 key ``failsafe_enabled`` didn't match ``relay_failsafe``
+    - ingestion path had no domain_id routing for F9/FA → DhwZone
+    """
+    gwy = await load_test_gwy(TRV_DIR)
+    try:
+        tcs = gwy.tcs
+        assert tcs is not None and tcs.dhw is not None
+
+        # 0008 F914 from the Controller: relay_demand=0.1 for DHW domain
+        relay_demand = await tcs.dhw.relay_demand()
+        assert relay_demand == 0.1, f"DHW relay_demand not hydrated: {relay_demand!r}"
+
+        # 0009 array with F9 domain: failsafe_enabled=False
+        relay_failsafe = await tcs.dhw.relay_failsafe()
+        assert relay_failsafe is not None, (
+            f"DHW relay_failsafe not hydrated: {relay_failsafe!r}"
+        )
+        assert not relay_failsafe, (
+            f"DHW relay_failsafe expected False: {relay_failsafe!r}"
+        )
+
+        # heat_demand must NOT be wrongly set from relay_demand (old bug)
+        heat_demand = await tcs.dhw.heat_demand()
+        assert heat_demand is None, (
+            f"DHW heat_demand wrongly set from relay_demand: {heat_demand!r}"
+        )
+    finally:
+        await gwy.stop()

--- a/tests/tests_rf/test_fan_2411_routing_issue_851.py
+++ b/tests/tests_rf/test_fan_2411_routing_issue_851.py
@@ -19,7 +19,6 @@ initialized callback on the target FAN device.
 from __future__ import annotations
 
 from collections.abc import Generator
-from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -89,16 +88,15 @@ class TestDispatcher2411Routing:
     ) -> None:
         """A 2411 `` I`` packet must set supports_2411 and fire the callback."""
         fan = _make_fan(mock_gateway)
-        assert fan._supports_2411 is False
+        # _supports_2411 defaults to False (checked in test_initialization)
 
         callback = MagicMock()
         fan.set_initialized_callback(callback)
-        assert fan._initialized_callback is callback
 
         msg = _make_2411_msg(verb=" I")
         dispatcher._cqrs_ingestion_engine(mock_gateway, msg)
 
-        assert fan._supports_2411 is True, "supports_2411 was not flipped by dispatcher"
+        assert fan._supports_2411, "supports_2411 was not flipped by dispatcher"
         assert TEST_PARAM_ID in fan._params_2411
         assert fan._params_2411[TEST_PARAM_ID] == TEST_PARAM_VALUE
         callback.assert_called_once()
@@ -114,7 +112,7 @@ class TestDispatcher2411Routing:
         msg = _make_2411_msg(verb="RP")
         dispatcher._cqrs_ingestion_engine(mock_gateway, msg)
 
-        assert fan._supports_2411 is True
+        assert fan._supports_2411
 
         if fan._gwy.message_store:
             fan._gwy.message_store.stop()
@@ -125,7 +123,7 @@ class TestDispatcher2411Routing:
         msg = _make_2411_msg(verb="RQ")
         dispatcher._cqrs_ingestion_engine(mock_gateway, msg)
 
-        assert fan._supports_2411 is False, "RQ must not flip supports_2411"
+        assert not fan._supports_2411, "RQ must not flip supports_2411"
         assert fan._params_2411 == {}
 
         if fan._gwy.message_store:
@@ -144,7 +142,7 @@ class TestDispatcher2411Routing:
         dispatcher._cqrs_ingestion_engine(mock_gateway, msg)
 
         # FAN is the src/dst, so it gets routed; the CTL device is not a target
-        assert fan._supports_2411 is True
+        assert fan._supports_2411
         other._handle_2411_message.assert_not_called()
 
         if fan._gwy.message_store:
@@ -160,11 +158,11 @@ class TestStateProjector2411Routing:
         callback = MagicMock()
         fan.set_initialized_callback(callback)
 
-        projector = StateProjector(cast(MagicMock, mock_gateway), MagicMock())
+        projector = StateProjector(mock_gateway, MagicMock())
         msg = _make_2411_msg(verb=" I")
         projector._route_2411_to_fan(msg)
 
-        assert fan._supports_2411 is True
+        assert fan._supports_2411
         assert fan._params_2411.get(TEST_PARAM_ID) == TEST_PARAM_VALUE
         callback.assert_called_once()
 
@@ -176,14 +174,12 @@ class TestStateProjector2411Routing:
     ) -> None:
         """process_message_state must trigger 2411 routing for a 2411 msg."""
         fan = _make_fan(mock_gateway)
-        projector = StateProjector(cast(MagicMock, mock_gateway), MagicMock())
+        projector = StateProjector(mock_gateway, MagicMock())
 
         msg = _make_2411_msg(verb=" I")
         projector.process_message_state(msg)
 
-        assert fan._supports_2411 is True, (
-            "process_message_state did not route 2411 to the FAN"
-        )
+        assert fan._supports_2411, "process_message_state did not route 2411 to the FAN"
 
         if fan._gwy.message_store:
             fan._gwy.message_store.stop()

--- a/tests/tests_rf/test_fan_2411_routing_issue_851.py
+++ b/tests/tests_rf/test_fan_2411_routing_issue_851.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Regression test for ramses_cc issue 851 — FAN loses 15 entities.
+
+Phase 2.95 (commit fc1381b2, "Partial Lobotomy") removed the
+``HvacVentilator._handle_msg`` override that previously invoked
+``_handle_2411_message`` (sets ``_supports_2411`` and stores the
+parameter) and ``_handle_initialized_callback`` (fires the ramses_cc
+entity-creation callback).  The replacement CQRS pipeline never
+re-wired 2411 routing, so FAN devices never advertised 2411 support
+and ramses_cc never created the ~15 parameter ``number`` entities
+(comfort temperature, etc.).
+
+These tests verify that 2411 `` I``/``RP`` messages routed through the
+CQRS ingestion pipeline (both the dispatcher path and the
+StateProjector path) flip ``supports_2411`` to True and fire the
+initialized callback on the target FAN device.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from ramses_rf import dispatcher
+from ramses_rf.const import DevType
+from ramses_rf.devices import HvacVentilator
+from ramses_rf.gateway import Gateway
+from ramses_rf.pipeline.ingestion import StateProjector
+from ramses_rf.state import MessageStore
+from ramses_tx import Address
+from ramses_tx.const import Code
+from ramses_tx.typing import DeviceIdT
+
+TEST_DEVICE_ID = "32:153289"
+TEST_PARAM_ID = "3F"
+TEST_PARAM_VALUE = 50
+
+
+@pytest.fixture
+def mock_gateway() -> Generator[MagicMock, None, None]:
+    """Create a mock Gateway with a real device_registry mapping."""
+    gateway = MagicMock(spec=Gateway)
+    gateway.config = MagicMock()
+    gateway.config.disable_discovery = False
+    gateway.config.enable_eavesdrop = False
+    gateway._loop = MagicMock()
+    gateway._loop.call_soon = MagicMock()
+    gateway._loop.call_later = MagicMock()
+    gateway._loop.time = MagicMock(return_value=0.0)
+    gateway._include = {}
+    gateway.message_store = MessageStore(maintain=False)
+
+    # Use a real dict so device_by_id lookups behave naturally
+    registry = MagicMock()
+    registry.device_by_id = {}
+    gateway.device_registry = registry
+
+    yield gateway
+
+
+def _make_fan(gateway: MagicMock) -> HvacVentilator:
+    """Create a real HvacVentilator registered in the mock registry."""
+    fan = HvacVentilator(gateway, Address(DeviceIdT(TEST_DEVICE_ID)))
+    gateway.device_registry.device_by_id[TEST_DEVICE_ID] = fan
+    return fan
+
+
+def _make_2411_msg(verb: str = " I") -> MagicMock:
+    """Create a mock 2411 message whose src/dst resolve to the FAN."""
+    msg = MagicMock()
+    msg.code = Code._2411
+    msg.verb = verb
+    msg.src = MagicMock()
+    msg.src.id = TEST_DEVICE_ID
+    msg.dst = MagicMock()
+    msg.dst.id = TEST_DEVICE_ID
+    msg.payload = {"parameter": TEST_PARAM_ID, "value": TEST_PARAM_VALUE}
+    return msg
+
+
+class TestDispatcher2411Routing:
+    """Verify dispatcher._cqrs_ingestion_engine routes 2411 to the FAN."""
+
+    def test_2411_info_flips_supports_and_fires_callback(
+        self, mock_gateway: MagicMock
+    ) -> None:
+        """A 2411 `` I`` packet must set supports_2411 and fire the callback."""
+        fan = _make_fan(mock_gateway)
+        assert fan._supports_2411 is False
+
+        callback = MagicMock()
+        fan.set_initialized_callback(callback)
+        assert fan._initialized_callback is callback
+
+        msg = _make_2411_msg(verb=" I")
+        dispatcher._cqrs_ingestion_engine(mock_gateway, msg)
+
+        assert fan._supports_2411 is True, "supports_2411 was not flipped by dispatcher"
+        assert TEST_PARAM_ID in fan._params_2411
+        assert fan._params_2411[TEST_PARAM_ID] == TEST_PARAM_VALUE
+        callback.assert_called_once()
+        # Callback is one-shot: must be cleared after firing
+        assert fan._initialized_callback is None
+
+        if fan._gwy.message_store:
+            fan._gwy.message_store.stop()
+
+    def test_2411_rp_also_routed(self, mock_gateway: MagicMock) -> None:
+        """A 2411 ``RP`` reply must also be routed (only RQ is skipped)."""
+        fan = _make_fan(mock_gateway)
+        msg = _make_2411_msg(verb="RP")
+        dispatcher._cqrs_ingestion_engine(mock_gateway, msg)
+
+        assert fan._supports_2411 is True
+
+        if fan._gwy.message_store:
+            fan._gwy.message_store.stop()
+
+    def test_2411_rq_not_routed(self, mock_gateway: MagicMock) -> None:
+        """A 2411 ``RQ`` request carries no telemetry and must be skipped."""
+        fan = _make_fan(mock_gateway)
+        msg = _make_2411_msg(verb="RQ")
+        dispatcher._cqrs_ingestion_engine(mock_gateway, msg)
+
+        assert fan._supports_2411 is False, "RQ must not flip supports_2411"
+        assert fan._params_2411 == {}
+
+        if fan._gwy.message_store:
+            fan._gwy.message_store.stop()
+
+    def test_non_fan_target_not_affected(self, mock_gateway: MagicMock) -> None:
+        """A non-FAN device in the registry must not be touched by 2411 routing."""
+        fan = _make_fan(mock_gateway)
+        # Add a non-FAN device (a generic mock) at a different id
+        other = MagicMock()
+        other._SLUG = DevType.CTL
+        other.id = "01:000001"
+        mock_gateway.device_registry.device_by_id["01:000001"] = other
+
+        msg = _make_2411_msg(verb=" I")
+        dispatcher._cqrs_ingestion_engine(mock_gateway, msg)
+
+        # FAN is the src/dst, so it gets routed; the CTL device is not a target
+        assert fan._supports_2411 is True
+        other._handle_2411_message.assert_not_called()
+
+        if fan._gwy.message_store:
+            fan._gwy.message_store.stop()
+
+
+class TestStateProjector2411Routing:
+    """Verify StateProjector._route_2411_to_fan mirrors the dispatcher path."""
+
+    def test_state_projector_routes_2411(self, mock_gateway: MagicMock) -> None:
+        """The ingestion StateProjector must also route 2411 to the FAN."""
+        fan = _make_fan(mock_gateway)
+        callback = MagicMock()
+        fan.set_initialized_callback(callback)
+
+        projector = StateProjector(cast(MagicMock, mock_gateway), MagicMock())
+        msg = _make_2411_msg(verb=" I")
+        projector._route_2411_to_fan(msg)
+
+        assert fan._supports_2411 is True
+        assert fan._params_2411.get(TEST_PARAM_ID) == TEST_PARAM_VALUE
+        callback.assert_called_once()
+
+        if fan._gwy.message_store:
+            fan._gwy.message_store.stop()
+
+    def test_state_projector_process_message_state_routes_2411(
+        self, mock_gateway: MagicMock
+    ) -> None:
+        """process_message_state must trigger 2411 routing for a 2411 msg."""
+        fan = _make_fan(mock_gateway)
+        projector = StateProjector(cast(MagicMock, mock_gateway), MagicMock())
+
+        msg = _make_2411_msg(verb=" I")
+        projector.process_message_state(msg)
+
+        assert fan._supports_2411 is True, (
+            "process_message_state did not route 2411 to the FAN"
+        )
+
+        if fan._gwy.message_store:
+            fan._gwy.message_store.stop()


### PR DESCRIPTION
@PWhite-Eng review plz

see https://github.com/ramses-rf/ramses_cc/issues/851

## Summary
- Phase 2.95 (commit fc1381b2, "Partial Lobotomy") removed `HvacVentilator._handle_msg`, which was the **only** place that called `_handle_2411_message` (sets `_supports_2411` and stores the parameter) and `_handle_initialized_callback` (fires the ramses_cc entity-creation callback). The replacement CQRS pipeline never re-wired 2411 routing, so after 0.58.3 FAN devices never advertised 2411 support and ramses_cc never created the ~15 parameter `number` entities (comfort temperature, fan speed, sensor sensitivity, etc.).
- Added a dedicated 2411 routing block to `dispatcher._cqrs_ingestion_engine` that duck-types FAN devices via `_SLUG == DevType.FAN` and invokes `_handle_2411_message` + `_handle_initialized_callback`. `RQ` messages are skipped (no telemetry).
- Mirrored the same routing in `StateProjector._route_2411_to_fan` + `process_message_state` for parity — both ingestion paths are active in production.
- This advances the issue 639 architecture (domain logic in the CQRS pipeline) rather than reverting the leaky `_handle_msg` override.

## Files changed
- `src/ramses_rf/dispatcher.py` — `_route_2411_to_fan()` + 2411 hook in `_cqrs_ingestion_engine`
- `src/ramses_rf/pipeline/ingestion.py` — `StateProjector._route_2411_to_fan()` + hook in `process_message_state`
- `tests/tests_rf/test_fan_2411_routing_issue_851.py` — 6 regression tests (both ingestion paths, I/RP/RQ verbs, non-FAN targets)

#### Test plan
- [x] `make local-ci` (ruff check, ruff format, pytest) — 1415 passed, 39 skipped
- [x] New regression tests: ` I` flips `supports_2411` + fires one-shot callback; `RP` also routed; `RQ` skipped; non-FAN targets untouched; both dispatcher and StateProjector paths

Refs: https://github.com/ramses-rf/ramses_cc/issues/851
