### PR TITLE
refactor(protocol): streamline transport FSM and delete WantRply state (Phase 4d.2)

### DIFF
--- a/src/ramses_tx/dtos.py
+++ b/src/ramses_tx/dtos.py
@@ -127,12 +127,3 @@ class CommandDTO:
 
         pkt = Packet._from_cmd(self)
         return str(pkt_header(pkt))
-
-    @property
-    def rx_header(self) -> str | None:
-        """Return the QoS header of the expected Rx packet."""
-        from .packet import Packet, pkt_header
-
-        pkt = Packet._from_cmd(self)
-        hdr = pkt_header(pkt, rx_header=True)
-        return str(hdr) if hdr else None

--- a/src/ramses_tx/packet.py
+++ b/src/ramses_tx/packet.py
@@ -15,7 +15,7 @@ import orjson
 
 from . import exceptions as exc
 from .address import ALL_DEV_ADDR, NON_DEV_ADDR, Address, pkt_addrs
-from .const import I_, RAW_LINE_REGEX, RP, RQ, W_, Code, VerbT
+from .const import I_, RAW_LINE_REGEX, RP, W_, Code, VerbT
 from .dtos import CommandDTO, PacketDTO
 from .logger import getLogger
 from .typing import HeaderT, PayloadT
@@ -742,31 +742,19 @@ class Packet:
         return cls.from_raw_line(dtm, raw_line, raw_frame=raw_frame)
 
 
-def pkt_header(pkt: Packet, /, rx_header: bool = False) -> HeaderT | None:
+def pkt_header(pkt: Packet, /) -> HeaderT | None:
     """Return the QoS header fingerprint of a packet.
 
     :param pkt: Packet instance to evaluate
     :type pkt: Packet
-    :param rx_header: If True, return expected response header fingerprint
-    :type rx_header: bool
     :returns: Header fingerprint string or None
     :rtype: HeaderT | None
     """
     if pkt.code == Code._1FC9:
-        if not rx_header:
-            device_id = ALL_DEV_ADDR.id if pkt.src == pkt.dst else pkt.dst.id
-            return HeaderT("|".join((pkt.code, pkt.verb, device_id)))
-        if pkt.src == pkt.dst:
-            return HeaderT("|".join((pkt.code, W_, pkt.src.id)))
-        if pkt.verb == W_:
-            return HeaderT("|".join((pkt.code, I_, pkt.src.id)))
-        return None
+        device_id = ALL_DEV_ADDR.id if pkt.src == pkt.dst else pkt.dst.id
+        return HeaderT("|".join((pkt.code, pkt.verb, device_id)))
 
-    if rx_header:
-        if pkt.verb in (I_, RP) or pkt.src == pkt.dst:
-            return None
-        header = "|".join((pkt.code, RP if pkt.verb == RQ else I_, pkt.dst.id))
-    elif pkt.verb in (I_, RP) or pkt.src == pkt.dst:
+    if pkt.verb in (I_, RP) or pkt.src == pkt.dst:
         header = "|".join((pkt.code, pkt.verb, pkt.src.id))
     else:
         header = "|".join((pkt.code, pkt.verb, pkt.dst.id))

--- a/src/ramses_tx/protocol/fsm.py
+++ b/src/ramses_tx/protocol/fsm.py
@@ -145,7 +145,7 @@ class ProtocolContext(StateMachineInterface):
     @property
     def is_sending(self) -> bool:
         """Return True if the context is currently sending a command."""
-        return isinstance(self._state, WantEcho | WantRply)
+        return isinstance(self._state, WantEcho)
 
     @property
     def state(self) -> _ProtocolStateT:
@@ -188,10 +188,9 @@ class ProtocolContext(StateMachineInterface):
                 if self._qos_mgr.tx_count == 3
                 else logging.WARNING
             )
-            state_str = "echo" if isinstance(self._state, WantEcho) else "reply"
             _LOGGER.log(
                 level,
-                f"Timeout expired waiting for {state_str}: {self} (delay={delay})",
+                f"Timeout expired waiting for echo: {self} (delay={delay})",
             )
 
             if self._qos_mgr.tx_count < self._qos_mgr.tx_limit:
@@ -205,13 +204,7 @@ class ProtocolContext(StateMachineInterface):
 
             if isinstance(self._state, IsInIdle):
                 self._loop.call_soon_threadsafe(self._check_buffer_for_cmd)
-            elif (
-                isinstance(self._state, WantRply)
-                and self._qos_mgr.qos
-                and not getattr(self._qos_mgr.qos, "wait_for_reply", False)
-            ):
-                self.set_state(IsInIdle, result=self._state._echo_pkt)
-            elif isinstance(self._state, WantEcho | WantRply):
+            elif isinstance(self._state, WantEcho):
                 self._expiry_timer = self._loop.create_task(expire_state_on_timeout())
 
         if self._expiry_timer is not None:
@@ -261,7 +254,7 @@ class ProtocolContext(StateMachineInterface):
             self._qos_mgr.tx_count += 1
         elif isinstance(self._state, WantEcho):
             self._qos_mgr.tx_count = 1
-        elif not isinstance(self._state, WantRply):
+        else:
             self._qos_mgr.reset_active()
 
         self._loop.call_soon_threadsafe(effect_state, timed_out)
@@ -513,7 +506,7 @@ class WantEcho(ProtocolStateBase):
         self._sent_cmd = context._state._sent_cmd
 
     def pkt_rcvd(self, pkt: Packet) -> None:
-        """If the pkt is the expected Echo, transition to IsInIdle, or WantRply."""
+        """If the pkt is the expected Echo, transition to IsInIdle."""
         if self._sent_cmd is None:
             _LOGGER.debug(
                 "%s: received packet while _sent_cmd is None "
@@ -527,33 +520,6 @@ class WantEcho(ProtocolStateBase):
         except PacketPayloadInvalid:
             return  # malformed packet, ignore
 
-        if (
-            self._sent_cmd.rx_header
-            and pkt_hdr == self._sent_cmd.rx_header
-            and (
-                pkt.dst.id == self._sent_cmd.addr1
-                or (
-                    self._sent_cmd.addr1 == HGI_DEVICE_ID
-                    and pkt.dst.id == self._context._protocol.hgi_id
-                )
-            )
-        ):
-            level = (
-                logging.DEBUG
-                if self._context._cmd_tx_count < 3
-                else logging.INFO
-                if self._context._cmd_tx_count == 3
-                else logging.WARNING
-            )
-            _LOGGER.log(
-                level,
-                "%s: Invalid state to receive a reply (expecting echo)",
-                self._context,
-            )
-            self._rply_pkt = pkt
-            self._context.set_state(IsInIdle, result=pkt)
-            return
-
         if HGI_DEVICE_ID in pkt_hdr:
             assert pkt._hdr_ is not None
             pkt__hdr = HeaderT(
@@ -566,74 +532,12 @@ class WantEcho(ProtocolStateBase):
             return
 
         self._echo_pkt = pkt
-        if (
-            self._sent_cmd.rx_header
-            and self._context._qos_mgr.qos
-            and getattr(self._context._qos_mgr.qos, "wait_for_reply", False)
-        ):
-            self._context.set_state(WantRply)
-        else:
-            self._context.set_state(IsInIdle, result=pkt)
+        self._context.set_state(IsInIdle, result=pkt)
 
     def cmd_sent(self, cmd: CommandDTO, is_retry: bool | None = None) -> None:
         """Transition to WantEcho (i.e. a retransmit)."""
         pass
 
 
-class WantRply(ProtocolStateBase):
-    """The Protocol is waiting to receive an reply Packet."""
-
-    def __init__(self, context: ProtocolContext) -> None:
-        """Initialize the state with the echo that triggered it."""
-        super().__init__(context)
-        self._sent_cmd = context._state._sent_cmd
-        self._echo_pkt = context._state._echo_pkt
-
-    def pkt_rcvd(self, pkt: Packet) -> None:
-        """If the pkt is the expected reply, transition to IsInIdle."""
-        if self._sent_cmd is None or self._echo_pkt is None:
-            _LOGGER.debug(
-                "%s: received packet while _sent_cmd/_echo_pkt is None "
-                "(unsolicited broadcast?), ignoring",
-                self._context,
-            )
-            return
-
-        try:
-            pkt_hdr = pkt._hdr
-        except PacketPayloadInvalid:
-            return  # malformed packet, ignore
-
-        if pkt_hdr == self._sent_cmd.tx_header and pkt.src == self._echo_pkt.src:
-            level = (
-                logging.DEBUG
-                if self._context._cmd_tx_count < 3
-                else logging.INFO
-                if self._context._cmd_tx_count == 3
-                else logging.WARNING
-            )
-            _LOGGER.log(
-                level,
-                "%s: Invalid state to receive an echo (expecting reply)",
-                self._context,
-            )
-            return
-
-        if (
-            self._sent_cmd.rx_header[:8] == "0418|RP|"  # type: ignore[index]
-            and self._sent_cmd.rx_header[:-2] == pkt_hdr[:-2]  # type: ignore[index]
-            and pkt.payload == "000000B0000000000000000000007FFFFF7000000000"
-        ):
-            self._rply_pkt = pkt
-        elif pkt_hdr != self._sent_cmd.rx_header:
-            return
-        else:
-            self._rply_pkt = pkt
-
-        self._context.set_state(IsInIdle, result=pkt)
-
-
-_ProtocolStateT: TypeAlias = Inactive | IsInIdle | WantEcho | WantRply
-_ProtocolStateClassT: TypeAlias = (
-    type[Inactive] | type[IsInIdle] | type[WantEcho] | type[WantRply]
-)
+_ProtocolStateT: TypeAlias = Inactive | IsInIdle | WantEcho
+_ProtocolStateClassT: TypeAlias = type[Inactive] | type[IsInIdle] | type[WantEcho]

--- a/tests/tests_rf/test_protocol_fsm.py
+++ b/tests/tests_rf/test_protocol_fsm.py
@@ -29,7 +29,6 @@ from ramses_tx.protocol.fsm import (
     IsInIdle,
     ProtocolContext,
     WantEcho,
-    WantRply,
     _ProtocolStateT,
 )
 from ramses_tx.transport import TransportConfig, transport_factory
@@ -180,7 +179,7 @@ def assert_protocol_state_detail(
 
     assert getattr(protocol._context.state, "_sent_cmd", None) == cmd
     assert protocol._context._cmd_tx_count == num_sends
-    assert bool(cmd) is isinstance(protocol._context.state, WantEcho | WantRply)
+    assert bool(cmd) is isinstance(protocol._context.state, WantEcho)
 
 
 async def async_pkt_received(

--- a/tests/tests_rf/test_use_regex.py
+++ b/tests/tests_rf/test_use_regex.py
@@ -153,8 +153,6 @@ async def test_regex_with_qos() -> None:
 
         for before, after in TESTS_OUTBOUND.items():
             cmd = Command.from_cli(before)
-            if cmd.rx_header:  # we won't be getting any replies
-                continue
 
             pkt_src = await gwy_0.async_send_cmd(cmd)
             assert str(pkt_src) == before

--- a/tests/tests_tx/protocol/test_fsm.py
+++ b/tests/tests_tx/protocol/test_fsm.py
@@ -10,15 +10,7 @@ import pytest
 from ramses_tx.const import Priority
 from ramses_tx.exceptions import TransportError
 from ramses_tx.packet import Packet
-
-# Updated imports based on your VSCode resolution
-from ramses_tx.protocol.fsm import (
-    Inactive,
-    IsInIdle,
-    ProtocolContext,
-    WantEcho,
-    WantRply,
-)
+from ramses_tx.protocol.fsm import Inactive, IsInIdle, ProtocolContext, WantEcho
 
 
 @pytest.fixture
@@ -48,7 +40,6 @@ def mock_cmd() -> MagicMock:
     """Provide a basic mocked Command."""
     cmd = MagicMock()
     cmd.tx_header = "10A0|RQ|01:123456"
-    cmd.rx_header = "10A0|RP|01:123456"
     cmd.src.id = "18:000730"
     cmd.dst.id = "01:123456"
     # To satisfy `HGI_DEVICE_ID in cmd.tx_header` checks in IsInIdle
@@ -108,21 +99,12 @@ async def test_fsm_send_cmd_success(
     echo_pkt._hdr = mock_cmd.tx_header
     fsm_context.pkt_received(echo_pkt)
 
-    # Given wait_for_reply is True in mock_qos, it moves to WantRply
-    assert isinstance(fsm_context.state, WantRply)
-
-    # Simulate receiving the reply packet
-    rply_pkt = MagicMock(spec=Packet)
-    rply_pkt._hdr = mock_cmd.rx_header
-    rply_pkt.src = MagicMock()  # Must not match echo's src identically
-    fsm_context.pkt_received(rply_pkt)
-
     # Should resolve and go back to Idle
     await asyncio.sleep(0.01)
     assert isinstance(fsm_context.state, IsInIdle)
 
     result = await send_task
-    assert result == rply_pkt
+    assert result == echo_pkt
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### ⚠️ STACKED PR: Depends on #928 < was merged

### The Problem:
Now that `wait_for_reply` has been deprecated from lower-level transport and gateway APIs (PR #928), the L3 Transport Layer (`ramses_tx`) contains unused code paths, state definitions (`WantRply`), and regex header matching (`rx_header`) previously used for conversational reply tracking.

### The Fix:
- **Deleted `WantRply` State**: Removed the `WantRply` class from `ramses_tx.protocol.fsm` and updated FSM state type aliases `_ProtocolStateT` and `_ProtocolStateClassT` to `Inactive | IsInIdle | WantEcho`.
- **Streamlined State Transitions**: Simplified `WantEcho.pkt_rcvd()` to transition directly back to `IsInIdle` upon receiving the physical transmission echo packet.
- **Removed Response Regex Matching**: Removed the `rx_header` parameter from `pkt_header()` in `ramses_tx.packet` and deleted the `CommandDTO.rx_header` property from `ramses_tx.dtos`.
- **Updated Test Suite**: Updated `tests_tx` and `tests_rf` FSM tests to verify direct-to-idle transitions on echo packets.

### Testing Performed:
- `mypy --strict`: Success (0 errors in 249 source files).
- `prek run -a`: All hooks passed cleanly.
- `pytest`: 1448 passed, 39 skipped.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.