### PR TITLE
fix: normalize verb in CommandDTO.__str__ and Engine.create_cmd (issu…

### DIFF
--- a/src/ramses_tx/dtos.py
+++ b/src/ramses_tx/dtos.py
@@ -81,9 +81,17 @@ class CommandDTO:
     num_repeats: int = 1
 
     def __str__(self) -> str:
-        """Return the string representation of the frame to be transmitted."""
+        """Return the string representation of the frame to be transmitted.
+
+        The verb is stripped and right-justified to 2 characters to match the
+        RF protocol format expected by the HGI80 (e.g. ``" W"`` not ``"W"``).
+        Without this normalisation, verbs passed as plain strings (e.g. from
+        the ramses_cc send_packet service) produce malformed frames that the
+        HGI80 silently drops — no echo, causing a 20s QoS timeout.
+        """
+        verb = f"{str(self.verb).strip():>2}"
         return (
-            f"{self.verb} --- {self.addr1} {self.addr2} {self.addr3} {self.code} "
+            f"{verb} --- {self.addr1} {self.addr2} {self.addr3} {self.code} "
             f"{int(len(self.payload) / 2):03d} {self.payload}"
         )
 

--- a/src/ramses_tx/engine.py
+++ b/src/ramses_tx/engine.py
@@ -19,9 +19,12 @@ from .const import (
     DEFAULT_NUM_REPEATS,
     DEFAULT_SEND_TIMEOUT,
     DEFAULT_WAIT_FOR_REPLY,
+    I_,
     SZ_ACTIVE_HGI,
+    W_,
     Code,
     Priority,
+    VerbT,
 )
 from .dtos import CommandDTO, PacketDTO
 from .packet import Packet
@@ -332,6 +335,12 @@ class Engine:
         from_id: str | None = None,
         seqn: str | None = None,
     ) -> CommandDTO:
+        # Normalise plain-string verbs to VerbT so that the frame is formatted
+        # correctly (e.g. "W" → " W").  The old Command._from_attrs did this;
+        # the migration to CommandDTO dropped it, causing malformed frames
+        # that the HGI80 silently drops (issue 835).
+        verb = I_ if verb == "I" else W_ if verb == "W" else verb
+
         addr1 = from_id or HGI_DEV_ADDR.id
 
         if device_id == addr1:

--- a/src/ramses_tx/protocol/fsm.py
+++ b/src/ramses_tx/protocol/fsm.py
@@ -557,7 +557,6 @@ class WantEcho(ProtocolStateBase):
         else:
             pkt__hdr = pkt_hdr
 
-        print(f"DEBUG: pkt__hdr={pkt__hdr!r} tx_header={self._sent_cmd.tx_header!r}")
         if pkt__hdr != self._sent_cmd.tx_header:
             return
 


### PR DESCRIPTION
…e 835)

The Command architecture migration (commit 2a86a4833) dropped the verb normalisation that the old Command._from_attrs did:

    verb = I_ if verb == "I" else W_ if verb == "W" else verb

Without this, passing verb="W" (without leading space) — as the ramses_cc send_packet service allows — produces a malformed frame:

    W --- 18:002965 21:057310 --:------ 01FF 026 ...

The HGI80 expects 2-character right-justified verbs (" W"), so it silently drops the frame. No echo comes back, and the QoS FSM times out after 20 seconds:

    Send timed out for 01FF| W|21:057310:
    <ProtocolContext state=WantEcho ...>: Expired global timer after 20.0 sec

The QoS header (tx_header) was correct because Packet._from_cmd uses cmd.verb.strip():>2, but the actual frame sent to the HGI80 used CommandDTO.__str__ which did {self.verb} without normalisation.

Changes:
- CommandDTO.__str__: strip and right-justify the verb to 2 chars (mirrors Packet._from_cmd formatting)
- Engine.create_cmd: convert "I"/"W" to I_/W_ (VerbT) before passing to CommandDTO, restoring the old Command._from_attrs behaviour
- fsm.py: remove leftover debug print() in WantEcho.pkt_rcvd

https://github.com/ramses-rf/ramses_cc/issues/835

AI used: GLM 5.2 high
