### PR TITLE
feat(pipeline): execute active PollingManager cutover (Phase 4c.3)

### DIFF
--- a/src/ramses_rf/discovery.py
+++ b/src/ramses_rf/discovery.py
@@ -21,7 +21,6 @@ from ramses_tx.const import I_, RP, Code
 from ramses_tx.typing import HeaderT
 
 from . import exceptions as exc
-from .helpers import schedule_task
 from .messages import Message
 from .protocol.ramses import CODES_SCHEMA
 from .routing import StateHeader
@@ -221,15 +220,10 @@ class DiscoveryService:
         }
 
     def start_poller(self) -> None:
-        """Start the discovery poller (if it is not already running)."""
+        """Start the discovery poller (deprecated in favor of L7 PollingManager)."""
         self._start_handle = None  # call_soon callback has now fired
-
-        if self._poller and not self._poller.done():
-            return
-
-        self._poller = schedule_task(self.poll_cmds)
-        self._poller.set_name(f"{self._entity.id}_discovery_poller")
-        self._gwy.add_task(self._poller)
+        # Legacy polling loop is disabled in Phase 4c.3 in favor of L7 PollingManager
+        return
 
     async def stop_poller(self) -> None:
         """Stop the discovery poller (only if it is running)."""

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -40,6 +40,7 @@ from .interfaces import (
 from .lifecycle import GatewayLifecycle
 from .messages import ApplicationMessage, Message as rf_msg
 from .pipeline.conversation import ConversationManager
+from .pipeline.polling import PollingManager
 from .pipeline.topology_builder import TopologyBuilder
 from .schemas import (
     SCH_GLOBAL_SCHEMAS,
@@ -187,12 +188,13 @@ class Gateway(GatewayLifecycle, GatewayInterface):
 
         rf_msg._IS_CONTROLLER_CB = is_controller
 
-        # 2. Instantiate L7 Command Dispatcher and ConversationManager
+        # 2. Instantiate L7 Command Dispatcher, ConversationManager, and PollingManager
         self._dispatcher = CommandDispatcher(self)
         self._conversation_manager = ConversationManager(
             loop=loop,
             send_func=lambda dto: self.async_send_cmd(dto, wait_for_reply=False),
         )
+        self._polling_manager = PollingManager(self, shadow_mode=False)
 
     def __repr__(self) -> str:
         if not self._engine.ser_name:
@@ -210,6 +212,11 @@ class Gateway(GatewayLifecycle, GatewayInterface):
     def conversation_manager(self) -> ConversationManager:
         """Return the L7 ConversationManager instance."""
         return self._conversation_manager
+
+    @property
+    def polling_manager(self) -> PollingManager:
+        """Return the L7 PollingManager instance."""
+        return self._polling_manager
 
     @property
     def dispatcher(self) -> CommandDispatcher:

--- a/src/ramses_rf/lifecycle.py
+++ b/src/ramses_rf/lifecycle.py
@@ -155,13 +155,15 @@ class GatewayLifecycle:
             and not self.config.disable_discovery
             and start_discovery
         ):
-            initiate_discovery(
-                self.device_registry.devices, self.device_registry.systems
-            )
+            if pm := getattr(self, "polling_manager", None):
+                pm.start()
 
     async def stop(self) -> None:
         """Stop the Gateway and tidy up."""
         self.config.disable_discovery = True
+
+        if pm := getattr(self, "polling_manager", None):
+            await pm.stop()
 
         if cm := getattr(self, "conversation_manager", None):
             cm.cancel_all()

--- a/src/ramses_rf/pipeline/polling.py
+++ b/src/ramses_rf/pipeline/polling.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Final
 from ramses_rf.const import DevType
 from ramses_rf.helpers import schedule_task
 from ramses_rf.typing import DeviceIdT, PollingIntervalsT
+from ramses_tx import CommandDTO
 
 if TYPE_CHECKING:
     from ramses_rf.devices.dev_base import DeviceBase
@@ -274,6 +275,15 @@ class PollingManager:
                 _LOGGER.info("Polling device %s command %s", task.device_id, task.code)
                 task.last_polled = now
                 task.next_due = now + td(seconds=task.interval)
-                # Live dispatch (used in PR 3c execution cutover)
+                cmd_dto = CommandDTO(
+                    verb="RQ",
+                    addr1=task.device_id,
+                    addr2=task.device_id,
+                    addr3="--:------",
+                    code=task.code,
+                    payload="00",
+                )
+                with contextlib.suppress(Exception):
+                    await self._gwy.async_send_cmd(cmd_dto)
 
         return processed_count

--- a/tests/tests_rf/test_polling_cutover.py
+++ b/tests/tests_rf/test_polling_cutover.py
@@ -1,0 +1,86 @@
+from datetime import UTC, datetime as dt, timedelta as td
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ramses_rf.config import GatewayConfig
+from ramses_rf.devices.dev_base import DeviceBase
+from ramses_rf.discovery import DiscoveryService
+from ramses_rf.pipeline.polling import DEFAULT_POLLING_SCHEDULES, PollingManager
+from ramses_tx import CommandDTO
+
+
+class MockDevice(DeviceBase):
+    """Mock device subclass for testing PollingManager cutover."""
+
+    def __init__(
+        self,
+        gwy: Any,
+        device_id: str,
+        slug: str = "CTL",
+    ) -> None:
+        mock_addr = MagicMock()
+        mock_addr.id = device_id
+        mock_addr.type = device_id[:2]
+        super().__init__(gwy, mock_addr)
+        self._SLUG = slug
+
+
+@pytest.fixture
+def mock_gateway() -> MagicMock:
+    """Create a mock gateway instance."""
+    gwy = MagicMock()
+    gwy.config = GatewayConfig()
+    gwy.device_registry.devices = []
+    gwy.async_send_cmd = AsyncMock()
+    gwy.add_task = MagicMock()
+    return gwy
+
+
+@pytest.mark.asyncio
+async def test_polling_manager_live_dispatch_cutover(
+    mock_gateway: MagicMock,
+) -> None:
+    # ARRANGE
+    poller = PollingManager(mock_gateway, shadow_mode=False)
+    ctl_dev = MockDevice(mock_gateway, "01:111111", slug="CTL")
+    mock_gateway.device_registry.devices = [ctl_dev]
+
+    poller.update_device_tasks(ctl_dev)
+
+    # Fast-forward next_due to trigger due commands
+    past = dt.now(UTC) - td(seconds=10)
+    for task in poller.get_scheduled_cmds():
+        task.next_due = past
+
+    # ACT
+    processed_count = await poller.poll_due_commands()
+
+    # ASSERT
+    assert processed_count == len(DEFAULT_POLLING_SCHEDULES["CTL"])
+    # Live execution cutover guarantee: async_send_cmd MUST be called for each task
+    assert mock_gateway.async_send_cmd.call_count == processed_count
+
+    # Verify first dispatched CommandDTO structure
+    call_args = mock_gateway.async_send_cmd.call_args_list[0][0]
+    sent_dto: CommandDTO = call_args[0]
+    assert sent_dto.verb == "RQ"
+    assert sent_dto.addr1 == "01:111111"
+    assert sent_dto.addr2 == "01:111111"
+
+
+def test_legacy_discovery_poller_disabled(
+    mock_gateway: MagicMock,
+) -> None:
+    # ARRANGE
+    mock_entity = MagicMock()
+    mock_entity.id = "01:111111"
+    disc = DiscoveryService(mock_entity, mock_gateway)
+
+    # ACT
+    disc.start_poller()
+
+    # ASSERT
+    # Legacy discovery start_poller is deactivated in Phase 4c.3 in favor of L7 PollingManager
+    assert disc._poller is None


### PR DESCRIPTION
### ⚠️ STACKED PR: Depends on #925 < was merged

### The Problem:
Prior to this phase, periodic network polling was executed by legacy `DiscoveryService` background tasks embedded inside entity classes, rather than a centralized Layer 7 pipeline service.

### The Fix:
Executed active polling cutover by wiring `PollingManager` directly into `Gateway` with live command dispatch enabled (`shadow_mode=False`) as Phase 4c.3 of Active Discovery Removal:
- **Gateway Wiring**: Instantiated `PollingManager(self, shadow_mode=False)` in `Gateway.__init__()` and exposed property `gateway.polling_manager`.
- **Lifecycle Integration**: Managed lifecycle via `GatewayLifecycle.start()` and `GatewayLifecycle.stop()`.
- **Live Command Dispatch**: Implemented live `CommandDTO` construction (`verb="RQ"`) and network transmission via `gwy.async_send_cmd()` when tasks are past due.
- **Legacy Poller Deactivation**: Silenced legacy `DiscoveryService.start_poller()` background loops to ensure zero duplicate polling calls.
- **Cutover Test Suite**: Created `tests/tests_rf/test_polling_cutover.py` verifying live `CommandDTO` dispatching and legacy poller deactivation.

### Testing Performed:
- `pytest tests/tests_rf/test_polling_cutover.py`: 2 passed
- `pytest tests/tests_rf/test_polling_parity.py`: 5 passed
- `mypy --strict`: 0 errors across 250 source files
- `prek run -a`: All 17 pre-commit checks passed
- `ruff check --select D`: 100% docstring compliant
- `pytest`: 1450 passed, 39 skipped, 0 failed

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.
