### PR TITLE
fix(hvac): restore mode_set 04 to Orcon 22F1 mode set

### DIFF
--- a/src/ramses_rf/parsers/hvac.py
+++ b/src/ramses_rf/parsers/hvac.py
@@ -575,7 +575,7 @@ def parser_22f1(payload: str, msg: Message) -> dict[str, Any]:
     else:
         from ramses_rf.protocol.ramses import _22F1_MODE_ORCON as _22F1_FAN_MODE
 
-        _22f1_mode_set = ("", "07", "0B")  # 0B?
+        _22f1_mode_set = ("", "04", "07", "0B")  # 0B?
         _22f1_scheme = "orcon"
 
     try:

--- a/tests/tests/test_parser_helpers.py
+++ b/tests/tests/test_parser_helpers.py
@@ -3,7 +3,10 @@
 
 # TODO: add test for ramses_tx.frame.pkt_header()
 
+import logging
 from datetime import datetime as dt
+
+import pytest
 
 from ramses_rf.messages import Message
 from ramses_rf.systems.zones import _transform
@@ -108,6 +111,29 @@ def test_22f1_vasco_directed_mode_max_06_still_vasco() -> None:
     result = msg.payload
     assert result["_scheme"] == "vasco"
     assert result["fan_mode"] == "low"
+
+
+def test_22f3_orcon_mode_set_04_no_warning(caplog: pytest.LogCaptureFixture) -> None:
+    # Arrange
+    pkt_str = (
+        "2026-07-28T23:49:38.000000 045  I --- 29:162275 32:139370 --:------"
+        " 22F3 007 00120F02040404"
+    )
+
+    # Act
+    with caplog.at_level(logging.WARNING):
+        msg = _make_22f1_msg(pkt_str)
+        result = msg.payload
+
+    # Assert
+    assert result["_scheme"] == "orcon"
+    assert result["fan_mode"] == "medium"
+    assert result["fallback_fan_mode"] == "auto"
+
+    warning_records = [
+        rec for rec in caplog.records if "unknown mode_set: 04" in rec.message
+    ]
+    assert not warning_records
 
 
 # --- 2411 parser data_type tests (issue #740) ---


### PR DESCRIPTION
### The Problem:
`22F3` fan boost payloads from Orcon remotes (e.g. `00120F02040404`) trigger an `unknown mode_set: 04` warning in `ramses_rf.parsers.hvac` (reported in ramses-rf/ramses_cc#878). Commit `19108789f3fd` removed `"04"` from Orcon's `_22f1_mode_set` tuple while scoping directed `22F1` `mode_max == 04` handling to standalone `22F1` packets. Because `22F3` packets bypass standalone `22F1` handling, `parser_22f1` falls through to `orcon`, failing the `mode_set` assertion.

### The Fix:
Restore `"04"` to Orcon's `_22f1_mode_set` tuple (`("", "04", "07", "0B")`) in `src/ramses_rf/parsers/hvac.py`.

### Testing Performed:
- Added `test_22f3_orcon_mode_set_04_no_warning` to `tests/tests/test_parser_helpers.py`.
- Ran `prek run -a`, `ruff format --check .`, `mypy`, and `pytest` (all passing cleanly).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.