### PR TITLE
perf(tx): increase address LRU cache maxsize to 2048

### DIFF
--- a/src/ramses_tx/address.py
+++ b/src/ramses_tx/address.py
@@ -122,7 +122,7 @@ class Address:
         return f"{(int(dev_type) << 18) + int(device_id[-6:]):0>6X}"
 
 
-@lru_cache(maxsize=256)
+@lru_cache(maxsize=2048)
 def id_to_address(device_id: DeviceIdT) -> Address:
     """Factory method to cache & return device Address from device ID."""
     return Address(device_id=device_id)
@@ -165,7 +165,7 @@ def hex_id_to_dev_id(device_hex: str, friendly_id: bool = False) -> DeviceIdT:
     return DeviceIdT(f"{dev_type}:{_tmp & 0x03FFFF:06d}")
 
 
-@lru_cache(maxsize=128)
+@lru_cache(maxsize=2048)
 def is_valid_dev_id(value: str, dev_class: None | str = None) -> bool:
     """Return True if a device_id is valid."""
 
@@ -175,7 +175,7 @@ def is_valid_dev_id(value: str, dev_class: None | str = None) -> bool:
     return not _DBG_DISABLE_DEV_HVAC or value.split(":", 1)[0] in DEV_TYPE_MAP
 
 
-@lru_cache(maxsize=256)
+@lru_cache(maxsize=2048)
 def pkt_addrs(
     addr_fragment: str,
 ) -> tuple[Address, Address, Address, Address, Address]:


### PR DESCRIPTION
### The Problem:
Ingestion of large log files (30,000+ lines) suffers from CPU overhead and cache eviction churn in the transport layer address parsing routines. Analysis revealed that `id_to_address`, `is_valid_dev_id`, and `pkt_addrs` in `ramses_tx/address.py` had default `@lru_cache` limits set to `128` or `256`. However, large log files contain 700+ unique device IDs and 1,000+ unique 30-character address combinations, causing continuous LRU cache evictions during ingestion.

### Consequences:
Repeated cache misses force redundant address parsing, string slicing, and regex validation for address fields on every packet, increasing execution time and CPU cycles during log processing and test execution.

### The Fix:
Increased `@lru_cache(maxsize=...)` from `128`/`256` to `2048` for `id_to_address`, `is_valid_dev_id`, and `pkt_addrs` in `src/ramses_tx/address.py`.

### Technical Implementation:
- Updated `@lru_cache(maxsize=2048)` on `id_to_address`, `is_valid_dev_id`, and `pkt_addrs`.
- Empirical simulation across 32,325 log lines confirmed that 1,033 unique address fragments are present in the test fixture. At `maxsize=2048`, cache misses drop to 1,033 (0 evictions), ensuring 100% cache hits after initial lookup.

### Testing Performed:
- Ran isolated benchmark across 32,325 packet log lines to confirm cache hit rates.
- Ran full regression test suite (`tests/tests_rf/test_regression_rf.py`), measuring a 1.415-second reduction in CPU time (`user` CPU time reduced from 25.853s to 24.438s).
- Verified unit tests pass with `.venv/bin/pytest tests/tests_tx/test_packet.py`.

### Risks of NOT Implementing:
Continued CPU inefficiency and cache eviction churn during ingestion of large packet logs and test suite runs.

### Risks of Implementing:
Negligible increase in RAM usage (~100 KB) to store cached address string tuples.

### Mitigation Steps:
Bounded cache maxsize to 2048 (rather than unlimited) to ensure memory consumption remains minimal and strictly capped.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.
