### PR TITLE
fix(logger): include frame properties in packet logger extra context

### DIFF
--- a/src/ramses_tx/packet.py
+++ b/src/ramses_tx/packet.py
@@ -263,6 +263,15 @@ class Packet:
         pkt._validate(strict_checking=False)
         return pkt
 
+    def _pkt_extra(self) -> dict[str, Any]:
+        """Return dictionary containing packet attributes for logging."""
+        return {
+            **self.__dict__,
+            "_frame": self._frame,
+            "_rssi": self.rssi,
+            "dtm": self.dtm,
+        }
+
     def _validate(self, *, strict_checking: bool = False) -> None:
         """Validate the packet and emit packet log entries.
 
@@ -278,7 +287,7 @@ class Packet:
 
             if not strict_checking:
                 if len(self.__dict__) > 0:
-                    PKT_LOGGER.info("", extra=self.__dict__)
+                    PKT_LOGGER.info("", extra=self._pkt_extra())
                 return
 
             if self.addr1 == NON_DEV_ADDR:
@@ -293,13 +302,13 @@ class Packet:
                 assert self.verb in (I_, W_), "wrong verb or dst addr should be src"
 
             if len(self.__dict__) > 0:
-                PKT_LOGGER.info("", extra=self.__dict__)
+                PKT_LOGGER.info("", extra=self._pkt_extra())
 
         except AssertionError as err:
             raise exc.PacketInvalid(f"Bad frame: Invalid address set: {err}") from err
         except exc.PacketInvalid as err:
             if getattr(self, "_frame", "") or self.error_text:
-                PKT_LOGGER.warning("%s", err, extra=self.__dict__)
+                PKT_LOGGER.warning("%s", err, extra=self._pkt_extra())
             raise err
 
     def __repr__(self) -> str:

--- a/tests/tests_tx/test_logger.py
+++ b/tests/tests_tx/test_logger.py
@@ -11,7 +11,58 @@ import pytest
 from ramses_rf import Gateway, GatewayConfig
 from ramses_tx.config import EngineConfig
 from ramses_tx.logger import flush_packet_log
-from ramses_tx.packet import PKT_LOGGER
+from ramses_tx.packet import PKT_LOGGER, Packet
+
+
+@pytest.mark.asyncio
+async def test_packet_logging_outputs_formatted_frame(tmp_path: Path) -> None:
+    # Arrange
+    log_file = tmp_path / "packet_frame.log"
+    input_file = tmp_path / "empty_input.log"
+    input_file.touch()
+
+    logging.disable(logging.NOTSET)
+    for h in list(PKT_LOGGER.handlers):
+        PKT_LOGGER.removeHandler(h)
+    PKT_LOGGER.handlers.clear()
+    PKT_LOGGER.filters.clear()
+    PKT_LOGGER.setLevel(logging.DEBUG)
+    PKT_LOGGER.disabled = False
+    PKT_LOGGER.propagate = False
+
+    gwy = Gateway(
+        None,
+        config=GatewayConfig(
+            engine=EngineConfig(
+                input_file=str(input_file),
+                packet_log={
+                    "packet_log_path": str(tmp_path),
+                    "packet_log_prefix": "packet_frame",
+                },
+            ),
+        ),
+    )
+    await gwy.start()
+
+    raw_packet_line = "...  I --- 01:161591 --:------ 01:161591 3150 002 0000"
+    pkt = Packet.from_file("2026-07-31T10:00:00.000000", raw_packet_line)
+
+    try:
+        # Act
+        PKT_LOGGER.info("", extra=pkt._pkt_extra())
+
+        for _ in range(100):
+            await asyncio.sleep(0.01)
+            if log_file.exists() and raw_packet_line in log_file.read_text():
+                break
+
+        # Assert
+        content = log_file.read_text()
+        assert "2026-07-31T10:00:00.000000" in content
+        assert raw_packet_line in content
+
+    finally:
+        await gwy.stop()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### The Problem
When `Packet._validate()` invokes `PKT_LOGGER.info("", extra=self.__dict__)`, `self.__dict__` only contains instance attributes. Properties (`_frame`, `rssi`, `dtm`) are not in `self.__dict__`. As a result, `_Logger.makeRecord` defaults `_frame` to `""`, causing packet log entries to render timestamp-only (blank) lines.

### The Fix
Added `_pkt_extra()` helper method on `Packet` class to explicitly include property descriptors `_frame`, `rssi`, and `dtm` alongside `self.__dict__`. Updated `PKT_LOGGER` calls in `Packet._validate()` to pass `extra=self._pkt_extra()`.

### Cross-Repository References
Addresses packet logging issue reported in ramses-rf/ramses_cc#883.

### Testing Performed
- Added unit test `test_packet_logging_outputs_formatted_frame` to `tests/tests_tx/test_logger.py`.
- Ran `.venv/bin/pytest tests/tests_tx/` (241 passed).
- Verified docstrings and pre-commit checks (`.venv/bin/prek run -a`).

### AI Assistance Disclosure
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.