### PR TITLE
feat(pipeline): implement L7 PollingManager shadow execution (Phase 4c.2)

### DIFF
--- a/src/ramses_rf/pipeline/__init__.py
+++ b/src/ramses_rf/pipeline/__init__.py
@@ -1,0 +1,15 @@
+"""RAMSES RF - Processing and Execution Pipeline Components."""
+
+from .conversation import ConversationManager, PendingConversation
+from .ingestion import StateProjector
+from .polling import PollingManager, PollingTask
+from .topology_builder import TopologyBuilder
+
+__all__ = [
+    "ConversationManager",
+    "PendingConversation",
+    "PollingManager",
+    "PollingTask",
+    "StateProjector",
+    "TopologyBuilder",
+]

--- a/src/ramses_rf/pipeline/polling.py
+++ b/src/ramses_rf/pipeline/polling.py
@@ -1,0 +1,279 @@
+"""RAMSES RF - Layer 7 SSOT-Driven Polling Manager.
+
+Orchestrates periodic polling schedules for network devices based on
+Layer 7 Schema-as-Source-of-Truth (SSOT) traits and fallback defaults.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime as dt, timedelta as td
+from typing import TYPE_CHECKING, Final
+
+from ramses_rf.const import DevType
+from ramses_rf.helpers import schedule_task
+from ramses_rf.typing import DeviceIdT, PollingIntervalsT
+
+if TYPE_CHECKING:
+    from ramses_rf.devices.dev_base import DeviceBase
+    from ramses_rf.gateway import Gateway
+
+_LOGGER = logging.getLogger(__name__)
+
+# Master default polling schedules table for all device classes.
+# Battery-powered devices (TRV, THM, DHW) set intervals to None to explicitly indicate
+# that polling is disabled for those command codes.
+DEFAULT_POLLING_SCHEDULES: Final[dict[str, dict[str, int | None]]] = {
+    DevType.CTL: {"10E0": 86400, "1F41": 3600, "313F": 43200},
+    DevType.BDR: {"10E0": 86400},
+    DevType.UFC: {"10E0": 86400, "1F09": 3600},
+    DevType.FAN: {"10E0": 86400, "3150": 3600},
+    DevType.TRV: {"10E0": None, "1060": None},  # Battery device - explicitly disabled
+    DevType.THM: {"10E0": None, "1060": None},  # Battery device - explicitly disabled
+    DevType.DHW: {"10E0": None, "1060": None},  # Battery device - explicitly disabled
+    "DEFAULT": {"10E0": 86400},
+}
+
+DEFAULT_POLL_CYCLE_SECS: Final[float] = 300.0  # 5 minutes maximum idle sleep
+
+
+def _ensure_aware(dtm: dt) -> dt:
+    """Ensure a datetime object is timezone-aware, defaulting to UTC if naive.
+
+    :param dtm: The input datetime instance.
+    :type dtm: dt
+    :returns: A timezone-aware datetime instance.
+    :rtype: dt
+    """
+    if dtm.tzinfo is None:
+        return dtm.replace(tzinfo=UTC)
+    return dtm
+
+
+@dataclass
+class PollingTask:
+    """Represents a scheduled polling task for a device command.
+
+    :param device_id: The ID of the target device.
+    :type device_id: DeviceIdT
+    :param code: The command code string (e.g., '10E0').
+    :type code: str
+    :param interval: Interval between polls in seconds.
+    :type interval: int
+    :param next_due: Datetime when the next poll is scheduled.
+    :type next_due: dt
+    :param last_polled: Datetime when the last poll occurred.
+    :type last_polled: dt | None
+    :param failures: Count of consecutive polling failures.
+    :type failures: int
+    """
+
+    device_id: DeviceIdT
+    code: str
+    interval: int
+    next_due: dt
+    last_polled: dt | None = None
+    failures: int = 0
+
+
+class PollingManager:
+    """SSOT-driven polling engine for Layer 7 device entities.
+
+    Evaluates device traits from the schema to determine scheduled command
+    polling intervals, falling back to class defaults where necessary.
+    Battery-powered devices are strictly excluded from polling.
+    """
+
+    def __init__(
+        self,
+        gwy: Gateway,
+        *,
+        shadow_mode: bool = True,
+        cycle_interval: float = DEFAULT_POLL_CYCLE_SECS,
+    ) -> None:
+        """Initialize the PollingManager.
+
+        :param gwy: The Gateway instance managing the device registry.
+        :type gwy: Gateway
+        :param shadow_mode: If True, log schedules without dispatching RF commands.
+        :type shadow_mode: bool
+        :param cycle_interval: Maximum loop sleep interval in seconds.
+        :type cycle_interval: float
+        """
+        self._gwy = gwy
+        self.shadow_mode: bool = shadow_mode
+        self._cycle_interval: float = cycle_interval
+
+        self._tasks: dict[tuple[DeviceIdT, str], PollingTask] = {}
+        self._poller_task: asyncio.Task[None] | None = None
+        self._running: bool = False
+
+    @property
+    def is_running(self) -> bool:
+        """Return True if the polling loop is active.
+
+        :returns: Active running status of the polling engine.
+        :rtype: bool
+        """
+        return (
+            self._running
+            and self._poller_task is not None
+            and not self._poller_task.done()
+        )
+
+    def resolve_schedule_for_device(self, device: DeviceBase) -> PollingIntervalsT:
+        """Resolve the effective polling schedule for a given device entity.
+
+        Battery-powered devices sleep and do not listen to RF requests; they are
+        never polled (returns an empty schedule dictionary).
+
+        For mains-powered devices, combines explicit schema traits
+        (`dev.polling_interval`) with fallback defaults for the class (`_SLUG`),
+        filtering out any entries set to None.
+
+        :param device: The target device entity.
+        :type device: DeviceBase
+        :returns: A dictionary mapping active command codes to interval seconds.
+        :rtype: PollingIntervalsT
+        """
+        # Battery devices sleep and cannot receive RF requests; never poll them
+        if device.is_battery:
+            return {}
+
+        slug = getattr(device, "_SLUG", "DEFAULT")
+        fallback_schedule = DEFAULT_POLLING_SCHEDULES.get(
+            slug, DEFAULT_POLLING_SCHEDULES["DEFAULT"]
+        )
+
+        schedule: dict[str, int | None] = dict(fallback_schedule)
+
+        # Override with explicit SSOT schema traits if provided
+        if device.polling_interval is not None:
+            schedule.update(device.polling_interval)
+
+        # Filter out disabled entries (None or <= 0) to return active intervals only
+        return {
+            code: interval
+            for code, interval in schedule.items()
+            if interval is not None and interval > 0
+        }
+
+    def update_device_tasks(self, device: DeviceBase) -> None:
+        """Update or register scheduled polling tasks for a device entity.
+
+        :param device: The device entity to register or refresh.
+        :type device: DeviceBase
+        """
+        schedule = self.resolve_schedule_for_device(device)
+        now = dt.now(UTC)
+
+        for code, interval in schedule.items():
+            key = (device.id, code)
+            if key not in self._tasks:
+                self._tasks[key] = PollingTask(
+                    device_id=device.id,
+                    code=code,
+                    interval=interval,
+                    next_due=now + td(seconds=interval),
+                )
+            else:
+                self._tasks[key].interval = interval
+
+    def get_scheduled_cmds(self) -> list[PollingTask]:
+        """Return a list of all currently tracked polling tasks.
+
+        :returns: A list of active PollingTask objects.
+        :rtype: list[PollingTask]
+        """
+        return list(self._tasks.values())
+
+    def start(self) -> None:
+        """Start the background polling loop if not disabled in config."""
+        if self._running:
+            return
+
+        if getattr(self._gwy.config, "disable_polling", False):
+            _LOGGER.info("PollingManager: Polling disabled by GatewayConfig.")
+            return
+
+        self._running = True
+        self._poller_task = schedule_task(self._poll_loop)
+        self._poller_task.set_name("l7_polling_manager")
+        self._gwy.add_task(self._poller_task)
+        _LOGGER.info("PollingManager started (shadow_mode=%s)", self.shadow_mode)
+
+    async def stop(self) -> None:
+        """Stop the background polling loop gracefully."""
+        self._running = False
+        if self._poller_task and not self._poller_task.done():
+            self._poller_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._poller_task
+        self._poller_task = None
+        _LOGGER.info("PollingManager stopped.")
+
+    def _calculate_next_sleep_interval(self) -> float:
+        """Calculate dynamic sleep delay in seconds based on next due task.
+
+        :returns: Dynamic sleep interval in seconds bounded between 1s and cycle_interval.
+        :rtype: float
+        """
+        if not self._tasks:
+            return self._cycle_interval
+
+        now = dt.now(UTC)
+        next_due = min(task.next_due for task in self._tasks.values())
+        delay = (next_due - now).total_seconds()
+        return max(1.0, min(delay, self._cycle_interval))
+
+    async def _poll_loop(self) -> None:
+        """Evaluate and execute scheduled tasks in the background."""
+        while self._running:
+            try:
+                await self.poll_due_commands()
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.error("Error in PollingManager loop: %s", err)
+
+            sleep_secs = self._calculate_next_sleep_interval()
+            await asyncio.sleep(sleep_secs)
+
+    async def poll_due_commands(self) -> int:
+        """Evaluate tracked tasks and process commands that are due.
+
+        :returns: Number of tasks processed during this cycle.
+        :rtype: int
+        """
+        if getattr(self._gwy.config, "disable_polling", False):
+            return 0
+
+        # Refresh tasks for all devices currently in registry
+        for dev in list(self._gwy.device_registry.devices):
+            self.update_device_tasks(dev)
+
+        now = dt.now(UTC)
+        processed_count = 0
+
+        for task in self._tasks.values():
+            if task.next_due > now:
+                continue
+
+            processed_count += 1
+            if self.shadow_mode:
+                _LOGGER.debug(
+                    "[SHADOW POLLING] Device %s command %s due (interval=%ss)",
+                    task.device_id,
+                    task.code,
+                    task.interval,
+                )
+                task.last_polled = now
+                task.next_due = now + td(seconds=task.interval)
+            else:
+                _LOGGER.info("Polling device %s command %s", task.device_id, task.code)
+                task.last_polled = now
+                task.next_due = now + td(seconds=task.interval)
+                # Live dispatch (used in PR 3c execution cutover)
+
+        return processed_count

--- a/tests/tests_rf/test_polling_parity.py
+++ b/tests/tests_rf/test_polling_parity.py
@@ -1,0 +1,155 @@
+from datetime import UTC, datetime as dt, timedelta as td
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ramses_rf.config import GatewayConfig
+from ramses_rf.devices.dev_base import BatteryState, DeviceBase
+from ramses_rf.models import DeviceTraits
+from ramses_rf.pipeline.polling import DEFAULT_POLLING_SCHEDULES, PollingManager
+
+
+class MockDevice(DeviceBase):
+    """Mock device subclass for unit testing PollingManager schedule resolution."""
+
+    def __init__(
+        self,
+        gwy: Any,
+        device_id: str,
+        slug: str = "DEFAULT",
+        traits: DeviceTraits | None = None,
+    ) -> None:
+        mock_addr = MagicMock()
+        mock_addr.id = device_id
+        mock_addr.type = device_id[:2]
+        super().__init__(gwy, mock_addr, traits=traits)
+        self._SLUG = slug
+
+
+class MockBatteryDevice(BatteryState):
+    """Mock battery-powered device subclass for unit testing."""
+
+    def __init__(
+        self,
+        gwy: Any,
+        device_id: str,
+        traits: DeviceTraits | None = None,
+    ) -> None:
+        mock_addr = MagicMock()
+        mock_addr.id = device_id
+        mock_addr.type = device_id[:2]
+        super().__init__(gwy, mock_addr, traits=traits)
+        self._SLUG = "TRV"
+
+
+@pytest.fixture
+def mock_gateway() -> MagicMock:
+    """Create a mock gateway instance with mock device registry and config."""
+    gwy = MagicMock()
+    gwy.config = GatewayConfig()
+    gwy.device_registry.devices = []
+    gwy.async_send_cmd = AsyncMock()
+    gwy.add_task = MagicMock()
+    return gwy
+
+
+def test_polling_manager_schedule_resolution_defaults(
+    mock_gateway: MagicMock,
+) -> None:
+    # ARRANGE
+    poller = PollingManager(mock_gateway, shadow_mode=True)
+
+    ctl_dev = MockDevice(mock_gateway, "01:111111", slug="CTL")
+    bdr_dev = MockDevice(mock_gateway, "13:222222", slug="BDR")
+    fan_dev = MockDevice(mock_gateway, "32:333333", slug="FAN")
+
+    # ACT
+    ctl_schedule = poller.resolve_schedule_for_device(ctl_dev)
+    bdr_schedule = poller.resolve_schedule_for_device(bdr_dev)
+    fan_schedule = poller.resolve_schedule_for_device(fan_dev)
+
+    # ASSERT
+    assert ctl_schedule == DEFAULT_POLLING_SCHEDULES["CTL"]
+    assert bdr_schedule == DEFAULT_POLLING_SCHEDULES["BDR"]
+    assert fan_schedule == DEFAULT_POLLING_SCHEDULES["FAN"]
+
+
+def test_polling_manager_custom_trait_override(
+    mock_gateway: MagicMock,
+) -> None:
+    # ARRANGE
+    custom_traits = DeviceTraits(polling_interval={"1F41": 1800, "10E0": 43200})
+    ctl_dev = MockDevice(mock_gateway, "01:111111", slug="CTL", traits=custom_traits)
+    poller = PollingManager(mock_gateway, shadow_mode=True)
+
+    # ACT
+    schedule = poller.resolve_schedule_for_device(ctl_dev)
+
+    # ASSERT
+    assert schedule["1F41"] == 1800
+    assert schedule["10E0"] == 43200
+    assert schedule["313F"] == DEFAULT_POLLING_SCHEDULES["CTL"]["313F"]
+
+
+def test_polling_manager_battery_device_zero_polling(
+    mock_gateway: MagicMock,
+) -> None:
+    # ARRANGE
+    battery_dev = MockBatteryDevice(mock_gateway, "04:222222")
+    explicit_battery_dev = MockDevice(
+        mock_gateway, "04:333333", slug="TRV", traits=DeviceTraits(is_battery=True)
+    )
+    poller = PollingManager(mock_gateway, shadow_mode=True)
+
+    # ACT
+    battery_schedule = poller.resolve_schedule_for_device(battery_dev)
+    explicit_schedule = poller.resolve_schedule_for_device(explicit_battery_dev)
+
+    # ASSERT
+    # Battery devices sleep and do not listen to RF commands; schedule must be empty
+    assert battery_schedule == {}
+    assert explicit_schedule == {}
+
+
+@pytest.mark.asyncio
+async def test_polling_manager_shadow_execution_parity(
+    mock_gateway: MagicMock,
+) -> None:
+    # ARRANGE
+    poller = PollingManager(mock_gateway, shadow_mode=True)
+    ctl_dev = MockDevice(mock_gateway, "01:111111", slug="CTL")
+    mock_gateway.device_registry.devices = [ctl_dev]
+
+    poller.update_device_tasks(ctl_dev)
+
+    # Fast-forward next_due to trigger due commands
+    past = dt.now(UTC) - td(seconds=10)
+    for task in poller.get_scheduled_cmds():
+        task.next_due = past
+
+    # ACT
+    processed_count = await poller.poll_due_commands()
+
+    # ASSERT
+    assert processed_count == len(DEFAULT_POLLING_SCHEDULES["CTL"])
+    # Crucial Shadow Mode Guarantee: Zero RF network transmissions
+    mock_gateway.async_send_cmd.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_polling_manager_disabled_config_parity(
+    mock_gateway: MagicMock,
+) -> None:
+    # ARRANGE
+    mock_gateway.config.disable_polling = True
+    poller = PollingManager(mock_gateway, shadow_mode=True)
+    ctl_dev = MockDevice(mock_gateway, "01:111111", slug="CTL")
+    mock_gateway.device_registry.devices = [ctl_dev]
+
+    # ACT
+    processed_count = await poller.poll_due_commands()
+
+    # ASSERT
+    assert processed_count == 0
+    mock_gateway.async_send_cmd.assert_not_called()


### PR DESCRIPTION
### ⚠️ STACKED PR: Depends on #924 < was merged

### The Problem:
Legacy `DiscoveryService` couples network command discovery with background periodic polling execution inside a monolithic class, hindering strict CQRS isolation and unit testability.

### The Fix:
Implemented the Layer 7 `PollingManager` in `src/ramses_rf/pipeline/polling.py` operating in **Shadow Execution Mode** (`shadow_mode=True`) alongside legacy `DiscoveryService` as Phase 4c.2 of Active Discovery Removal:
- **SSOT Schedule Resolution**: Combines explicit schema traits (`dev.polling_interval`) with default fallback schedules per device class (`_SLUG`).
- **Battery-Friendly Zero Polling**: Battery devices (`TRV`, `THM`, `DHW`) are explicitly set to `None` in default tables and return an empty schedule `{}` (`dev.is_battery`).
- **Dynamic Loop Ticker**: Background ticker dynamically calculates next sleep interval (`min(delay, 300s)`), optimizing idle CPU usage.
- **Shadow Mode Guarantee**: Logs schedule evaluations without firing RF commands (`gwy.async_send_cmd` is never invoked).
- **Parity Unit Test Suite**: Created `tests/tests_rf/test_polling_parity.py` demonstrating 100% schedule resolution, custom trait overrides, battery zero polling, shadow execution, and gateway config compliance.

### Testing Performed:
- `pytest tests/tests_rf/test_polling_parity.py`: 5 passed
- `mypy --strict`: 0 errors across 249 source files
- `prek run -a`: All 17 pre-commit checks passed
- `ruff check --select D`: 100% docstring compliant
- `pytest`: 1448 passed, 39 skipped, 0 failed

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.
