### PR TITLE
chore(config): Ignore pydocstyle rules for test files in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -325,7 +325,7 @@
 
 
 [tool.ruff.lint.per-file-ignores]
-  "tests/*" = ["ASYNC"]
+  "tests/*" = ["ASYNC", "D"]
 
 [tool.importlinter]
 root_packages = [


### PR DESCRIPTION
### The Problem:
If we enforce pydocstyle (the `D` rules via ruff) for strictly formatted docstrings on python files, the rules currently apply to the `tests/` directory as well. This will cause failures in CI/CD and pre-commits for tests because we exempt test files from formal docstrings.

### Consequences:
If we do not exempt the tests directory from this configuration, developers (or agents) running `ruff check --select D` will be spammed with errors about missing docstrings in test methods, potentially failing builds.

### The Fix:
Added `"D"` to the `[tool.ruff.lint.per-file-ignores]` list specifically for `"tests/*"` in `pyproject.toml`.
*(Note: This PR does **not** automatically enable or force `ruff check --select D` to run globally. It only ensures that when it **is** run, it safely ignores test files).*

### Technical Implementation:
Appended `"D"` to the ignored rules alongside `"ASYNC"` in `pyproject.toml`.

### Testing Performed:
Manually verified the `pyproject.toml` syntax and ensuring it aligns with ruff's configuration standards.

### Risks of NOT Implementing:
If developers or agents begin verifying docstrings using `ruff check --select D` (if instructed in `AGENTS.md`), they will receive false positives in the test suite.

### Risks of Implementing:
None. This is purely a safeguard configuration.

### Mitigation Steps:
N/A.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. All logic and implementations were reviewed and verified by the author.
