### PR TITLE
fix(parser): add data_type 91 (signed int32) for `2411` bypass valve param

### DIFF
--- a/src/ramses_rf/parsers/hvac.py
+++ b/src/ramses_rf/parsers/hvac.py
@@ -796,6 +796,13 @@ def parser_2411(payload: str, msg: Message) -> dict[str, Any]:
             return val
         return None
 
+    def signed32(x: str) -> int:
+        # 4-byte signed integer (two's complement), used by params whose
+        # min_value can be negative (e.g. 4B bypass valve test position,
+        # which reports min 0xFFFFFF38 = -200). See issue 740.
+        val = int(x, 16)
+        return val - 0x100000000 if val >= 0x80000000 else val
+
     _2411_DATA_TYPES = {
         "00": (2, counter),  # 4E (0-1), 54 (15-60)
         "01": (2, centile),  # 52 (0.0-25.0) (%)
@@ -806,6 +813,7 @@ def parser_2411(payload: str, msg: Message) -> dict[str, Any]:
         "20": (4, counter),  # 01 - Support parameter
         "80": (4, bool32),  # 07 - ClimaRad MiniBox: 0/1, FFFFFFFF/000000FF = N/A
         "90": (4, counter),  # 3E - Away mode Exhaust fan rate (%)
+        "91": (8, signed32),  # 4B - Bypass Valve test position (signed int32)
         "92": (4, hex_to_temp),  # 75 (0-30) (C)
     }
 

--- a/tests/tests/test_parser_helpers.py
+++ b/tests/tests/test_parser_helpers.py
@@ -244,6 +244,27 @@ def test_2411_data_type_80_bool_values() -> None:
     assert "_unknown_data_type" not in result
 
 
+def test_2411_data_type_91_bypass_valve_signed() -> None:
+    """2411 param 4B with data_type 91 (signed int32) must parse without warning.
+
+    The device sends data_type 91 for the bypass valve test position, with a
+    negative min_value (0xFFFFFF38 = -200 as two's complement). data_type 91
+    is a 4-byte signed integer. See issue 740.
+    """
+    msg = _make_22f1_msg(
+        "2026-07-26T15:55:42.000000 040 RP --- 32:022222 29:091138 --:------ 2411 022 "
+        "00004B5891000000E6FFFFFF38000001F40000000164"
+    )
+    result = msg.payload
+    assert result["parameter"] == "4B"
+    assert result["description"] == "(Test) Bypass Valve (0=auto, 1=open, 2=closed)"
+    assert result["value"] == 230  # 0x000000E6
+    assert result["min_value"] == -200  # 0xFFFFFF38 (two's complement)
+    assert result["max_value"] == 500  # 0x000001F4
+    assert result["precision"] == 1
+    assert "_unknown_data_type" not in result
+
+
 def test_helper_demand_transform() -> None:
     assert [x[1] for x in TRANSFORMS] == [_transform(x[0]) for x in TRANSFORMS]
 


### PR DESCRIPTION
The ClimaRad Ventura sends param 4B (bypass valve test position) with data_type 91, which was unrecognized and produced a warning in the HA log. data_type 91 is a 4-byte signed integer (two's complement) — the device reports a negative min_value of 0xFFFFFF38 (-200), which the existing unsigned counter decoder would misdecode as 4294967096.

Adds a signed32() decoder and the "91" entry to _2411_DATA_TYPES, following the same pattern as the existing bool32/counter/hex_to_temp entries. Includes a regression test using the exact packet from silverailscolo's report on issue 740.

Refs: https://github.com/ramses-rf/ramses_cc/issues/740

AI used: GLM 5.2 high