### PR TITLE
feat(pipeline): cut over live execution to L7 ConversationManager (Phase 4b)

### DIFF
--- a/src/ramses_rf/commands/dispatcher.py
+++ b/src/ramses_rf/commands/dispatcher.py
@@ -1,5 +1,7 @@
 """RAMSES RF - Outbound Command Dispatcher."""
 
+from typing import cast
+
 from ramses_rf.commands.builders import build_dto
 from ramses_rf.commands.core import Command
 from ramses_rf.interfaces import GatewayInterface
@@ -32,15 +34,26 @@ class CommandDispatcher:
         """Translate and send a high-level intent over the RF network.
 
         :param intent: The high-level intent to execute.
-        :return: The resulting Packet from the modem (or an RP if requested).
+        :type intent: Command
+        :param priority: Priority override for transmission.
+        :type priority: Priority | None
+        :param wait_for_reply: True if the L7 FSM should await a reply.
+        :type wait_for_reply: bool | None
+        :returns: The resulting Packet from the modem (or RP packet).
+        :rtype: Packet
         """
         dto: CommandDTO = build_dto(intent)
+        conv_mgr = getattr(self._gwy, "conversation_manager", None)
 
-        if (
-            wait_for_reply
-            and getattr(self._gwy, "conversation_manager", None) is not None
-        ):
-            await self._gwy.conversation_manager.track_intent(intent, dto)
+        if wait_for_reply and conv_mgr is not None:
+            rply_fut = await conv_mgr.track_intent(intent, dto)
+            await self._gwy.async_send_cmd(
+                dto,
+                priority=priority if priority is not None else Priority(dto.priority),
+                wait_for_reply=False,
+            )
+            msg = await rply_fut
+            return cast(Packet, msg._pkt)
 
         return await self._gwy.async_send_cmd(
             dto,

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -189,7 +189,10 @@ class Gateway(GatewayLifecycle, GatewayInterface):
 
         # 2. Instantiate L7 Command Dispatcher and ConversationManager
         self._dispatcher = CommandDispatcher(self)
-        self._conversation_manager = ConversationManager(loop=loop)
+        self._conversation_manager = ConversationManager(
+            loop=loop,
+            send_func=lambda dto: self.async_send_cmd(dto, wait_for_reply=False),
+        )
 
     def __repr__(self) -> str:
         if not self._engine.ser_name:

--- a/src/ramses_rf/messages/base.py
+++ b/src/ramses_rf/messages/base.py
@@ -7,7 +7,7 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime as dt
-from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, cast
 
 from ramses_rf.address import Address, id_to_address
 from ramses_tx import CommandDTO, PacketDTO
@@ -73,6 +73,11 @@ class _LegacyPktShim:
         self._msg = msg
         self._dto = msg._dto
 
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, _LegacyPktShim):
+            return self._msg == other._msg
+        return False
+
     @property
     def _ctx(self) -> Any:
         """Legacy context bridge."""
@@ -89,6 +94,8 @@ class _LegacyPktShim:
 
         Calculates the frame string dynamically from the L7 properties.
         """
+        if hasattr(self, "_override_frame"):
+            return self._override_frame
         seqn = self._msg.seqn if self._msg.seqn else "---"
         addr1 = self._msg._addrs[0].id
         addr2 = self._msg._addrs[1].id
@@ -97,6 +104,29 @@ class _LegacyPktShim:
             f"{self._msg.verb} {seqn} {addr1} {addr2} {addr3} "
             f"{self._msg.code} {self._msg.len:03d} {self._dto.payload}"
         )
+
+    @_frame.setter
+    def _frame(self, value: str) -> None:
+        self._override_frame = value
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Delegate attribute setting to underlying DTO if not on shim."""
+        if name in ("_msg", "_dto", "_override_frame"):
+            object.__setattr__(self, name, value)
+        else:
+            try:
+                setattr(self._dto, name, value)
+            except (AttributeError, TypeError):
+                object.__setattr__(self, name, value)
+
+    @property
+    def _idx(self) -> str | bool:
+        """Legacy payload index bridge."""
+        return self._dto.payload[:2] if self._dto.payload else "00"
+
+    def to_dto(self) -> PacketDTO:
+        """Legacy DTO bridge."""
+        return self._dto
 
     def __getattr__(self, name: str) -> Any:
         """Delegate all other attributes to the underlying DTO.
@@ -215,6 +245,10 @@ class Message:
         :return: The generated message.
         :rtype: Message
         """
+        if isinstance(pkt, Message):
+            return cast(_MessageT, pkt)
+        if hasattr(pkt, "_msg") and isinstance(pkt._msg, Message):
+            return cast(_MessageT, pkt._msg)
         return cls(pkt.to_dto())
 
     @classmethod

--- a/src/ramses_rf/pipeline/conversation.py
+++ b/src/ramses_rf/pipeline/conversation.py
@@ -8,13 +8,14 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime as dt
 from typing import TYPE_CHECKING, Final
 
 from ramses_rf.commands.builders import build_dto
 from ramses_rf.commands.core import Command
-from ramses_tx import RP
+from ramses_tx import RP, Packet
 from ramses_tx.dtos import CommandDTO
 from ramses_tx.exceptions import ProtocolSendFailed, ProtocolTimeoutError
 
@@ -25,6 +26,8 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_RPLY_TIMEOUT: Final[float] = 1.0
 MAX_RETRY_LIMIT: Final[int] = 3
+
+SendCallbackT = Callable[[CommandDTO], Awaitable[Packet]]
 
 
 @dataclass
@@ -70,6 +73,7 @@ class ConversationManager:
         *,
         default_timeout: float = DEFAULT_RPLY_TIMEOUT,
         max_retries: int = MAX_RETRY_LIMIT,
+        send_func: SendCallbackT | None = None,
     ) -> None:
         """Initialise the ConversationManager.
 
@@ -79,10 +83,13 @@ class ConversationManager:
         :type default_timeout: float
         :param max_retries: Maximum number of retries before failing.
         :type max_retries: int
+        :param send_func: Callback for physical RF transmission retries.
+        :type send_func: SendCallbackT | None
         """
         self._loop = loop or asyncio.get_event_loop()
         self.default_timeout = default_timeout
         self.max_retries = max_retries
+        self._send_func = send_func
         self._pending: dict[str, PendingConversation] = {}
 
     @property
@@ -190,6 +197,15 @@ class ConversationManager:
                 pending.retry_count,
                 pending.max_retries,
             )
+            if self._send_func is not None:
+                try:
+                    await self._send_func(pending.dto)
+                except Exception as err:
+                    _LOGGER.warning(
+                        "Failed to re-send DTO during retry for %s: %s",
+                        key,
+                        err,
+                    )
             # Re-schedule timeout
             self._schedule_timeout(key, pending)
         else:

--- a/src/ramses_tx/protocol/fsm.py
+++ b/src/ramses_tx/protocol/fsm.py
@@ -566,7 +566,11 @@ class WantEcho(ProtocolStateBase):
             return
 
         self._echo_pkt = pkt
-        if self._sent_cmd.rx_header:
+        if (
+            self._sent_cmd.rx_header
+            and self._context._qos_mgr.qos
+            and self._context._qos_mgr.qos.wait_for_reply
+        ):
             self._context.set_state(WantRply)
         else:
             self._context.set_state(IsInIdle, result=pkt)

--- a/tests/tests_rf/test_live_conversation_parity.py
+++ b/tests/tests_rf/test_live_conversation_parity.py
@@ -48,10 +48,9 @@ async def test_live_gateway_conversation_manager_integration(
     )
 
     # Act
-    pkt = await gwy.dispatcher.send(intent, wait_for_reply=True)
+    send_task = asyncio.create_task(gwy.dispatcher.send(intent, wait_for_reply=True))
+    await asyncio.sleep(0.01)
 
-    # Assert
-    assert pkt == mock_packet
     assert gwy.conversation_manager.pending_count == 1
 
     # Simulate inbound RP response processing via real Packet & Message parsing
@@ -60,7 +59,10 @@ async def test_live_gateway_conversation_manager_integration(
     reply_msg = Message._from_pkt(rp_pkt)
 
     gwy.conversation_manager.process_msg(reply_msg)
+    pkt = await send_task
 
+    # Assert
+    assert pkt == reply_msg._pkt
     assert gwy.conversation_manager.pending_count == 0
 
     await gwy.stop()
@@ -82,7 +84,8 @@ async def test_live_dispatcher_process_msg_routes_to_conversation_manager(
         data={"zone_idx": "00", "setpoint": 21.0},
     )
 
-    await gwy.dispatcher.send(intent, wait_for_reply=True)
+    send_task = asyncio.create_task(gwy.dispatcher.send(intent, wait_for_reply=True))
+    await asyncio.sleep(0.01)
     assert gwy.conversation_manager.pending_count == 1
 
     rp_frame = "000 RP --- 01:078710 18:000730 --:------ 2309 003 000834"
@@ -91,6 +94,7 @@ async def test_live_dispatcher_process_msg_routes_to_conversation_manager(
 
     # Act
     await process_msg(gwy, reply_msg)
+    await send_task
 
     # Assert
     assert gwy.conversation_manager.pending_count == 0


### PR DESCRIPTION
### ⚠️ STACKED PR: Depends on #920 < was merged

### The Problem:
Prior to this PR, Request/Reply (RQ/RP) conversational tracking in the live pipeline was managed in L3 (`ramses_tx`). In Phase 4a/4a.5, the new L7 `ConversationManager` was integrated as a passive shadow observer to prove parity. However, live execution was still relying on L3 to track responses and handle retransmissions.

### The Fix:
This PR performs Phase 4b (The Execution Cutover) of ramses-rf/ramses_rf#915:
- **L7 Execution Cutover**: `CommandDispatcher.send()` now registers the intent with `ConversationManager` and awaits its L7 response future when `wait_for_reply=True`.
- **L3 Simplification**: Passes `wait_for_reply=False` to L3 `async_send_cmd()`, so `ramses_tx` only waits for physical transmission echo. Updates `WantEcho.pkt_rcvd()` in `fsm.py` to bypass `WantRply` when `wait_for_reply=False`.
- **L7 Retries**: Injected a decoupled `send_func` callback into `ConversationManager` so L7 actively triggers RF retransmissions upon timeout up to `max_retries`.
- **API Contract Preservation (Strangler Fig)**: Returns `cast(Packet, msg._pkt)` to keep existing callers working until Phase 4e (API Modernization).

### Testing Performed:
- Passed full test suite: 1441 passed, 39 skipped (`pytest`).
- Passed `mypy --strict .` (0 errors across 260 source files).
- Passed pre-commit checks (`prek run -a`).
- Verified conversational parity test suites (`test_conversation_parity.py` & `test_live_conversation_parity.py`).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.