### PR TITLE
Fix PollingManager task pruning, rate limiting, and exception logging (closes #944)

### DIFF
--- a/src/ramses_rf/devices/dev_registry.py
+++ b/src/ramses_rf/devices/dev_registry.py
@@ -150,11 +150,15 @@ class DeviceRegistry:
 
             # ROUTING INTERCEPT: Target the correct sub-domain
             if hasattr(tcs, "_get_zone"):
-                with contextlib.suppress(Exception):
+                try:
                     tcs._get_zone(zone_idx)
+                except (IndexError, KeyError, TypeError, ValueError) as err:
+                    _LOGGER.debug("Failed to resolve zone %s: %s", zone_idx, err)
             elif hasattr(tcs, "_get_htg_zone"):
-                with contextlib.suppress(Exception):
+                try:
                     tcs._get_htg_zone(zone_idx)
+                except (IndexError, KeyError, TypeError, ValueError) as err:
+                    _LOGGER.debug("Failed to resolve htg zone %s: %s", zone_idx, err)
 
             if hasattr(tcs, "get_htg_zone"):
                 parent = tcs.get_htg_zone(zone_idx)

--- a/src/ramses_rf/dispatcher.py
+++ b/src/ramses_rf/dispatcher.py
@@ -555,7 +555,7 @@ def _update_faultlog_state(target: Any, p: dict[str, Any], msg: Message) -> None
 
     from ramses_rf.systems.faultlog import FaultLogEntry
 
-    with contextlib.suppress(Exception):
+    try:
         entry = FaultLogEntry.from_msg(msg)
 
         # Append to the immutable tuple, safely removing stale matching timestamps
@@ -578,6 +578,8 @@ def _update_faultlog_state(target: Any, p: dict[str, Any], msg: Message) -> None
             causation_id=getattr(msg, "message_id", uuid.uuid4()),
         )
         target.apply_state_update(event)
+    except (AttributeError, KeyError, TypeError, ValueError) as err:
+        _LOGGER.warning("Failed to process fault log entry from msg %s: %s", msg, err)
 
 
 def _update_system_state(target: Any, p: dict[str, Any], msg: Message) -> None:

--- a/src/ramses_rf/lifecycle.py
+++ b/src/ramses_rf/lifecycle.py
@@ -158,8 +158,14 @@ class GatewayLifecycle:
         for dev in self.device_registry.devices:
             bm = getattr(dev, "_binding_manager", None)
             if bm:
-                with contextlib.suppress(Exception):
+                try:
                     bm.cancel()
+                except (AttributeError, RuntimeError) as err:
+                    _LOGGER.debug(
+                        "Error cancelling binding manager for device %s: %s",
+                        getattr(dev, "id", dev),
+                        err,
+                    )
 
         await self._engine.stop()
 

--- a/src/ramses_rf/parsers/decoder.py
+++ b/src/ramses_rf/parsers/decoder.py
@@ -488,8 +488,18 @@ class HeartbeatDecoder(PayloadDecoder):
                 res = parser(payload_str, msg)
                 if res == {}:
                     return None
-            except Exception:
-                pass
+            except (
+                exc.ParserBaseError,
+                IndexError,
+                KeyError,
+                TypeError,
+                ValueError,
+            ) as err:
+                _LOGGER.debug(
+                    "Parser for code %s failed, falling back to heartbeat: %s",
+                    dto.code,
+                    err,
+                )
             return parser_heartbeat(payload_str, msg)
 
         if self._next_decoder:

--- a/src/ramses_rf/parsers/pipeline.py
+++ b/src/ramses_rf/parsers/pipeline.py
@@ -177,8 +177,18 @@ class HeartbeatDecoder(PayloadDecoder):
                 res = parser(payload_str, msg)
                 if res == {}:
                     return None
-            except Exception:
-                pass
+            except (
+                exc.ParserBaseError,
+                IndexError,
+                KeyError,
+                TypeError,
+                ValueError,
+            ) as err:
+                _LOGGER.debug(
+                    "Parser for code %s failed, falling back to heartbeat: %s",
+                    msg.code,
+                    err,
+                )
             return parser_heartbeat(payload_str, msg)
 
         if self._next_decoder:

--- a/src/ramses_rf/pipeline/polling.py
+++ b/src/ramses_rf/pipeline/polling.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Final
 
 from ramses_rf.const import DevType
 from ramses_rf.devices.helpers import build_rq_cmd
+from ramses_rf.exceptions import RamsesException
 from ramses_rf.helpers import schedule_task
 from ramses_rf.typing import DeviceIdT, PollingIntervalsT
 
@@ -70,6 +71,7 @@ DEFAULT_POLLING_SCHEDULES: Final[dict[str, dict[str, int | None]]] = {
     },
 }
 
+POLL_INTER_CMD_GAP: Final[float] = 0.5  # Rate limit gap between consecutive TX commands
 DEFAULT_POLL_CYCLE_SECS: Final[float] = 300.0  # 5 minutes maximum idle sleep
 
 
@@ -191,17 +193,21 @@ class PollingManager:
             if interval is not None and interval > 0
         }
 
-    def update_device_tasks(self, device: DeviceBase) -> None:
+    def update_device_tasks(self, device: DeviceBase) -> set[tuple[DeviceIdT, str]]:
         """Update or register scheduled polling tasks for a device entity.
 
         :param device: The device entity to register or refresh.
         :type device: DeviceBase
+        :returns: Set of active task keys (device_id, code) for the device.
+        :rtype: set[tuple[DeviceIdT, str]]
         """
         schedule = self.resolve_schedule_for_device(device)
         now = dt.now(UTC)
+        active_keys: set[tuple[DeviceIdT, str]] = set()
 
         for code, interval in schedule.items():
             key = (device.id, code)
+            active_keys.add(key)
             if key not in self._tasks:
                 self._tasks[key] = PollingTask(
                     device_id=device.id,
@@ -211,6 +217,8 @@ class PollingManager:
                 )
             else:
                 self._tasks[key].interval = interval
+
+        return active_keys
 
     def get_scheduled_cmds(self) -> list[PollingTask]:
         """Return a list of all currently tracked polling tasks.
@@ -264,7 +272,7 @@ class PollingManager:
         while self._running:
             try:
                 await self.poll_due_commands()
-            except Exception as err:  # noqa: BLE001
+            except (RamsesException, TimeoutError) as err:
                 _LOGGER.error("Error in PollingManager loop: %s", err)
 
             sleep_secs = self._calculate_next_sleep_interval()
@@ -279,16 +287,24 @@ class PollingManager:
         if getattr(self._gwy.config, "disable_polling", False):
             return 0
 
-        # Refresh tasks for all devices currently in registry
+        # Refresh tasks for all devices currently in registry and prune stale tasks
+        active_keys: set[tuple[DeviceIdT, str]] = set()
         for dev in list(self._gwy.device_registry.devices):
-            self.update_device_tasks(dev)
+            active_keys.update(self.update_device_tasks(dev))
+
+        for key in list(self._tasks):
+            if key not in active_keys:
+                del self._tasks[key]
 
         now = dt.now(UTC)
         processed_count = 0
 
-        for task in self._tasks.values():
+        for task in list(self._tasks.values()):
             if task.next_due > now:
                 continue
+
+            if processed_count > 0 and not self.shadow_mode:
+                await asyncio.sleep(POLL_INTER_CMD_GAP)
 
             processed_count += 1
             if self.shadow_mode:
@@ -305,7 +321,14 @@ class PollingManager:
                 task.last_polled = now
                 task.next_due = now + td(seconds=task.interval)
                 cmd_dto = build_rq_cmd(task.device_id, task.code)
-                with contextlib.suppress(Exception):
+                try:
                     await self._gwy.async_send_cmd(cmd_dto)
+                except (RamsesException, TimeoutError) as err:
+                    _LOGGER.warning(
+                        "PollingManager failed to send command %s to %s: %s",
+                        task.code,
+                        task.device_id,
+                        err,
+                    )
 
         return processed_count

--- a/tests/tests_rf/test_polling_parity.py
+++ b/tests/tests_rf/test_polling_parity.py
@@ -6,6 +6,7 @@ import pytest
 
 from ramses_rf.config import GatewayConfig
 from ramses_rf.devices.dev_base import BatteryState, DeviceBase
+from ramses_rf.exceptions import RamsesException
 from ramses_rf.models import DeviceTraits
 from ramses_rf.pipeline.polling import DEFAULT_POLLING_SCHEDULES, PollingManager
 
@@ -153,3 +154,80 @@ async def test_polling_manager_disabled_config_parity(
     # ASSERT
     assert processed_count == 0
     mock_gateway.async_send_cmd.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_polling_manager_stale_task_pruning(
+    mock_gateway: MagicMock,
+) -> None:
+    # ARRANGE
+    poller = PollingManager(mock_gateway, shadow_mode=True)
+    ctl_dev = MockDevice(mock_gateway, "01:111111", slug="CTL")
+    mock_gateway.device_registry.devices = [ctl_dev]
+
+    # ACT
+    await poller.poll_due_commands()
+    initial_count = len(poller.get_scheduled_cmds())
+
+    mock_gateway.device_registry.devices = []
+    await poller.poll_due_commands()
+    pruned_count = len(poller.get_scheduled_cmds())
+
+    # ASSERT
+    assert initial_count > 0
+    assert pruned_count == 0
+
+
+@pytest.mark.asyncio
+async def test_polling_manager_send_cmd_exception_handling(
+    mock_gateway: MagicMock,
+) -> None:
+    # ARRANGE
+    poller = PollingManager(mock_gateway, shadow_mode=False)
+    bdr_dev = MockDevice(mock_gateway, "13:222222", slug="BDR")
+    mock_gateway.device_registry.devices = [bdr_dev]
+    mock_gateway.async_send_cmd.side_effect = RamsesException("Transmission failure")
+
+    poller.update_device_tasks(bdr_dev)
+    past = dt.now(UTC) - td(seconds=10)
+    for task in poller.get_scheduled_cmds():
+        task.next_due = past
+
+    # ACT
+    processed_count = await poller.poll_due_commands()
+
+    # ASSERT
+    assert processed_count == 1
+    mock_gateway.async_send_cmd.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_polling_manager_rate_limiting(
+    mock_gateway: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # ARRANGE
+    poller = PollingManager(mock_gateway, shadow_mode=False)
+    ctl_dev = MockDevice(mock_gateway, "01:111111", slug="CTL")
+    mock_gateway.device_registry.devices = [ctl_dev]
+
+    poller.update_device_tasks(ctl_dev)
+    past = dt.now(UTC) - td(seconds=10)
+    tasks = poller.get_scheduled_cmds()
+    for task in tasks:
+        task.next_due = past
+
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(secs: float) -> None:
+        sleep_calls.append(secs)
+
+    monkeypatch.setattr("asyncio.sleep", fake_sleep)
+
+    # ACT
+    processed_count = await poller.poll_due_commands()
+
+    # ASSERT
+    assert processed_count == len(tasks)
+    assert len(sleep_calls) == len(tasks) - 1
+    assert all(s == 0.5 for s in sleep_calls)


### PR DESCRIPTION
### The Problem:
1. `PollingManager` never prunes stale tasks when devices are deleted or schedules change.
2. Multiple locations across `polling.py`, `dispatcher.py`, `dev_registry.py`, `lifecycle.py`, `decoder.py`, and `pipeline.py` suppressed generic `Exception` silently without logging or caught `Exception` broadly.
3. The first polling cycle causes a thundering-herd TX flood on startup.

### The Fix:
1. Updated `update_device_tasks()` to return active task keys and added pruning logic in `poll_due_commands()`.
2. Replaced generic/broad exception catches with fine-grained exception tuples and added appropriate debug/warning logging.
3. Added `POLL_INTER_CMD_GAP = 0.5` delay between consecutive TX commands in `poll_due_commands()` to rate-limit active polling transmissions.

### Testing Performed:
- `prek run -a` passed completely.
- `ruff format --check .` passed cleanly.
- Unit tests added in `test_polling_parity.py` covering task pruning, send exception handling, and rate-limiting.
- Full `pytest` test suite passed (1457 passed, 39 skipped).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.