### PR TITLE
set_dhw_mode accept I_ as response for W_

### DIFF
--- a/src/ramses_rf/pipeline/conversation.py
+++ b/src/ramses_rf/pipeline/conversation.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Final
 
 from ramses_rf.commands.builders import build_dto
 from ramses_rf.commands.core import Command
-from ramses_tx import RP, Packet
+from ramses_tx import I_, RP, W_, Packet
 from ramses_tx.dtos import CommandDTO
 from ramses_tx.exceptions import ProtocolSendFailed, ProtocolTimeoutError
 
@@ -229,9 +229,6 @@ class ConversationManager:
         :returns: True if matched, False otherwise.
         :rtype: bool
         """
-        if msg.verb != RP:
-            return False
-
         matched_key: str | None = None
         matched_pending: PendingConversation | None = None
 
@@ -242,6 +239,12 @@ class ConversationManager:
 
             # Check code matching
             if str(msg.code) != pending.dto.code:
+                continue
+
+            # Check verb matching: RP is always valid; I is valid for W commands
+            # (e.g. Evohome DHW acknowledges W 1F41 with I 1F41, not RP 1F41).
+            # See issue 873.
+            if msg.verb != RP and not (msg.verb == I_ and pending.dto.verb == W_):
                 continue
 
             matched_key = key

--- a/tests/tests_rf/test_conversation_parity.py
+++ b/tests/tests_rf/test_conversation_parity.py
@@ -109,3 +109,43 @@ async def test_conversation_manager_timeout_and_retries() -> None:
     assert manager.pending_count == 0
     with pytest.raises(ProtocolTimeoutError):
         fut.result()
+
+
+def test_conversation_manager_accepts_i_for_w_commands() -> None:
+    """ConversationManager must accept I responses for W commands (issue 873).
+
+    Evohome DHW controllers acknowledge W 1F41 writes with I 1F41, not RP 1F41.
+    """
+    import asyncio
+    from unittest.mock import MagicMock
+
+    from ramses_rf.address import Address
+    from ramses_rf.commands.core import Command
+    from ramses_rf.enums import Action
+    from ramses_rf.pipeline.conversation import ConversationManager
+    from ramses_tx import I_
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    cm = ConversationManager(loop=loop, default_timeout=0.5, max_retries=2)
+
+    intent = Command(
+        src=Address("18:191664"),
+        dst=Address("01:216136"),
+        action=Action.SET_DHW_MODE,
+        data={"mode": "permanent_override", "active": False},
+        needs_reply=True,
+        timeout=0.5,
+    )
+    fut = loop.run_until_complete(cm.track_intent(intent, timeout=0.5, max_retries=2))
+
+    # Simulate the I 1F41 response from the CTL (broadcast dst)
+    mock_msg = MagicMock()
+    mock_msg.verb = I_
+    mock_msg.src.id = "01:216136"  # from the device we sent to
+    mock_msg.code.__str__ = lambda self: "1F41"
+    mock_msg._pkt = MagicMock()
+
+    matched = cm.process_msg(mock_msg)
+    assert matched is True
+    assert fut.done() and not fut.cancelled()


### PR DESCRIPTION
This PR fixes issue [cc 873](https://github.com/ramses-rf/ramses_cc/issues/873#issuecomment-5084421410)

- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: suggested fix from https://github.com/ramses-rf/ramses_cc/issues/873#issuecomment-5084368950

**PR Summary**
Handle special case for `set_dhw_mode` where `W_` command is confirmed using `I_`, normally `RQ`
Add test