### PR TITLE
refactor(transport): harden CallbackTransport and add Sphinx docstrings

### DIFF
--- a/src/ramses_tx/transport/callback.py
+++ b/src/ramses_tx/transport/callback.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
+from datetime import datetime as dt
 from typing import TYPE_CHECKING, Any
 
 from .. import exceptions as exc
@@ -28,7 +29,12 @@ class _CallbackTransportAbstractor:
 
 
 class CallbackTransport(_FullTransport, _CallbackTransportAbstractor):
-    """A virtual transport that delegates I/O to external callbacks."""
+    """A virtual transport that delegates I/O to external callbacks.
+
+    This transport provides an Inversion of Control (IoC) interface
+    designed for integrations such as Home Assistant, allowing external
+    services to inject inbound frames and handle outbound transmission.
+    """
 
     def __init__(
         self,
@@ -40,16 +46,28 @@ class CallbackTransport(_FullTransport, _CallbackTransportAbstractor):
         extra: dict[str, Any] | None = None,
         loop: asyncio.AbstractEventLoop | None = None,
     ) -> None:
-        """Initialize the callback transport."""
+        """Initialize the callback transport.
+
+        :param protocol: The RAMSES protocol bound to this transport.
+        :type protocol: RamsesProtocolT
+        :param io_writer: Async callback used to transmit outbound frames.
+        :type io_writer: Callable[[str], Awaitable[None]]
+        :param config: Extracted setup configuration for transports.
+        :type config: TransportConfig
+        :param extra: Additional configuration state dictionary, if any.
+        :type extra: dict[str, Any] | None
+        :param loop: Asyncio event loop instance, defaults to None.
+        :type loop: asyncio.AbstractEventLoop | None
+        """
         _CallbackTransportAbstractor.__init__(self, loop=loop)
         _FullTransport.__init__(self, config=config, extra=extra, loop=loop)
 
         self._protocol = protocol
-        self._io_writer = io_writer
+        self._io_writer: Callable[[str], Awaitable[None]] | None = io_writer
 
         self._reading = False
 
-        _LOGGER.info(f"CallbackTransport created with io_writer={io_writer}")
+        _LOGGER.info("CallbackTransport created with io_writer=%s", io_writer)
 
         self._protocol.connection_made(self, ramses=True)
 
@@ -57,16 +75,32 @@ class CallbackTransport(_FullTransport, _CallbackTransportAbstractor):
             self.resume_reading()
 
     async def write_frame(self, frame: str, disable_tx_limits: bool = False) -> None:
-        """Process a frame for transmission by passing it to the external writer."""
+        """Process a frame for transmission by passing it to external writer.
+
+        :param frame: The raw string frame to be transmitted.
+        :type frame: str
+        :param disable_tx_limits: Flag to bypass transmit rate limits.
+        :type disable_tx_limits: bool
+        :returns: None
+        :rtype: None
+        :raises exc.TransportError: If sending disabled or io_writer fails.
+        :raises asyncio.CancelledError: If the write task is cancelled.
+        """
         if self._disable_sending:
             raise exc.TransportError("Sending has been disabled")
 
-        _LOGGER.debug(f"Sending frame via external writer: {frame}")
+        if self._io_writer is None:
+            raise exc.TransportError("Transport has been closed")
+
+        _LOGGER.debug("Sending frame via external writer: %s", frame)
 
         try:
             await self._io_writer(frame)
+        except asyncio.CancelledError:
+            _LOGGER.debug("External writer task cancelled while sending frame")
+            raise
         except Exception as err:
-            _LOGGER.error(f"External writer failed to send frame: {err}")
+            _LOGGER.error("External writer failed to send frame: %s", err)
             raise exc.TransportError(f"External writer failed: {err}") from err
 
     async def _write_frame(self, frame: str) -> None:
@@ -74,19 +108,52 @@ class CallbackTransport(_FullTransport, _CallbackTransportAbstractor):
         await self.write_frame(frame)
 
     def receive_frame(self, frame: str, dtm: str | None = None) -> None:
-        """Ingest a frame from the external source (Read Path)."""
+        """Ingest a frame from the external source (Read Path).
+
+        :param frame: The raw string frame received from external source.
+        :type frame: str
+        :param dtm: Optional ISO timestamp string for the frame.
+        :type dtm: str | None
+        :returns: None
+        :rtype: None
+        """
         _LOGGER.debug(
-            f"Received frame from external source: frame={repr(frame)}, timestamp={dtm}"
+            "Received frame from external source: frame=%r, timestamp=%s",
+            frame,
+            dtm,
         )
 
         if not self._reading:
-            _LOGGER.debug(f"Dropping received frame (transport paused): {repr(frame)}")
+            _LOGGER.debug("Dropping received frame (transport paused): %r", frame)
             return
 
-        dtm = dtm or dt_now().isoformat()
+        if dtm:
+            try:
+                dt.fromisoformat(dtm)
+            except (ValueError, TypeError):
+                _LOGGER.warning(
+                    "Invalid ISO timestamp format (%r), using current time",
+                    dtm,
+                )
+                dtm = dt_now().isoformat()
+        else:
+            dtm = dt_now().isoformat()
 
         _LOGGER.debug(
-            f"Ingesting frame into transport: frame={repr(frame)}, timestamp={dtm}"
+            "Ingesting frame into transport: frame=%r, timestamp=%s",
+            frame,
+            dtm,
         )
 
-        self._frame_read(dtm, frame.rstrip())
+        try:
+            self._frame_read(dtm, frame.rstrip())
+        except exc.TransportError as err:
+            _LOGGER.warning("Transport error processing received frame: %s", err)
+        except Exception as err:
+            _LOGGER.warning("Error processing received frame (%r): %s", frame, err)
+
+    def _close(self, exc: exc.RamsesException | None = None) -> None:
+        """Close the transport and unbind callbacks."""
+        super()._close(exc)
+        self._reading = False
+        self._io_writer = None

--- a/tests/test_ha_mqtt/test_transport_callback.py
+++ b/tests/test_ha_mqtt/test_transport_callback.py
@@ -143,3 +143,56 @@ class TestCallbackTransport(unittest.IsolatedAsyncioTestCase):
             self.fail(f"Test failed: {err}")
         finally:
             await gwy.stop()
+
+    async def test_write_frame_propagates_asyncio_cancelled_error(self) -> None:
+        """Verify asyncio.CancelledError is re-raised during task cancellation."""
+        # Arrange
+        self.mock_writer.side_effect = asyncio.CancelledError()
+
+        # Act & Assert
+        with self.assertRaises(asyncio.CancelledError):
+            await self.transport.write_frame("test_frame")
+
+    async def test_receive_frame_handles_malformed_packets_gracefully(self) -> None:
+        """Verify malformed inbound packets do not raise unhandled exceptions."""
+        # Arrange
+        self.transport.resume_reading()
+
+        # Act & Assert (invalid hex string should log warning inside _frame_read and not raise)
+        try:
+            self.transport.receive_frame("INVALID_HEX_STRING")
+            await asyncio.sleep(0)
+        except Exception as err:
+            self.fail(
+                f"receive_frame raised unhandled exception on malformed packet: {err}"
+            )
+
+    async def test_receive_frame_validates_iso_timestamp(self) -> None:
+        """Verify invalid ISO timestamps fallback to current system time."""
+        # Arrange
+        self.transport.resume_reading()
+        invalid_timestamp = "NOT-A-VALID-TIMESTAMP"
+        valid_frame = (
+            "059 RP --- 01:195932 04:017982 --:------ 313F 009 00FC2300C4150C07E9"
+        )
+
+        # Act
+        self.transport.receive_frame(valid_frame, dtm=invalid_timestamp)
+        await asyncio.sleep(0)
+
+        # Assert
+        self.assertEqual(self.mock_protocol.pkt_received.call_count, 1)
+
+    async def test_callback_transport_teardown_cleans_up_writer(self) -> None:
+        """Verify _close resets state and clears io_writer reference."""
+        # Arrange
+        self.transport.resume_reading()
+        self.assertTrue(self.transport.is_reading())
+
+        # Act
+        self.transport.close()
+
+        # Assert
+        self.assertFalse(self.transport.is_reading())
+        with self.assertRaises(exc.TransportError):
+            await self.transport.write_frame("test_frame")


### PR DESCRIPTION
### The Problem:
`CallbackTransport` in `ramses_tx/transport/callback.py` lacked complete Sphinx-style docstrings and did not handle certain edge cases gracefully (e.g. malformed inbound frames causing uncaught exceptions in Home Assistant's MQTT message listener task, `asyncio.CancelledError` being caught as a generic `TransportError` instead of propagating, invalid ISO timestamp strings in `receive_frame`, and unbinding callbacks on transport `_close()`).

### Consequences:
Corrupt packets received over MQTT could crash Home Assistant's message listener task, task cancellations during integration reloads could be swallowed as transport errors, and missing Sphinx docstrings violated repository documentation rules.

### The Fix:
Harden `CallbackTransport` error handling, add full Sphinx-style docstrings, validate datetime strings in `receive_frame()`, ensure `asyncio.CancelledError` is re-raised cleanly in `write_frame()`, implement callback unbinding in `_close()`, and expand the AAA unit test suite.

### Technical Implementation:
- In `CallbackTransport.write_frame()`: Catch `asyncio.CancelledError` explicitly to allow task teardown to propagate without being wrapped as a `TransportError`.
- In `CallbackTransport.receive_frame()`: Validate datetime ISO strings (`dt.fromisoformat`), falling back to `dt_now().isoformat()`, and wrap `_frame_read()` in a try/except block to log parsing warnings safely rather than crashing the caller's task.
- In `CallbackTransport._close()`: Unbind `_io_writer` and set `_reading` state to `False`.
- Public APIs (`CallbackTransport`, `write_frame`, `receive_frame`): Added Sphinx-style docstrings (`:param:`, `:type:`, `:returns:`, `:rtype:`).
- In `tests/test_ha_mqtt/test_transport_callback.py`: Added AAA unit tests for `CancelledError` propagation, malformed packet handling, ISO timestamp fallback, and teardown cleanup.

### Testing Performed:
Ran `pytest tests/test_ha_mqtt/test_transport_callback.py` (10/10 passed), full test suite (`pytest`), `prek run -a`, `ruff check --select D`, and `mypy --strict`.

### Risks of NOT Implementing:
Intermittent crashes in Home Assistant MQTT listener tasks when malformed frames are ingested, and improper task cleanup during integration reloads.

### Risks of Implementing:
Low risk; all changes are limited to virtual callback transport error handling and docstrings.

### Mitigation Steps:
Added unit tests covering invalid timestamps, corrupt packets, task cancellation, and teardown cleanup.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash (High) for code generation and documentation. All logic and implementations were reviewed and verified by the author.