### PR TITLE
fix: use correct `zone_idx` when faking `30C9` sensor temperature

### DIFF
--- a/src/ramses_rf/commands/builders/heat.py
+++ b/src/ramses_rf/commands/builders/heat.py
@@ -46,7 +46,8 @@ def build_put_dhw_temp(intent: Command) -> CommandDTO:
 def build_put_sensor_temp(intent: Command) -> CommandDTO:
     """Translate a PUT_SENSOR_TEMP intent into a CommandDTO."""
     temperature = intent.get("temperature")
-    payload = f"00{hex_from_temp(temperature)}"
+    zone_idx = intent.get("zone_idx", "00")
+    payload = f"{zone_idx}{hex_from_temp(temperature)}"
     addr1, addr2, addr3 = resolve_addrs(intent.src, intent.dst)
 
     return CommandDTO(

--- a/src/ramses_rf/devices/heat_sensors.py
+++ b/src/ramses_rf/devices/heat_sensors.py
@@ -77,8 +77,16 @@ class Temperature(DeviceHeat):  # 30C9
         # Update local state immediately so the temperature is available
         # even if the RF command times out (e.g. faked devices on a simulator)
         self.temp_state = dataclasses.replace(self.temp_state, temperature=value)
+        # Determine the zone_idx from the parent zone (if bound) so that
+        # UFH zone sensors emit 30C9 with the correct zone_idx.  Without
+        # this, the fake always sends idx 00 and the UFC ignores it.
+        zone_idx = "00"
+        if self._parent is not None and hasattr(self._parent, "idx"):
+            zone_idx = self._parent.idx
         return await send_fake_intent(
-            self, Action.PUT_SENSOR_TEMP, {"temperature": value}
+            self,
+            Action.PUT_SENSOR_TEMP,
+            {"temperature": value, "zone_idx": zone_idx},
         )
 
     async def status(self) -> dict[str, Any]:

--- a/tests/tests_rf/test_device_heat.py
+++ b/tests/tests_rf/test_device_heat.py
@@ -199,7 +199,7 @@ async def test_temperature_set_faked(mock_gwy: MagicMock, mock_addr: MagicMock) 
         from ramses_rf.enums import Action
 
         assert intent.action == Action.PUT_SENSOR_TEMP
-        assert intent.data == {"temperature": 22.0}
+        assert intent.data == {"temperature": 22.0, "zone_idx": "00"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`build_put_sensor_temp` hardcoded `zone_idx=00` in the `30C9` payload.  For UFH zone sensors (THM bound to a UFC zone with `idx != 00`), the fake emitted `30C9` with idx 00 while the real device uses its actual zone idx (e.g. `01`).  The UFC ignored the mismatched packets and the zone stayed in comms-lost.

Now
`Temperature.set_temperature()` reads the zone_idx from self._parent.idx (the Zone's _child_id) and passes it through the intent data to build_put_sensor_temp, which uses it in the payload instead of the hardcoded "00".

If the device has no parent zone (unbound), it falls back to "00" preserving backward compatibility.

Faking a UFH zone sensor: transmit works after binding, but the UFC never accepts it — looks like a wrong zone idx (packet-log evidence)
---
from: https://community.home-assistant.io/t/honeywell-ch-dhw-via-rf-evohome-sundial-hometronics-chronotherm/151584/5100

> Hi all,
> 
> I’ve spent a lot of time trying to control an evohome underfloor-heating (UFH) zone from Home Assistant by faking its room thermostat, and I’ve hit a very specific wall that I believe is a zone-idx issue. I have packet-log evidence and would really appreciate any guidance (or confirmation that it’s a limitation/bug).
> 
> 
> 
> ### Setup
> 
> 
> 
> ramses_cc 0.58.3, HA Core 2026.6.2 (HA OS)
> 
> Gateway: RAMSES-ESP (evofw3-based), connected via USB/serial
> 
> System: evohome controller 01:010153, UFH controller (UFC/HCE80) 02:009007, 5× HCW82 room stats (03:2388xx)
> 
> Goal: fake room stat 03:238899 so HA can drive that zone’s demand.
> 
> ### What works
>
> Normal HGI-sourced send_packet transmits fine (green TX LED on the dongle blinks; controller replies).
> 
> After: 03:238899 set to {class: THM, faked: true}, enforce_known_list on, and binding it (put the evohome controller in “add room sensor” mode for the zone, then ramses_cc.bind_device with offer: {30C9: null}), put_room_temp now transmits (green TX LED) and the controller displays the faked temperature (e.g. Principal shows 15 °C). So binding unblocked the transmit path.
> 
> ### What does NOT work
>
> The UFC/HCE80 keeps the zone in comms-lost (red LED), heat_demand stays unknown, no actuator movement — even with sustained injection every 1 min for 15+ min, and even in Heat mode with current < setpoint.
> 
> send_packet with a non-HGI from_id (impersonation) still fails, even after binding:
> 
> `Failed to send packet: <ProtocolContext state=IsInIdle cmd_=30C9| I, tx_count=0/0>: Expired global timer after 20.0 sec`
> 
> The smoking gun — packet log shows the fake uses the wrong zone idx
>
> Real thermostat 03:238899 (RX, RSSI 080):
> 
> `2026-07-21T00:33:32 080 I 166 03:238899 --:------ 03:238899 30C9 003 0109EC`
>
> 
> → payload 01 09EC = idx 01, 25.40 °C. (It also periodically emits 2389 and 0002.)
> 
> 
> 
> Faked 03:238899 (TX, RSSI 000, my injection every 2 min):
> 
> `2026-07-21T00:00:00 000 I — 03:238899 --:------ 03:238899 30C9 003 000708`
> 
> → payload 00 0708 = idx 00, 18.00 °C.
> 
> So the faking emits 30C9 with idx 00, but this device (a UFH zone sensor) uses idx 01. The UFC expects idx 01, so it ignores the idx-00 fake and the zone stays in comms-lost. This is consistent with a RX warning I also get: Packet idx is 01, but expecting no idx (00) — it seems ramses_rf models these THMs as idx-00 devices and therefore fakes them with idx 00.
>
> ### Questions

>- Can faking be made to emit 30C9 with the correct zone idx (01) for a THM that is a UFH zone sensor? (Packet log proves the fake uses idx 00 while the real device uses idx 01.)
>- Why does send_packet (non-HGI from_id) still fail with tx_count=0/0 after binding, while put_room_temp transmits? That’s the only route I can see to send idx 01 manually.
>- The real device also emits 2389 and 0002 that the fake doesn’t — are any of these required for the UFC to treat the zone as “live”?
> 
> Thanks so much for this great integration — happy to provide full logs or test anything.
> 
