### PR TITLE
fix(transport): handle TransportError during closing and validate topic_sub before MQTT unsubscribe

### DIFF
--- a/src/ramses_tx/transport/base.py
+++ b/src/ramses_tx/transport/base.py
@@ -169,7 +169,11 @@ class _ReadTransport(_BaseTransport, TransportInterface):
             _LOGGER.warning("%s < PacketInvalid(%s)", frame, err)
             return
 
-        self._pkt_read(pkt)
+        try:
+            self._pkt_read(pkt)
+        except exc.TransportError as err:
+            _LOGGER.debug("%s < Transport Error(%s)", pkt, err)
+            return
 
     def _pkt_read(self, pkt: Packet) -> None:
         """Pass any valid Packets to the protocol's callback."""

--- a/src/ramses_tx/transport/mqtt.py
+++ b/src/ramses_tx/transport/mqtt.py
@@ -567,7 +567,8 @@ class MqttTransport(_FullTransport, _MqttTransportAbstractor):
         self._connected = False
 
         try:
-            self.client.unsubscribe(self._topic_sub)
+            if hasattr(self, "_topic_sub") and self._topic_sub:
+                self.client.unsubscribe(self._topic_sub)
             self.client.disconnect()
             self.client.loop_stop()
         except (ValueError, MQTTException) as err:


### PR DESCRIPTION
### The Problem:
1. When a transport is closing or closed during reload/teardown, `_pkt_read()` raises `exc.TransportError("Transport is closing or has closed")`. `_frame_read()` in `_ReadTransport` did not catch `exc.TransportError`, causing unhandled exceptions in Home Assistant's event loop callback wrapper (`Error doing job: Exception in callback _ReadTransport._frame_read()`).
2. `MqttTransport._close()` attempted to call `self.client.unsubscribe(self._topic_sub)` even when `self._topic_sub` was empty `""`, raising `ValueError: Invalid topic.`.

### The Fix:
1. Updated `_frame_read()` in `src/ramses_tx/transport/base.py` to catch `exc.TransportError` when closing and log at `DEBUG` level.
2. Updated `_close()` in `src/ramses_tx/transport/mqtt.py` to check that `self._topic_sub` is non-empty before calling `unsubscribe()`.

### Testing Performed:
- Verified docstring compliance (`ruff check --select D`).
- Passed strict `mypy` type checking (`mypy --strict`).
- Verified `prek` pre-commit checks.
- Validated via `ha_sim_test` integration test suite, eliminating 100% of transport callback errors (reduced unexpected errors from 293 down to 0).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.