### PR TITLE
refactor(typing): add domain payload types, protocol interfaces and class factory generics

### DIFF
--- a/src/ramses_rf/interfaces.py
+++ b/src/ramses_rf/interfaces.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from .commands.dispatcher import CommandDispatcher as CQRSDispatcher
     from .devices.dev_base import Device
     from .models import TopologyChangedEvent
+    from .routing import StateHeader
     from .topology import Parent
 
 # Generic type variable for downcasting returned Device instances to subclasses
@@ -66,8 +67,8 @@ class MessageStoreInterface(Protocol):
         verb: str | None = None,
         code: str | None = None,
         ctx: Any | None = None,
-        hdr: str | None = None,
-    ) -> tuple[Any, ...]: ...
+        hdr: str | StateHeader | None = None,
+    ) -> tuple[Message, ...] | list[Message]: ...
     async def rem(
         self,
         msg: Any | None = None,

--- a/src/ramses_rf/lifecycle.py
+++ b/src/ramses_rf/lifecycle.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from .config import GatewayConfig
     from .gateway import Gateway
     from .interfaces import DeviceRegistryInterface, MessageStoreInterface
+    from .systems.tcs import Evohome
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,6 +48,7 @@ class GatewayLifecycle:
         _message_store: MessageStoreInterface | None
         _pkt_log_listener: QueueListener | None
         _schema: dict[str, Any]
+        _tcs: Evohome | None
         state_projector: StateProjector | None
 
         def add_task(self, task: asyncio.Task[Any]) -> None: ...
@@ -74,7 +76,7 @@ class GatewayLifecycle:
         if self._pkt_log_listener:
             self._pkt_log_listener.start()
 
-            pkt_log_config = cast("dict[str, Any]", self._engine._packet_log)
+            pkt_log_config: dict[str, Any] = dict(self._engine._packet_log)
             if flush_interval := pkt_log_config.get("flush_interval", 0):
 
                 async def _periodic_flush() -> None:
@@ -252,7 +254,7 @@ class GatewayLifecycle:
 
         def clear_state() -> None:
             _LOGGER.info("Gateway: Clearing existing schema/state...")
-            cast("Gateway", self)._tcs = None
+            self._tcs = None
             self.device_registry.devices.clear()
             self.device_registry.device_by_id.clear()
             self.clear_message_history()

--- a/src/ramses_rf/messages/base.py
+++ b/src/ramses_rf/messages/base.py
@@ -7,7 +7,7 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime as dt
-from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar
 
 from ramses_rf.address import Address, id_to_address
 from ramses_tx import CommandDTO, PacketDTO
@@ -245,10 +245,11 @@ class Message:
         :return: The generated message.
         :rtype: Message
         """
-        if isinstance(pkt, Message):
-            return cast(_MessageT, pkt)
-        if hasattr(pkt, "_msg") and isinstance(pkt._msg, Message):
-            return cast(_MessageT, pkt._msg)
+        if isinstance(pkt, cls):
+            return pkt
+        msg = getattr(pkt, "_msg", None)
+        if isinstance(msg, cls):
+            return msg
         return cls(pkt.to_dto())
 
     @classmethod

--- a/src/ramses_rf/parsers/hvac.py
+++ b/src/ramses_rf/parsers/hvac.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping
 from datetime import datetime as dt, timedelta as td
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
+from ramses_rf.typing import HvacPayloadT
 from ramses_tx.address import NON_DEV_ADDR, hex_id_to_dev_id
 from ramses_tx.const import (
     I_,
@@ -222,7 +223,7 @@ def parser_12a0(payload: str, msg: Message) -> dict[str, Any] | list[dict[str, A
     Structural unpacking occurs in the CQRS quirks pipeline.
     """
     if len(payload) <= 14:
-        return cast("dict[str, Any]", parse_indoor_humidity(payload[2:12]))
+        return dict(parse_indoor_humidity(payload[2:12]))
 
     return [
         {
@@ -442,7 +443,7 @@ def parser_22b0(payload: str, msg: Message) -> dict[str, Any]:
 
 # WIP: unknown, HVAC
 @register_parser("22E0")
-def parser_22e0(payload: str, msg: Message) -> Mapping[str, float | None]:
+def parser_22e0(payload: str, msg: Message) -> HvacPayloadT:
     """Parse the 22e0 packet.
 
     :param payload: The raw hex payload
@@ -450,7 +451,7 @@ def parser_22e0(payload: str, msg: Message) -> Mapping[str, float | None]:
     :param msg: The message object
     :type msg: Message
     :return: A mapping of percentage values extracted from the payload
-    :rtype: Mapping[str, float | None]
+    :rtype: HvacPayloadT
     :raises AssertionError: If a value exceeds the expected 200 threshold.
     :raises ValueError: If the payload cannot be parsed as percentages.
     """
@@ -476,7 +477,7 @@ def parser_22e0(payload: str, msg: Message) -> Mapping[str, float | None]:
 
 # WIP: unknown, HVAC
 @register_parser("22E5")
-def parser_22e5(payload: str, msg: Message) -> Mapping[str, float | None]:
+def parser_22e5(payload: str, msg: Message) -> HvacPayloadT:
     """Parse the 22e5 packet.
 
     :param payload: The raw hex payload
@@ -484,17 +485,17 @@ def parser_22e5(payload: str, msg: Message) -> Mapping[str, float | None]:
     :param msg: The message object
     :type msg: Message
     :return: A mapping of percentage values extracted from the payload
-    :rtype: Mapping[str, float | None]
+    :rtype: HvacPayloadT
     """
     # RP --- 32:153258 18:005904 --:------ 22E5 004 00-96-C8-14
     # RP --- 32:155617 18:005904 --:------ 22E5 004 00-72-C8-14
 
-    return cast("Mapping[str, float | None]", parser_22e0(payload, msg))
+    return parser_22e0(payload, msg)
 
 
 # WIP: unknown, HVAC
 @register_parser("22E9")
-def parser_22e9(payload: str, msg: Message) -> Mapping[str, float | str | None]:
+def parser_22e9(payload: str, msg: Message) -> HvacPayloadT:
     """Parse the 22e9 packet.
 
     :param payload: The raw hex payload
@@ -502,14 +503,14 @@ def parser_22e9(payload: str, msg: Message) -> Mapping[str, float | str | None]:
     :param msg: The message object
     :type msg: Message
     :return: A mapping of unknown identifiers or percentage values
-    :rtype: Mapping[str, float | str | None]
+    :rtype: HvacPayloadT
     """
     if payload[2:4] == "01":
         return {
             "unknown_4": payload[4:6],
             "unknown_6": payload[6:8],
         }
-    return cast("Mapping[str, float | str | None]", parser_22e0(payload, msg))
+    return parser_22e0(payload, msg)
 
 
 # fan_speed (switch_mode), HVAC

--- a/src/ramses_rf/parsers/registry.py
+++ b/src/ramses_rf/parsers/registry.py
@@ -7,7 +7,10 @@ parsers, replacing the dynamic locals() inspection.
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
+from typing import Any, ParamSpec, TypeVar
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 # A type alias for parser functions. They accept a payload string and a
 # Message object, returning various mappings or typed dictionaries.
@@ -16,22 +19,22 @@ ParserFunc = Callable[..., Any]
 _PAYLOAD_PARSERS: dict[str, ParserFunc] = {}
 
 
-def register_parser(code: str) -> Callable[[ParserFunc], ParserFunc]:
+def register_parser(code: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Register a parser function for a specific packet code.
 
     :param code: The 4-character packet code.
     :type code: str
     :return: A decorator that registers the function.
-    :rtype: Callable[[ParserFunc], ParserFunc]
+    :rtype: Callable[[Callable[P, R]], Callable[P, R]]
     """
 
-    def decorator(func: ParserFunc) -> ParserFunc:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         """Decorate and register the parser function.
 
         :param func: The parser function to register.
-        :type func: ParserFunc
+        :type func: Callable[P, R]
         :return: The unmodified parser function.
-        :rtype: ParserFunc
+        :rtype: Callable[P, R]
         """
         _PAYLOAD_PARSERS[code.upper()] = func
         return func

--- a/src/ramses_rf/schemas.py
+++ b/src/ramses_rf/schemas.py
@@ -371,7 +371,9 @@ def _get_device(gwy: Gateway, dev_id: DeviceIdT, **kwargs: Any) -> Device:  # , 
 
 
 def load_schema(
-    gwy: Gateway, known_list: DeviceListT | dict[str, Any] | None = None, **schema: Any
+    gwy: Gateway,
+    known_list: DeviceListT | dict[str, Any] | None = None,
+    **schema: Any,
 ) -> None:
     """Instantiate all entities in the schema, and faked devices in the known_list.
 

--- a/src/ramses_rf/state/entity_state.py
+++ b/src/ramses_rf/state/entity_state.py
@@ -12,7 +12,7 @@ import asyncio
 import contextlib
 import logging
 from datetime import UTC, datetime as dt
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from ramses_tx.address import ALL_DEVICE_ID
 
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
     from ramses_tx.typing import HeaderT
 
     from ..interfaces import DeviceInterface, EntityInterface, GatewayInterface
-    from .store import MessageStore
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -218,8 +217,7 @@ class EntityState:
     async def _delete_msg(self, msg: ApplicationMessage) -> None:
         """Remove the msg from the central state databases."""
         if self._gwy.message_store:
-            store = cast("MessageStore", self._gwy.message_store)
-            await store.rem(msg)
+            await self._gwy.message_store.rem(msg)
         self._pending_deletes.discard(msg.state_header)
 
     async def _get_msg_by_hdr(
@@ -238,7 +236,7 @@ class EntityState:
             header = hdr
 
         if self._gwy.message_store:
-            store = cast("MessageStore", self._gwy.message_store)
+            store = self._gwy.message_store
             msgs = await store.get(hdr=header)
             if msgs:
                 if (
@@ -248,7 +246,8 @@ class EntityState:
                     raise exc.DatabaseQueryError(
                         f"Header mismatch: {msgs[0].state_header.legacy_hdr} != {hdr}"
                     )
-                return cast("ApplicationMessage", msgs[0])
+                if isinstance(msgs[0], ApplicationMessage):
+                    return msgs[0]
             return None
 
         cache = await self._build_state_cache()

--- a/src/ramses_rf/state/store.py
+++ b/src/ramses_rf/state/store.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any, NewType
 
 import orjson
 
+from ramses_rf.interfaces import MessageStoreInterface
 from ramses_tx import RP, RQ, Code, Packet
 
 from ..exceptions import DatabaseQueryError
@@ -89,7 +90,7 @@ def payload_keys(parsed_payload: list[dict[str, Any]] | dict[str, Any]) -> str:
     return _keys
 
 
-class MessageStore:
+class MessageStore(MessageStoreInterface):
     """A central in-memory SQLite3 database for indexing RF messages.
     Index holds all the latest messages to & from all devices by `dtm`
     (timestamp) and strictly-typed `StateHeader` DTOs."""

--- a/src/ramses_rf/systems/zones.py
+++ b/src/ramses_rf/systems/zones.py
@@ -7,7 +7,7 @@ import dataclasses
 import logging
 import math
 from datetime import datetime as dt, timedelta as td
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from ramses_rf import exceptions as exc
 from ramses_rf.address import Address
@@ -114,7 +114,7 @@ class ZoneBase(Child, Parent, Entity):
     @classmethod
     def create_from_schema(
         cls, tcs: _MultiZoneT | _StoredHwT, zone_idx: str, **schema: Any
-    ) -> ZoneBase:
+    ) -> Self:
         """Create a CH/DHW zone for a TCS and set its schema attrs.
 
         The appropriate Zone class should have been determined by a
@@ -488,7 +488,9 @@ class Zone(ZoneSchedule):
 
             self._heating_type = klass
             if self._SLUG is None and klass in ZONE_CLASS_BY_SLUG:
-                self.__class__ = cast("type[Zone]", ZONE_CLASS_BY_SLUG[klass])
+                target_cls = ZONE_CLASS_BY_SLUG[klass]
+                if issubclass(target_cls, Zone):
+                    self.__class__ = target_cls
 
         # if schema.get(SZ_CLASS) == ZON_ROLE_MAP[ZON_ROLE.ACT]:
         #     schema.pop(SZ_CLASS)
@@ -941,18 +943,14 @@ def zone_factory(
         )
         return Zone
 
-    zon = cast(
-        "DhwZone | Zone",
-        best_zon_class(
-            tcs.ctl.addr,
-            idx,
-            msg=msg,
-            eavesdrop=tcs._gwy.config.enable_eavesdrop,
-            **schema,
-        ).create_from_schema(tcs, idx, **schema),
-    )
+    zon = best_zon_class(
+        tcs.ctl.addr,
+        idx,
+        msg=msg,
+        eavesdrop=tcs._gwy.config.enable_eavesdrop,
+        **schema,
+    ).create_from_schema(tcs, idx, **schema)
 
-    # assert isinstance(zon, DhwZone | Zone)  # mypy
     return zon
 
 

--- a/src/ramses_rf/typing.py
+++ b/src/ramses_rf/typing.py
@@ -13,6 +13,11 @@ DeviceTraitsT: TypeAlias = dict[str, Any]
 DeviceListT: TypeAlias = dict[str, DeviceTraitsT]
 PollingIntervalsT: TypeAlias = dict[str, int]
 
+# Domain Payload Type Aliases
+HvacPayloadT: TypeAlias = dict[str, Any]
+OpenThermPayloadT: TypeAlias = dict[str, Any]
+HeatingPayloadT: TypeAlias = dict[str, Any]
+
 
 # For fingerprints.py
 class DeviceFingerprint(TypedDict):


### PR DESCRIPTION
### ⚠️ STACKED PR: Depends on ramses-rf/ramses_rf#952 < was merged

### Overview:
This PR implements medium-difficulty type-safety improvements across `ramses_rf`, focusing on Domain Payload Types, Protocol Interfaces, and Class Factory generics to eliminate unnecessary `cast()` calls and untyped signatures.

### Key Changes:
* **Domain Payload Types & Decorator Preservations**: Added domain payload type aliases (`HvacPayloadT`, `OpenThermPayloadT`, `HeatingPayloadT`) in `typing.py` and typed `register_parser` in `parsers/registry.py` using `ParamSpec` and `TypeVar` to preserve decorated parser signatures and return types without `cast()`.
* **Protocol Interfaces**: Made `MessageStore` in `state/store.py` implement `MessageStoreInterface` from `interfaces.py`, enabling typed storage access without concrete class casting.
* **Type Narrowing via `isinstance`**: Refactored `Message._from_pkt` in `messages/base.py` and `_get_msg_by_hdr` in `state/entity_state.py` to use explicit `isinstance` guards for automatic type narrowing.
* **Class Factory Return Types**: Annotated `ZoneBase.create_from_schema` with `Self` return type in `systems/zones.py` and added an `issubclass(target_cls, Zone)` guard for in-place class promotion.

### Testing Performed:
* `.venv/bin/prek run -a`: Passed
* `.venv/bin/mypy --strict`: Passed (0 errors across 222 source files)
* `.venv/bin/pytest tests`: Passed (1,425 passed, 4 skipped)

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.