### PR TITLE
fix(dispatcher): route zone temperature packets from CTL sensors to main TCS

### DIFF
--- a/src/ramses_rf/dispatcher.py
+++ b/src/ramses_rf/dispatcher.py
@@ -401,6 +401,7 @@ def _resolve_logical_targets(
     src_dev = gwy.device_registry.device_by_id.get(msg.src.id)
     dst_dev = gwy.device_registry.device_by_id.get(msg.dst.id)
     tcs = getattr(src_dev, "tcs", None) if src_dev else None
+    tcs = tcs or gwy.tcs
 
     # 1. Fault logs strictly target the TCS (if it exists) or the source device
     if msg.code == "0418":

--- a/tests/tests_rf/test_dispatcher.py
+++ b/tests/tests_rf/test_dispatcher.py
@@ -555,3 +555,43 @@ class TestForeignHgiDispatcher:
             for call in mock_gateway.device_registry.get_device.call_args_list
         ]
         assert self._FOREIGN_HGI in called_ids
+
+
+class TestResolveLogicalTargets:
+    """Test resolution of logical targets from messages."""
+
+    def test_zone_temp_fallback_to_main_tcs(self, mock_gateway: MagicMock) -> None:
+        """Test _resolve_logical_targets falls back to gwy.tcs for zone targets.
+
+        Regression test for #942: zone temp packets from a secondary CTL
+        (where src_dev.tcs is None) must still route to the main TCS zones.
+        """
+        # 1. Setup the Gateway with a main TCS and one zone
+        mock_tcs = MagicMock()
+        mock_zone = MagicMock()
+        mock_tcs.zone_by_idx = {"00": mock_zone}
+        mock_gateway.tcs = mock_tcs
+
+        # 2. Setup the source device (CTL) which has no TCS property set
+        src_id = "01:150003"
+        mock_src_dev = MagicMock()
+        mock_src_dev.tcs = None
+        mock_src_dev.type = "01"
+        mock_gateway.device_registry.device_by_id = {src_id: mock_src_dev}
+
+        # 3. Setup the message and payload (a typical 30C9 zone temp broadcast)
+        msg = MagicMock()
+        msg.src.id = src_id
+        msg.dst.id = src_id
+        msg.code = "30C9"
+        msg._has_array = False
+
+        payload = {"zone_idx": "00", "temperature": 21.0}
+
+        # 4. Resolve the targets
+        targets = dispatcher._resolve_logical_targets(mock_gateway, msg, payload)
+
+        # 5. Assert that the zone from the main TCS was included in the targets
+        assert mock_zone in targets, (
+            "Zone target was not resolved using fallback gwy.tcs"
+        )


### PR DESCRIPTION
### The Problem:
In `src/ramses_rf/dispatcher.py`, `_resolve_logical_targets` resolved target `tcs` using only `src_dev.tcs`. When zone temperature packets (e.g. `30C9` or `12B0`) originate from temperature sensors or secondary CTL devices, `src_dev.tcs` is `None`. Consequently, zone temperature broadcasts from these sensors were not routed to the target `Zone` in the main TCS (`gwy.tcs`), preventing temperature updates from reaching the zone state model (ramses-rf/ramses_rf#942).

### The Fix:
Updated `_resolve_logical_targets` in `src/ramses_rf/dispatcher.py` to fall back to `gwy.tcs` when `src_dev.tcs` is `None`. Added a unit test in `tests/tests_rf/test_dispatcher.py` (`TestResolveLogicalTargets`) to prevent future regressions.

### Testing Performed:
- Added `test_zone_temp_fallback_to_main_tcs` to `tests/tests_rf/test_dispatcher.py` following a TDD workflow.
- Verified test suite passes: `.venv/bin/pytest tests/tests_rf/test_dispatcher.py`.
- Ran `.venv/bin/prek run -a`, `.venv/bin/ruff format --check .`, and `.venv/bin/mypy`.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.