### PR TITLE
refactor(protocol): deprecate wait_for_reply in transport layer and gateway (Phase 4d.1)

### DIFF
--- a/src/ramses_cli/discovery.py
+++ b/src/ramses_cli/discovery.py
@@ -130,7 +130,7 @@ async def exec_cmd(gwy: Gateway, **kwargs: Any) -> None:
     :param kwargs: CLI parameters containing the 'EXEC_CMD' string.
     """
     cmd = CommandDTO.from_cli(kwargs[EXEC_CMD])
-    await gwy.async_send_cmd(cmd, priority=Priority.HIGH, wait_for_reply=True)
+    await gwy.async_send_cmd(cmd, priority=Priority.HIGH)
 
 
 async def get_faults(

--- a/src/ramses_rf/binding_fsm.py
+++ b/src/ramses_rf/binding_fsm.py
@@ -89,7 +89,6 @@ _RATIFY_WAIT_TIME: Final[float] = (
 BINDING_QOS = QosParams(
     max_retries=SENDING_RETRY_LIMIT,
     timeout=WAITING_TIMEOUT_SECS * 2,
-    wait_for_reply=False,
 )
 
 

--- a/src/ramses_rf/commands/dispatcher.py
+++ b/src/ramses_rf/commands/dispatcher.py
@@ -50,7 +50,6 @@ class CommandDispatcher:
             await self._gwy.async_send_cmd(
                 dto,
                 priority=priority if priority is not None else Priority(dto.priority),
-                wait_for_reply=False,
             )
             msg = await rply_fut
             return cast(Packet, msg._pkt)
@@ -58,5 +57,4 @@ class CommandDispatcher:
         return await self._gwy.async_send_cmd(
             dto,
             priority=priority if priority is not None else Priority(dto.priority),
-            wait_for_reply=wait_for_reply,
         )

--- a/src/ramses_rf/entity.py
+++ b/src/ramses_rf/entity.py
@@ -158,7 +158,7 @@ class _Entity:
             _LOGGER.info(f"{cmd} < Sending was deprecated for {self}")
             return None
 
-        return self._gwy.send_cmd(cmd, wait_for_reply=False, **kwargs)
+        return self._gwy.send_cmd(cmd, **kwargs)
 
     async def _async_send_cmd(
         self,
@@ -191,8 +191,6 @@ class _Entity:
                 kwargs["max_retries"] = qos.max_retries
             if hasattr(qos, "timeout") and qos.timeout is not None:
                 kwargs["timeout"] = qos.timeout
-            if hasattr(qos, "wait_for_reply") and qos.wait_for_reply is not None:
-                kwargs["wait_for_reply"] = qos.wait_for_reply
 
         return await self._gwy.async_send_cmd(cmd, **kwargs)
 

--- a/src/ramses_rf/gateway.py
+++ b/src/ramses_rf/gateway.py
@@ -18,7 +18,6 @@ from ramses_tx.const import (
     DEFAULT_MAX_RETRIES,
     DEFAULT_NUM_REPEATS,
     DEFAULT_SEND_TIMEOUT,
-    DEFAULT_WAIT_FOR_REPLY,
     SZ_ACTIVE_HGI,
     Priority,
 )
@@ -192,7 +191,7 @@ class Gateway(GatewayLifecycle, GatewayInterface):
         self._dispatcher = CommandDispatcher(self)
         self._conversation_manager = ConversationManager(
             loop=loop,
-            send_func=lambda dto: self.async_send_cmd(dto, wait_for_reply=False),
+            send_func=lambda dto: self.async_send_cmd(dto),
         )
         self._polling_manager = PollingManager(self, shadow_mode=False)
 
@@ -441,7 +440,6 @@ class Gateway(GatewayLifecycle, GatewayInterface):
         num_repeats: int = DEFAULT_NUM_REPEATS,
         priority: Priority = Priority.DEFAULT,
         timeout: float = DEFAULT_SEND_TIMEOUT,
-        wait_for_reply: bool | None = DEFAULT_WAIT_FOR_REPLY,
         max_retries: int = DEFAULT_MAX_RETRIES,
     ) -> asyncio.Task[Packet]:
         coro = self.async_send_cmd(
@@ -450,7 +448,6 @@ class Gateway(GatewayLifecycle, GatewayInterface):
             num_repeats=num_repeats,
             priority=priority,
             timeout=timeout,
-            wait_for_reply=wait_for_reply,
             max_retries=max_retries,
         )
         task = self._engine._loop.create_task(coro)
@@ -472,7 +469,6 @@ class Gateway(GatewayLifecycle, GatewayInterface):
         num_repeats: int = DEFAULT_NUM_REPEATS,
         priority: Priority = Priority.DEFAULT,
         timeout: float = DEFAULT_SEND_TIMEOUT,
-        wait_for_reply: bool | None = DEFAULT_WAIT_FOR_REPLY,
         max_retries: int = DEFAULT_MAX_RETRIES,
     ) -> Packet:
         try:
@@ -483,7 +479,6 @@ class Gateway(GatewayLifecycle, GatewayInterface):
                 priority=priority,
                 max_retries=max_retries,
                 timeout=timeout,
-                wait_for_reply=wait_for_reply,
             )
         except (ProtocolSendFailed, NotImplementedError) as err:
             if (

--- a/src/ramses_rf/interfaces.py
+++ b/src/ramses_rf/interfaces.py
@@ -263,7 +263,6 @@ class GatewayInterface(Protocol):
         /,
         *,
         priority: Priority = Priority.DEFAULT,
-        wait_for_reply: bool | None = True,
         max_retries: int = 3,
         timeout: float = 3.0,
     ) -> Packet:

--- a/src/ramses_rf/systems/tcs.py
+++ b/src/ramses_rf/systems/tcs.py
@@ -1188,9 +1188,7 @@ class SystemMode(SystemBase):  # 2E04
                 data={"system_mode": system_mode, "until": until},
             )
         )
-        return await self._gwy.async_send_cmd(
-            cmd, priority=Priority.HIGH, wait_for_reply=True
-        )
+        return await self._gwy.async_send_cmd(cmd, priority=Priority.HIGH)
 
     async def set_auto(self) -> Packet:
         """Revert system to Auto, setting zones to FollowSchedule.
@@ -1249,7 +1247,7 @@ class Datetime(SystemBase):  # 313F
                 data={},
             )
         )
-        pkt = await self._gwy.async_send_cmd(cmd, wait_for_reply=True)
+        pkt = await self._gwy.async_send_cmd(cmd)
         msg = Message._from_pkt(pkt)
         return dt.fromisoformat(msg.payload[SZ_DATETIME])
 

--- a/src/ramses_tx/engine.py
+++ b/src/ramses_tx/engine.py
@@ -18,7 +18,6 @@ from .const import (
     DEFAULT_MAX_RETRIES,
     DEFAULT_NUM_REPEATS,
     DEFAULT_SEND_TIMEOUT,
-    DEFAULT_WAIT_FOR_REPLY,
     I_,
     SZ_ACTIVE_HGI,
     W_,
@@ -369,13 +368,11 @@ class Engine:
         priority: Priority = Priority.DEFAULT,
         max_retries: int = DEFAULT_MAX_RETRIES,
         timeout: float = DEFAULT_SEND_TIMEOUT,
-        wait_for_reply: bool | None = DEFAULT_WAIT_FOR_REPLY,
     ) -> Packet:
         """Send a Command and return the corresponding Packet."""
         qos = QosParams(
             max_retries=max_retries,
             timeout=timeout,
-            wait_for_reply=wait_for_reply,
         )
 
         return await self._protocol.send_cmd(

--- a/src/ramses_tx/protocol/base.py
+++ b/src/ramses_tx/protocol/base.py
@@ -321,18 +321,11 @@ class _BaseProtocol(ProtocolInterface, asyncio.Protocol):
         """Send a Command with Qos (with retries, until success or
         ProtocolError).
 
-        Returns the Command's response Packet or the Command echo if a
-        response is not expected (e.g. sending an RP).
-
-        If wait_for_reply is True, return the RQ's RP (or W's I), or
-        raise an exception if one doesn't arrive. If it is False, return
-        the echo of the Command only. If it is None (the default), act
-        as True for RQs, and False for all other Commands.
+        Returns the Command's response Packet or the Command echo.
 
         num_repeats is # of times to send the Command, in addition to
-        the fist transmit, with gap_duration seconds between each
-        transmission. If wait_for_reply is True, then num_repeats is
-        ignored.
+        the first transmit, with gap_duration seconds between each
+        transmission.
 
         Commands are queued and sent FIFO, except higher-priority
         Commands are always sent first.
@@ -354,10 +347,6 @@ class _BaseProtocol(ProtocolInterface, asyncio.Protocol):
 
         if cmd.addr1 != self.hgi_id:  # Was HGI_DEV_ADDR.id
             await self._send_impersonation_alert(cmd)
-
-        if qos and qos.wait_for_reply and num_repeats:
-            _LOGGER.warning(f"{cmd} < num_repeats set to 0, as wait_for_reply is True")
-            num_repeats = 0  # the lesser crime over wait_for_reply=False
 
         pkt = await self._send_cmd(  # may: raise ProtocolError/ProtocolSendFailed
             cmd,

--- a/src/ramses_tx/protocol/core.py
+++ b/src/ramses_tx/protocol/core.py
@@ -19,7 +19,6 @@ from ..const import (
     MAX_NUM_REPEATS,
     SZ_ACTIVE_HGI,
     SZ_IS_EVOFW3,
-    Code,
     Priority,
 )
 from ..dtos import CommandDTO
@@ -248,13 +247,6 @@ class PortProtocol(_DeviceIdFilterMixin):
             await send_cmd(cmd)
             return None  # type: ignore[return-value]
 
-        _CODES = (Code._0006, Code._0404, Code._0418, Code._1FC9)
-
-        if self._disable_qos is True or _DBG_DISABLE_QOS:
-            qos._wait_for_reply = False
-        elif self._disable_qos is None and cmd.code not in _CODES:
-            qos._wait_for_reply = False
-
         assert self._context
 
         try:
@@ -278,16 +270,10 @@ class PortProtocol(_DeviceIdFilterMixin):
     ) -> Packet:
         """Send a Command with Qos (with retries, until success or ProtocolError).
 
-        Returns the Command's response Packet or the Command echo if a response is not
-        expected (e.g. sending an RP).
+        Returns the Command's response Packet or the Command echo.
 
-        If wait_for_reply is True, return the RQ's RP (or W's I), or raise an exception
-        if one doesn't arrive. If it is False, return the echo of the Command only. If
-        it is None (the default), act as True for RQs, and False for all other Commands.
-
-        num_repeats is # of times to send the Command, in addition to the fist transmit,
-        with gap_duration seconds between each transmission. If wait_for_reply is True,
-        then num_repeats is ignored.
+        num_repeats is # of times to send the Command, in addition to the first transmit,
+        with gap_duration seconds between each transmission.
 
         Commands are queued and sent FIFO, except higher-priority Commands are always
         sent first.
@@ -302,10 +288,6 @@ class PortProtocol(_DeviceIdFilterMixin):
 
         if qos and not self._context:
             _LOGGER.warning(f"{cmd} < QoS is currently disabled by this Protocol")
-
-        if qos and qos.wait_for_reply and num_repeats:
-            _LOGGER.warning(f"{cmd} < num_repeats set to 0, as wait_for_reply is True")
-            num_repeats = 0
 
         # Patch command with actual HGI ID if it uses the default placeholder.
         # PortProtocol.send_cmd overrides _BaseProtocol.send_cmd (which does this

--- a/src/ramses_tx/protocol/fsm.py
+++ b/src/ramses_tx/protocol/fsm.py
@@ -208,7 +208,7 @@ class ProtocolContext(StateMachineInterface):
             elif (
                 isinstance(self._state, WantRply)
                 and self._qos_mgr.qos
-                and not self._qos_mgr.qos.wait_for_reply
+                and not getattr(self._qos_mgr.qos, "wait_for_reply", False)
             ):
                 self.set_state(IsInIdle, result=self._state._echo_pkt)
             elif isinstance(self._state, WantEcho | WantRply):
@@ -569,7 +569,7 @@ class WantEcho(ProtocolStateBase):
         if (
             self._sent_cmd.rx_header
             and self._context._qos_mgr.qos
-            and self._context._qos_mgr.qos.wait_for_reply
+            and getattr(self._context._qos_mgr.qos, "wait_for_reply", False)
         ):
             self._context.set_state(WantRply)
         else:

--- a/src/ramses_tx/typing.py
+++ b/src/ramses_tx/typing.py
@@ -20,7 +20,6 @@ from .const import (
     DEFAULT_MAX_RETRIES,
     DEFAULT_NUM_REPEATS,
     DEFAULT_SEND_TIMEOUT,
-    DEFAULT_WAIT_FOR_REPLY,
     FaultDeviceClass,
     FaultState,
     FaultType,
@@ -68,7 +67,6 @@ class QosParams:
         *,
         max_retries: int | None = DEFAULT_MAX_RETRIES,
         timeout: float | None = DEFAULT_SEND_TIMEOUT,
-        wait_for_reply: bool | None = DEFAULT_WAIT_FOR_REPLY,
     ) -> None:
         """Create a QosParams instance."""
         if max_retries is None:
@@ -77,7 +75,6 @@ class QosParams:
             self._max_retries = max_retries
 
         self._timeout = timeout or DEFAULT_SEND_TIMEOUT
-        self._wait_for_reply = wait_for_reply
 
         self._echo_pkt: Packet | None = None
         self._rply_pkt: Packet | None = None
@@ -93,10 +90,6 @@ class QosParams:
     @property
     def timeout(self) -> float:
         return self._timeout
-
-    @property
-    def wait_for_reply(self) -> bool | None:
-        return self._wait_for_reply
 
 
 class SendParams:

--- a/tests/tests_rf/test_binding_fsm.py
+++ b/tests/tests_rf/test_binding_fsm.py
@@ -235,7 +235,6 @@ def _setup_fakeable_device(gwy: Gateway, device_id: str) -> Fakeable:
             if qos is not None:
                 kwargs["max_retries"] = qos.max_retries
                 kwargs["timeout"] = qos.timeout
-                kwargs["wait_for_reply"] = qos.wait_for_reply
 
             return await gwy.async_send_cmd(cmd, **kwargs)
 

--- a/tests/tests_rf/test_hgi_behaviors.py
+++ b/tests/tests_rf/test_hgi_behaviors.py
@@ -125,7 +125,7 @@ async def _test_gwy_device(gwy: Gateway, test_idx: int) -> None:
         # using gwy._engine._protocol.send_cmd() instead of gwy.async_send_cmd() as the
         # latter may swallow the exception we wish to capture (ProtocolSendFailed)
         pkt = await gwy._engine._protocol.send_cmd(
-            cmd, qos=QosParams(wait_for_reply=False, timeout=timeout)
+            cmd, qos=QosParams(timeout=timeout)
         )  # for this test, we only need the cmd echo
     except exc.ProtocolSendFailed:
         if is_hgi80 and cmd_str[7:16] != HGI_DEVICE_ID:

--- a/tests/tests_rf/test_protocol_fsm.py
+++ b/tests/tests_rf/test_protocol_fsm.py
@@ -225,20 +225,20 @@ async def _test_flow_30x(protocol: PortProtocol) -> None:
     rf: VirtualRf = protocol._transport.get_extra_info("virtual_rf")
     ser = serial.Serial(rf.ports[1])
 
-    qos = QosParams(wait_for_reply=True)
+    qos = QosParams()
 
     # STEP 1: Send an I cmd (no reply)...
     task = rf._loop.create_task(protocol._send_cmd(II_CMD_0, qos=qos), name="send_1")
     _assert_pkt_eq_cmd(await task, II_CMD_0)  # no reply pkt expected
 
-    # STEP 2: Send an RQ cmd, then receive the corresponding RP pkt...
+    # STEP 2: Send an RQ cmd (returns echo at L3)...
     task = rf._loop.create_task(protocol._send_cmd(RQ_CMD_0, qos=qos), name="send_2")
     protocol._loop.call_later(
         CALL_LATER_DELAY,
         ser.write,
         bytes(str(RP_PKT_0).encode("ascii")) + b"\r\n",
     )
-    assert await task == RP_PKT_0
+    _assert_pkt_eq_cmd(await task, RQ_CMD_0)
 
     # STEP 3: Send an I cmd (no reply) *twice*...
     task = rf._loop.create_task(protocol._send_cmd(II_CMD_0, qos=qos), name="send_3A")
@@ -247,7 +247,7 @@ async def _test_flow_30x(protocol: PortProtocol) -> None:
     task = rf._loop.create_task(protocol._send_cmd(II_CMD_0, qos=qos), name="send_3B")
     _assert_pkt_eq_cmd(await task, II_CMD_0)  # no reply pkt expected
 
-    # STEP 4: Send an RQ cmd, then receive the corresponding RP pkt...
+    # STEP 4: Send an RQ cmd (returns echo at L3)...
     task = rf._loop.create_task(protocol._send_cmd(RQ_CMD_1, qos=qos), name="send_4A")
 
     # TODO: make these deterministic so ser replies *only after* it receives cmd
@@ -262,11 +262,11 @@ async def _test_flow_30x(protocol: PortProtocol) -> None:
         bytes(str(RP_PKT_1).encode("ascii")) + b"\r\n",
     )
 
-    assert await task == RP_PKT_1
+    _assert_pkt_eq_cmd(await task, RQ_CMD_1)
 
 
 async def _test_flow_401(protocol: PortProtocol) -> None:
-    qos = QosParams(wait_for_reply=False)
+    qos = QosParams()
 
     numbers = list(range(24))
     tasks = dict()
@@ -283,7 +283,7 @@ async def _test_flow_401(protocol: PortProtocol) -> None:
 
 
 async def _test_flow_402(protocol: PortProtocol) -> None:
-    qos = QosParams(wait_for_reply=False)
+    qos = QosParams()
 
     numbers = list(range(24))
     tasks = dict()
@@ -323,7 +323,7 @@ async def _test_flow_60x(protocol: PortProtocol, num_cmds: int = 1) -> None:
                 data={"zone_idx": f"{idx:02X}"},
             )
         )
-        coro = protocol._send_cmd(cmd, qos=QosParams(wait_for_reply=False))
+        coro = protocol._send_cmd(cmd, qos=QosParams())
         tasks.append(protocol._loop.create_task(coro, name=f"cmd_{idx:02X}"))
 
     assert await asyncio.gather(*tasks)
@@ -352,15 +352,15 @@ async def _test_flow_qos(protocol: PortProtocol) -> None:
     _assert_pkt_eq_cmd(pkt, cmd, "Should be echo as there's no reply to wait for")
 
     cmd = put_sensor_temp("03:000444", 19.5)
-    pkt = await protocol._send_cmd(cmd, qos=QosParams(wait_for_reply=None))
+    pkt = await protocol._send_cmd(cmd, qos=QosParams())
     _assert_pkt_eq_cmd(pkt, cmd, "should be echo as there is no wait_for_reply")
 
     cmd = put_sensor_temp("03:000555", 19.5)
-    pkt = await protocol._send_cmd(cmd, qos=QosParams(wait_for_reply=False))
+    pkt = await protocol._send_cmd(cmd, qos=QosParams())
     _assert_pkt_eq_cmd(pkt, cmd, "should be echo as there is no wait_for_reply")
 
     cmd = put_sensor_temp("03:000666", 19.5)
-    pkt = await protocol._send_cmd(cmd, qos=QosParams(wait_for_reply=True))
+    pkt = await protocol._send_cmd(cmd, qos=QosParams())
     _assert_pkt_eq_cmd(pkt, cmd, "Should be echo as there's no reply to wait for")
 
     # # ### Simple test for an RQ (expects an RP)...
@@ -406,7 +406,7 @@ async def _test_flow_qos(protocol: PortProtocol) -> None:
             data={},
         )
     )
-    pkt = await protocol._send_cmd(cmd, qos=QosParams(wait_for_reply=None))
+    pkt = await protocol._send_cmd(cmd, qos=QosParams())
     _assert_pkt_eq_cmd(pkt, cmd, "Should be echo as there is no wait_for_reply")
 
     cmd = build_dto(
@@ -417,7 +417,7 @@ async def _test_flow_qos(protocol: PortProtocol) -> None:
             data={},
         )
     )
-    pkt = await protocol._send_cmd(cmd, qos=QosParams(wait_for_reply=False))
+    pkt = await protocol._send_cmd(cmd, qos=QosParams())
     _assert_pkt_eq_cmd(pkt, cmd, "Should be echo as there is no wait_for_reply")
 
     cmd = build_dto(
@@ -428,8 +428,8 @@ async def _test_flow_qos(protocol: PortProtocol) -> None:
             data={},
         )
     )
-    coro = protocol._send_cmd(cmd, qos=QosParams(wait_for_reply=True, timeout=0.05))
-    await _test_flow_qos_helper(coro)
+    pkt = await protocol._send_cmd(cmd, qos=QosParams(timeout=0.05))
+    _assert_pkt_eq_cmd(pkt, cmd, "Should be echo as there's no reply to wait for")
 
     # # ### Simple test for an I (does not expect any reply)...
 

--- a/tests/tests_tx/protocol/test_fsm.py
+++ b/tests/tests_tx/protocol/test_fsm.py
@@ -61,7 +61,6 @@ def mock_qos() -> MagicMock:
     """Provide a mocked QoS Params object."""
     qos = MagicMock()
     qos.timeout = 1.0
-    qos.wait_for_reply = True
     qos.max_retries = 2  # Added to prevent TypeError in qos.py
     return qos
 


### PR DESCRIPTION
### ⚠️ STACKED PR: Depends on #927 < was merged

### The Problem:
`wait_for_reply` was historically passed down to the L3 Transport Layer (`ramses_tx`) to instruct the L3 FSM to wait for conversational reply packets. Since Phase 4b (The Execution Cutover), L7 `CommandDispatcher` and `ConversationManager` have taken over conversational tracking. Passing `wait_for_reply` down to `Gateway`, `Engine`, and `QosParams` is now obsolete boilerplate.

### The Fix:
- Removed `wait_for_reply` parameter from `Gateway.send_cmd()`, `Gateway.async_send_cmd()`, `Engine.async_send_cmd()`, and `QosParams`.
- Retained `wait_for_reply` on `CommandDispatcher.send()` for L7 conversation tracking, but stopped forwarding `wait_for_reply` kwargs to `Gateway`.
- Stripped legacy `wait_for_reply` logic from `ramses_tx.protocol.core` and `ramses_tx.protocol.base`.
- Updated test suites across `tests_tx` and `tests_rf` to reflect L3 echo-only resolution.

### Testing Performed:
- `mypy --strict`: Success (no issues found in 249 source files).
- `prek run -a`: All hooks passed.
- `pytest`: 1448 passed, 39 skipped.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.