### PR TITLE
fix(polling): clarify default polling schedules for CO2, REM, and HUM devices

### DIFF
--- a/src/ramses_rf/pipeline/polling.py
+++ b/src/ramses_rf/pipeline/polling.py
@@ -30,8 +30,8 @@ INTERVAL_EVERY_12_HOURS: Final[int] = 43200  # 12 hours in seconds
 INTERVAL_DAILY: Final[int] = 86400  # 24 hours in seconds
 
 # Master default polling schedules table for all device classes.
-# Battery-powered devices (TRV, THM, DHW) set intervals to None to explicitly
-# indicate that polling is disabled for those command codes.
+# Battery-powered devices (TRV, THM, DHW, REM, HUM) set intervals to None
+# to explicitly indicate that polling is disabled for those command codes.
 DEFAULT_POLLING_SCHEDULES: Final[dict[str, dict[str, int | None]]] = {
     # Evohome Controller
     DevType.CTL: {
@@ -61,10 +61,16 @@ DEFAULT_POLLING_SCHEDULES: Final[dict[str, dict[str, int | None]]] = {
         "10D0": INTERVAL_DAILY,  # Filter Change Sensor Status
         "3150": INTERVAL_HOURLY,  # Fan Speed / Airflow Status
     },
+    # HVAC Carbon Dioxide Sensor (mains-powered)
+    DevType.CO2: {
+        "10E0": INTERVAL_DAILY,  # Device Specification / Info
+    },
     # Battery-Powered Devices - Polling disabled to preserve battery life
     DevType.TRV: {"10E0": None, "1060": None},
     DevType.THM: {"10E0": None, "1060": None},
     DevType.DHW: {"10E0": None, "1060": None},
+    DevType.REM: {"10E0": None, "1060": None},
+    DevType.HUM: {"10E0": None, "1060": None},
     # Fallback Default
     "DEFAULT": {
         "10E0": INTERVAL_DAILY,  # Device Specification / Info


### PR DESCRIPTION
### The Problem:
`DEFAULT_POLLING_SCHEDULES` in `pipeline/polling.py` did not explicitly list `DevType.CO2`, `DevType.REM`, or `DevType.HUM`. While `CO2` fell back to `DEFAULT` (`10E0` daily) and `REM`/`HUM` were protected by `is_battery`, explicit table entries improve readability and alignment with feedback in ramses-rf/ramses_rf#759.

### The Fix:
- Explicitly add `DevType.CO2` with `"10E0": INTERVAL_DAILY` to `DEFAULT_POLLING_SCHEDULES`.
- Explicitly add `DevType.REM` and `DevType.HUM` with `"10E0": None` to `DEFAULT_POLLING_SCHEDULES`.

### Testing Performed:
- Executed `.venv/bin/prek run -a` and `.venv/bin/ruff format --check .` (passed cleanly).
- Executed `.venv/bin/mypy src/ramses_rf/pipeline/polling.py` (passed cleanly).
- Executed `.venv/bin/pytest tests/tests_rf/test_polling_parity.py` (11 passed).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.