### PR TITLE
refactor(logging): defer string evaluation in logger calls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ All contributions (whether written by human contributors or generated via AI cod
 * **Line Constraints**: PEP 8 compliance (code ≤ 79 characters, docstrings/comments ≤ 72 characters).
 * **EXEMPTION (Raw Data)**: Raw RF packets, hex strings, routing dictionaries, and timestamped packet logs are strictly exempt from line limits to preserve readability and grep-ability.
 * **String Literals**: Prefer double quotes (`"`) for all string literals.
-* **Deferred Logging**: Always use standard deferred `%`-formatting in logger calls (e.g., `_LOGGER.debug("Recv'd: %s %s", pkt.rssi, pkt)`) instead of `f-strings` to prevent string evaluation and interpolation overhead when debug logging is disabled.
+* **Deferred Logging**: Always use standard deferred `%`-formatting across all log levels and logger instances (e.g., `_LOGGER.debug(...)`, `_TRACE.info(...)`, `PKT_LOGGER.warning(...)`) instead of `f-strings` to prevent string evaluation and interpolation overhead when logging is disabled or filtered.
 
 ### 2. Typing & Type Safety
 * **Strict Type Safety**: 100% compliance with `mypy --strict`. Do not introduce untyped definitions (`Any`) without strong technical justification.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,7 @@ All contributions (whether written by human contributors or generated via AI cod
 * **Line Constraints**: PEP 8 compliance (code ≤ 79 characters, docstrings/comments ≤ 72 characters).
 * **EXEMPTION (Raw Data)**: Raw RF packets, hex strings, routing dictionaries, and timestamped packet logs are strictly exempt from line limits to preserve readability and grep-ability.
 * **String Literals**: Prefer double quotes (`"`) for all string literals.
+* **Deferred Logging**: Always use standard deferred `%`-formatting in logger calls (e.g., `_LOGGER.debug("Recv'd: %s %s", pkt.rssi, pkt)`) instead of `f-strings` to prevent string evaluation and interpolation overhead when debug logging is disabled.
 
 ### 2. Typing & Type Safety
 * **Strict Type Safety**: 100% compliance with `mypy --strict`. Do not introduce untyped definitions (`Any`) without strong technical justification.

--- a/misc/2411_parser.py
+++ b/misc/2411_parser.py
@@ -61,7 +61,7 @@ def parser_2411(payload: str, msg: Any) -> dict[str, Any]:
     else:
         result["parameter_name"] = f"unknown_{param_id}"
         result["description"] = "Unknown"
-        _LOGGER.warning(f"Unknown parameter ID: {param_id}. Payload: {payload}")
+        _LOGGER.warning("Unknown parameter ID: %s. Payload: %s", param_id, payload)
 
     # For RQ (request) messages, just return parameter info
     if hasattr(msg, "verb") and msg.verb == "RQ":
@@ -85,7 +85,7 @@ def parser_2411(payload: str, msg: Any) -> dict[str, Any]:
             result["status_flag ?(19)"] = payload[38:40]  # Byte 19
 
     except (ValueError, IndexError) as err:
-        _LOGGER.error(f"Error parsing 2411 payload for param {param_id}: {err}")
+        _LOGGER.error("Error parsing 2411 payload for param %s: %s", param_id, err)
         result["error"] = str(err)
         result["raw_data"] = payload[6:]
     return result

--- a/src/ramses_cli/discovery.py
+++ b/src/ramses_cli/discovery.py
@@ -109,9 +109,9 @@ def spawn_scripts(gwy: Gateway, **kwargs: Any) -> list[asyncio.Task[None]]:
     elif kwargs.get(EXEC_SCR):
         script = SCRIPTS.get(f"{kwargs[EXEC_SCR][0]}")
         if script is None:
-            _LOGGER.warning(f"Script: {kwargs[EXEC_SCR][0]}() - unknown script")
+            _LOGGER.warning("Script: %s() - unknown script", kwargs[EXEC_SCR][0])
         else:
-            _LOGGER.info(f"Script: {kwargs[EXEC_SCR][0]}().- starts...")
+            _LOGGER.info("Script: %s().- starts...", kwargs[EXEC_SCR][0])
             # script_poll_device returns a list of tasks, others return a coroutine
             result = script(gwy, kwargs[EXEC_SCR][1])
             if isinstance(result, list):

--- a/src/ramses_rf/binding_fsm.py
+++ b/src/ramses_rf/binding_fsm.py
@@ -568,7 +568,9 @@ class BindStateBase:
 
         # Strong typing on Future ensures .result() correctly returns a Message
         self._fut: asyncio.Future[Message] = self._loop.create_future()
-        _LOGGER.debug(f"{self}: Changing state from: {self._context.state} to: {self}")
+        _LOGGER.debug(
+            "%s: Changing state from: %s to: %s", self, self._context.state, self
+        )
 
         if self._has_wait_timer:
             self._timer_handle = self._loop.call_later(
@@ -843,7 +845,7 @@ class RespHasBoundAsRespondent(BindStateBase):
 
     def __init__(self, context: BindingManagerBase) -> None:
         super().__init__(context)
-        _LOGGER.info(f"{context._dev.id}: Binding completed as respondent")
+        _LOGGER.info("%s: Binding completed as respondent", context._dev.id)
 
 
 class RespIsWaitingForAddenda(_DevIsWaitingForMsg, BindStateBase):
@@ -899,7 +901,7 @@ class SuppHasBoundAsSupplicant(BindStateBase):
 
     def __init__(self, context: BindingManagerBase) -> None:
         super().__init__(context)
-        _LOGGER.info(f"{context._dev.id}: Binding completed as supplicant")
+        _LOGGER.info("%s: Binding completed as supplicant", context._dev.id)
 
 
 class SuppIsReadyToSendAddenda(

--- a/src/ramses_rf/devices/__init__.py
+++ b/src/ramses_rf/devices/__init__.py
@@ -173,12 +173,14 @@ def best_dev_role(
     if slug and slug in _CLASS_BY_SLUG:
         cls = _CLASS_BY_SLUG[slug]
         _LOGGER.debug(
-            f"Using an explicitly-defined class for: {dev_addr!r} ({cls._SLUG})"
+            "Using an explicitly-defined class for: %r (%s)", dev_addr, cls._SLUG
         )
         return cls
 
     if dev_addr.type == DEV_TYPE_MAP.HGI:
-        _LOGGER.debug(f"Using the default class for: {dev_addr!r} ({HgiGateway._SLUG})")
+        _LOGGER.debug(
+            "Using the default class for: %r (%s)", dev_addr, HgiGateway._SLUG
+        )
         return HgiGateway
 
     try:  # or, is it a well-known CH/DHW class, derived from the device type...

--- a/src/ramses_rf/devices/dev_base.py
+++ b/src/ramses_rf/devices/dev_base.py
@@ -206,7 +206,9 @@ class DeviceBase(Entity):
             and not self.is_faked
             and cmd.addr2 == self.id
         ):
-            _LOGGER.info(f"{cmd} < Sending inadvisable for {self} (it has a battery)")
+            _LOGGER.info(
+                "%s < Sending inadvisable for %s (it has a battery)", cmd, self
+            )
 
         return super()._send_cmd(cmd, **kwargs)
 
@@ -452,7 +454,7 @@ class Fakeable(DeviceBase):
         if self.id not in self._gwy.config.known_list:
             self._gwy.config.known_list[self.id] = {}
         self._gwy.config.known_list[self.id][SZ_FAKED] = True  # TODO: remove this
-        _LOGGER.info(f"Faking now enabled for: {self}")
+        _LOGGER.info("Faking now enabled for: %s", self)
 
     async def _async_send_cmd(
         self,

--- a/src/ramses_rf/devices/dev_registry.py
+++ b/src/ramses_rf/devices/dev_registry.py
@@ -107,12 +107,15 @@ class DeviceRegistry:
             SystemSchemaInconsistent,
         ) as err:
             # Safely reject the mutation if it violates the static schema constraints
-            _TRACE.debug(f"Topology mutation safely rejected ({event.action}): {err}")
+            _TRACE.debug(
+                "Topology mutation safely rejected (%s): %s", event.action, err
+            )
         except Exception as err:
             # Exception Shield: Catch-all to absolutely guarantee the asyncio
             # background task does not silently die.
             _TRACE.exception(
-                f"CRITICAL: Registry event router caught unhandled exception: {err}"
+                "CRITICAL: Registry event router caught unhandled exception: %s",
+                err,
             )
 
     def _handle_bind_device(self, event: TopologyChangedEvent) -> None:
@@ -216,7 +219,9 @@ class DeviceRegistry:
                     is_sensor=is_sensor,
                 )
             except DeviceNotFoundError as err:
-                _TRACE.error(f"BIND EXCEPTION: Failed fetching {event.child_id}: {err}")
+                _TRACE.error(
+                    "BIND EXCEPTION: Failed fetching %s: %s", event.child_id, err
+                )
 
             # 2. REVERSE BINDING (Native CQRS Shadow State)
             if child_dev:
@@ -501,7 +506,9 @@ class DeviceRegistry:
             try:
                 dev = self._device_factory_cb(Address(device_id), msg, traits)
             except Exception as err:
-                _TRACE.error(f"FACTORY EXCEPTION: Failed creating {device_id}: {err}")
+                _TRACE.error(
+                    "FACTORY EXCEPTION: Failed creating %s: %s", device_id, err
+                )
                 raise
 
             if traits.faked:

--- a/src/ramses_rf/devices/dev_registry.py
+++ b/src/ramses_rf/devices/dev_registry.py
@@ -96,7 +96,7 @@ class DeviceRegistry:
         """
         handler = self._event_routers.get(event.action)
         if not handler:
-            _LOGGER.warning(f"No registry handler defined for action: {event.action}")
+            _LOGGER.warning("No registry handler defined for action: %s", event.action)
             return
 
         try:
@@ -295,7 +295,7 @@ class DeviceRegistry:
         dev = self.device_by_id.get(event.device_id)
         if dev and hasattr(dev, "_make_tcs_controller"):
             dev._make_tcs_controller()
-            _LOGGER.debug(f"Created Controller on {dev.id} via {event.causation}")
+            _LOGGER.debug("Created Controller on %s via %s", dev.id, event.causation)
 
     def _handle_create_circuit(self, event: TopologyChangedEvent) -> None:
         """Instruct a UFH controller to initialize a circuit."""
@@ -508,7 +508,7 @@ class DeviceRegistry:
                 if isinstance(dev, Fakeable):
                     dev._make_fake()
                 else:
-                    _LOGGER.warning(f"The device is not fakeable: {dev}")
+                    _LOGGER.warning("The device is not fakeable: %s", dev)
 
         if parent or child_id:
             self._maybe_reparent_bdr(dev, parent, child_id)

--- a/src/ramses_rf/entity.py
+++ b/src/ramses_rf/entity.py
@@ -152,7 +152,7 @@ class _Entity:
         :rtype: asyncio.Task[Any] | None
         """
         if self._qos_tx_count > _QOS_TX_LIMIT:
-            _LOGGER.info(f"{cmd} < Sending was deprecated for {self}")
+            _LOGGER.info("%s < Sending was deprecated for %s", cmd, self)
             return None
 
         return self._gwy.send_cmd(cmd, **kwargs)
@@ -175,7 +175,7 @@ class _Entity:
         :rtype: Packet | None
         """
         if self._qos_tx_count > _QOS_TX_LIMIT:
-            _LOGGER.warning(f"{cmd} < Sending was deprecated for {self}")
+            _LOGGER.warning("%s < Sending was deprecated for %s", cmd, self)
             return None
 
         # Build kwargs dynamically to prevent passing `None` to strict Gateway args

--- a/src/ramses_rf/parsers/heating.py
+++ b/src/ramses_rf/parsers/heating.py
@@ -560,7 +560,7 @@ def parser_12c0(payload: str, msg: Message) -> PayDictT._12C0:
     if payload[2:4] == "80":
         temp: float | None = None
     elif payload[4:6] == "00":  # units are 1.0 F
-        _LOGGER.warning(f"{msg!r} < {_INFORM_DEV_MSG} (Fahrenheit TRV detected)")
+        _LOGGER.warning("%r < %s (Fahrenheit TRV detected)", msg, _INFORM_DEV_MSG)
         temp = round((int(payload[2:4], 16) - 32) * 5 / 9, 2)
     else:  # if payload[4:] == "01":  # units are 0.5 C
         temp = int(payload[2:4], 16) / 2

--- a/src/ramses_rf/parsers/hvac.py
+++ b/src/ramses_rf/parsers/hvac.py
@@ -321,7 +321,7 @@ def parser_1f70(payload: str, msg: Message) -> dict[str, Any]:
         assert msg.verb != RP or payload[26:] == "008000"
 
     except AssertionError as err:
-        _LOGGER.warning(f"{msg!r} < {_INFORM_DEV_MSG} ({err})")
+        _LOGGER.warning("%r < %s (%s)", msg, _INFORM_DEV_MSG, err)
 
     return {
         "day_idx": payload[16:18],  # depends upon 1470[3:4]?
@@ -397,7 +397,7 @@ def parser_2210(payload: str, msg: Message) -> dict[str, Any]:
         ), f"expected byte 41- (00|40), not {payload[82:]}"
 
     except AssertionError as err:
-        _LOGGER.warning(f"{msg!r} < {_INFORM_DEV_MSG} ({err})")
+        _LOGGER.warning("%r < %s (%s)", msg, _INFORM_DEV_MSG, err)
 
     _req = "IDL"
     if payload[20:22] == "02":
@@ -532,7 +532,7 @@ def parser_22f1(payload: str, msg: Message) -> dict[str, Any]:
             "mode_idx > mode_max"
         )
     except AssertionError as err:
-        _LOGGER.warning(f"{msg!r} < {_INFORM_DEV_MSG} ({err})")
+        _LOGGER.warning("%r < %s (%s)", msg, _INFORM_DEV_MSG, err)
 
     # Scheme detection: the mode_max byte (payload[4:6]) is the primary
     # indicator.  mode_max=04 → itho (5 modes: 00-04), mode_max=0A → nuaire,
@@ -582,7 +582,7 @@ def parser_22f1(payload: str, msg: Message) -> dict[str, Any]:
         assert payload[2:4] in _22F1_FAN_MODE, f"unknown fan_mode: {payload[2:4]}"
         assert payload[4:6] in _22f1_mode_set, f"unknown mode_set: {payload[4:6]}"
     except AssertionError as err:
-        _LOGGER.warning(f"{msg!r} < {_INFORM_DEV_MSG} ({err})")
+        _LOGGER.warning("%r < %s (%s)", msg, _INFORM_DEV_MSG, err)
 
     return {
         SZ_FAN_MODE: _22F1_FAN_MODE.get(payload[2:4], f"unknown_{payload[2:4]}"),
@@ -634,7 +634,7 @@ def parser_22f3(payload: str, msg: Message) -> dict[str, Any]:
     try:
         assert msg.len <= 7 or payload[14:] == "0000", f"byte 7: {payload[14:]}"
     except AssertionError as err:
-        _LOGGER.warning(f"{msg!r} < {_INFORM_DEV_MSG} ({err})")
+        _LOGGER.warning("%r < %s (%s)", msg, _INFORM_DEV_MSG, err)
 
     new_speed = {  # from now, until timer expiry
         0x00: "fan_boost",  # set fan off, or 'boost' mode?
@@ -828,7 +828,7 @@ def parser_2411(payload: str, msg: Message) -> dict[str, Any]:
                 f"Message: {msg!r}"
             )
     except Exception as err:
-        _LOGGER.warning(f"Error looking up 2411 parameter {param_id}: {err}")
+        _LOGGER.warning("Error looking up 2411 parameter %s: %s", param_id, err)
         description = "Unknown"
 
     result = {
@@ -861,7 +861,7 @@ def parser_2411(payload: str, msg: Message) -> dict[str, Any]:
                     "precision": f"0x{payload[34:42]}",
                     "_value_42": payload[42:],
                 }
-            _LOGGER.warning(f"{warningmsg} Found values: {result}")
+            _LOGGER.warning("%s Found values: %s", warningmsg, result)
             return result
 
         length, parser = _2411_DATA_TYPES[payload[8:10]]
@@ -883,7 +883,7 @@ def parser_2411(payload: str, msg: Message) -> dict[str, Any]:
             }
         )
     except Exception as err:
-        _LOGGER.warning(f"{msg!r} < {_INFORM_DEV_MSG} (Error parsing 2411: {err})")
+        _LOGGER.warning("%r < %s (Error parsing 2411: %s)", msg, _INFORM_DEV_MSG, err)
         result["value"] = f"0x{payload[10:18]}"
         result["_parse_error"] = f"Parser error: {err}"
         return result
@@ -918,7 +918,7 @@ def parser_3110(payload: str, msg: Message) -> PayDictT._3110:
             f"byte 3: {payload[6:]}"
         )
     except AssertionError as err:
-        _LOGGER.warning(f"{msg!r} < {_INFORM_DEV_MSG} ({err})")
+        _LOGGER.warning("%r < %s (%s)", msg, _INFORM_DEV_MSG, err)
 
     mode = {
         0x00: SZ_DISABLE,
@@ -958,7 +958,7 @@ def parser_3120(payload: str, msg: Message) -> dict[str, Any]:
         assert payload[10:12] in ("00", "03", "0A", "9C"), f"byte 5: {payload[10:12]}"
         assert payload[12:] == "FF", f"byte 6: {payload[12:]}"
     except AssertionError as err:
-        _LOGGER.warning(f"{msg!r} < {_INFORM_DEV_MSG} ({err})")
+        _LOGGER.warning("%r < %s (%s)", msg, _INFORM_DEV_MSG, err)
 
     return {
         "unknown_0": payload[2:10],
@@ -1014,7 +1014,7 @@ def parser_31d9(payload: str, msg: Message) -> dict[str, Any]:
             f"byte 2: {payload[4:6]}"
         )
     except AssertionError as err:
-        _LOGGER.warning(f"{msg!r} < {_INFORM_DEV_MSG} ({err})")
+        _LOGGER.warning("%r < %s (%s)", msg, _INFORM_DEV_MSG, err)
 
     bitmap = int(payload[2:4], 16)
 
@@ -1051,7 +1051,7 @@ def parser_31d9(payload: str, msg: Message) -> dict[str, Any]:
                     f"unknown 31D9 fan_mode lookup key: {payload[4:6]}"
                 )
             except AssertionError as err:
-                _LOGGER.warning(f"{msg!r} < {_INFORM_DEV_MSG} ({err})")
+                _LOGGER.warning("%r < %s (%s)", msg, _INFORM_DEV_MSG, err)
             fan_mode = _31D9_FAN_INFO_VASCO.get(
                 int(payload[4:6], 16) & 0xFF, f"unknown_{payload[4:6]}"
             )
@@ -1061,7 +1061,7 @@ def parser_31d9(payload: str, msg: Message) -> dict[str, Any]:
     try:
         assert payload[6:8] in ("00", "07", "0A", "FE"), f"byte 3: {payload[6:8]}"
     except AssertionError as err:
-        _LOGGER.warning(f"{msg!r} < {_INFORM_DEV_MSG} ({err})")
+        _LOGGER.warning("%r < %s (%s)", msg, _INFORM_DEV_MSG, err)
 
     result.update({"_unknown_3": payload[6:8]})
 
@@ -1072,7 +1072,7 @@ def parser_31d9(payload: str, msg: Message) -> dict[str, Any]:
         assert payload[8:32] in ("00" * 12, "20" * 12), f"byte 4: {payload[8:32]}"
         assert payload[32:] in ("00", "04", "08"), f"byte 16: {payload[32:]}"
     except AssertionError as err:
-        _LOGGER.warning(f"{msg!r} < {_INFORM_DEV_MSG} ({err})")
+        _LOGGER.warning("%r < %s (%s)", msg, _INFORM_DEV_MSG, err)
 
     return {
         **result,

--- a/src/ramses_rf/parsers/opentherm.py
+++ b/src/ramses_rf/parsers/opentherm.py
@@ -175,7 +175,7 @@ def parser_2401(payload: str, msg: Message) -> dict[str, Any]:
         )
         assert int(payload[6:], 0x10) <= 200, f"byte 3: {payload[6:]}"
     except AssertionError as err:
-        _LOGGER.warning(f"{msg!r} < {_INFORM_DEV_MSG} ({err})")
+        _LOGGER.warning("%r < %s (%s)", msg, _INFORM_DEV_MSG, err)
 
     return {
         "_flags_2": hex_to_flag8(payload[4:6]),
@@ -215,7 +215,7 @@ def parser_2410(payload: str, msg: Message) -> dict[str, Any]:
         assert payload[18:26] in ("00000001", "FFFFFFFF"), _INFORM_DEV_MSG
         assert payload[26:34] in ("00000001", "00000000"), _INFORM_DEV_MSG
     except AssertionError as err:
-        _LOGGER.warning(f"{msg!r} < {_INFORM_DEV_MSG} ({err})")
+        _LOGGER.warning("%r < %s (%s)", msg, _INFORM_DEV_MSG, err)
 
     return {
         "tail": payload[34:],

--- a/src/ramses_rf/systems/faultlog.py
+++ b/src/ramses_rf/systems/faultlog.py
@@ -304,7 +304,9 @@ class FaultLog:  # 0418
                         wait_for_reply=True,
                     )
                 except exc.RamsesException as err:
-                    _LOGGER.warning(f"Failed to retrieve fault log entry {idx}: {err}")
+                    _LOGGER.warning(
+                        "Failed to retrieve fault log entry %s: %s", idx, err
+                    )
                     error_occurred = True
                     self._is_current = False
                     break

--- a/src/ramses_rf/systems/tcs.py
+++ b/src/ramses_rf/systems/tcs.py
@@ -523,7 +523,7 @@ class MultiZone(SystemBase):  # 0005 (+/- 000C?)
                 SchemaInconsistentError,
                 SystemSchemaInconsistent,
             ) as err:
-                _TRACE.warning(f"SUPPRESSED in correlation matching: {err}")
+                _TRACE.warning("SUPPRESSED in correlation matching: %s", err)
 
         # _LOGGER.warning("System state (after): %s", self.schema)
 
@@ -549,7 +549,7 @@ class MultiZone(SystemBase):  # 0005 (+/- 000C?)
                 SchemaInconsistentError,
                 SystemSchemaInconsistent,
             ) as err:
-                _TRACE.warning(f"SUPPRESSED in ctl correlation matching: {err}")
+                _TRACE.warning("SUPPRESSED in ctl correlation matching: %s", err)
 
         # _LOGGER.warning("System state (finally): %s", self.schema)
 
@@ -584,7 +584,7 @@ class MultiZone(SystemBase):  # 0005 (+/- 000C?)
                 SchemaInconsistentError,
                 SystemSchemaInconsistent,
             ) as err:
-                _TRACE.warning(f"SUPPRESSED in trv correlation matching: {err}")
+                _TRACE.warning("SUPPRESSED in trv correlation matching: %s", err)
 
     def _handle_msg(self, msg: Message) -> None:
         """Process any relevant message.

--- a/src/ramses_rf/systems/zones.py
+++ b/src/ramses_rf/systems/zones.py
@@ -646,13 +646,14 @@ class Zone(ZoneSchedule):
                 {"zone_idx": self.idx},
             )
         except ProtocolTimeoutError as err:
-            _LOGGER.warning(f"{self}: _get_temp timed out: {err}")
+            _LOGGER.warning("%s: _get_temp timed out: %s", self, err)
             return None
         except ProtocolSendFailed:
             # Silently drop the request if the transport is inactive
             # (e.g., during cache restoration prior to gateway startup).
             _LOGGER.debug(
-                f"{self}: Dropped request: gateway transport is inactive.",
+                "%s: Dropped request: gateway transport is inactive.",
+                self,
             )
             return None
 

--- a/src/ramses_rf/systems/zones.py
+++ b/src/ramses_rf/systems/zones.py
@@ -239,7 +239,7 @@ class DhwZone(ZoneSchedule):  # CS92A
                 exc.SchemaInconsistentError,
                 exc.SystemSchemaInconsistent,
             ) as err:
-                _TRACE.warning(f"SUPPRESSED in DhwZone._update_schema (sensor): {err}")
+                _TRACE.warning("SUPPRESSED in DhwZone._update_schema (sensor): %s", err)
 
         if dev_id := schema.get(DEV_ROLE_MAP[DevRole.HTG]):
             try:
@@ -509,7 +509,7 @@ class Zone(ZoneSchedule):
                 exc.SchemaInconsistentError,
                 exc.SystemSchemaInconsistent,
             ) as err:
-                _TRACE.warning(f"SUPPRESSED in Zone._update_schema (sensor): {err}")
+                _TRACE.warning("SUPPRESSED in Zone._update_schema (sensor): %s", err)
 
         for act_id in schema.get(SZ_ACTUATORS, []):
             try:
@@ -519,7 +519,7 @@ class Zone(ZoneSchedule):
                 exc.SchemaInconsistentError,
                 exc.SystemSchemaInconsistent,
             ) as err:
-                _TRACE.warning(f"SUPPRESSED in Zone._update_schema (actuator): {err}")
+                _TRACE.warning("SUPPRESSED in Zone._update_schema (actuator): %s", err)
 
     @property
     def sensor(self) -> Device | None:

--- a/src/ramses_rf/topology.py
+++ b/src/ramses_rf/topology.py
@@ -304,7 +304,9 @@ class Child:
             if isinstance(parent, _HasTcs) and parent.tcs is not None:
                 parent = parent.tcs
                 parent_class = parent.__class__.__name__
-                _TRACE.info(f"SUB-CONTROLLER: {self} shifted parent to {parent_class}")
+                _TRACE.info(
+                    "SUB-CONTROLLER: %s shifted parent to %s", self, parent_class
+                )
             else:
                 raise exc.SchemaInconsistentError(
                     f"{self}: controller parent tcs cannot be None"
@@ -315,13 +317,15 @@ class Child:
                 if isinstance(parent, _HasZones):
                     parent = parent.get_dhw_zone()
                     parent_class = parent.__class__.__name__
-                    _TRACE.info(f"DHW SHIFT: {self} shifted parent to {parent_class}")
+                    _TRACE.info(
+                        "DHW SHIFT: %s shifted parent to %s", self, parent_class
+                    )
             elif (
                 isinstance(parent, _HasZones) and int(child_id, 16) < parent._max_zones
             ):
                 parent = parent.get_htg_zone(child_id)
                 parent_class = parent.__class__.__name__
-                _TRACE.info(f"ZONE SHIFT: {self} shifted parent to {parent_class}")
+                _TRACE.info("ZONE SHIFT: %s shifted parent to %s", self, parent_class)
 
         elif (
             parent_class
@@ -343,7 +347,7 @@ class Child:
                 f"{self} can't change parent "
                 f"({self._parent}_{self._child_id} to {parent}_{child_id})"
             )
-            _TRACE.error(f"PARENT CHANGE EXCEPTION: {err_msg}")
+            _TRACE.error("PARENT CHANGE EXCEPTION: %s", err_msg)
             raise exc.SystemSchemaInconsistent(err_msg)
 
         PARENT_RULES: dict[str, dict[str, tuple[str, ...]]] = {
@@ -385,23 +389,27 @@ class Child:
 
         rules = PARENT_RULES.get(parent_class)
         if not rules:
-            _TRACE.error(f"PARENT RULES EXCEPTION: {parent} is not a valid parent.")
+            _TRACE.error("PARENT RULES EXCEPTION: %s is not a valid parent.", parent)
             raise exc.SchemaInconsistentError(
                 f"for Parent {parent}: not a valid parent"
             )
 
         if is_sensor and self_class not in rules[SZ_SENSOR]:
             _TRACE.error(
-                f"RULES EXCEPTION: Sensor {self} must be {rules[SZ_SENSOR]} "
-                f"for parent {parent}"
+                "RULES EXCEPTION: Sensor %s must be %s for parent %s",
+                self,
+                rules[SZ_SENSOR],
+                parent,
             )
             raise exc.SchemaInconsistentError(
                 f"for Parent {parent}: Sensor {self} must be {rules[SZ_SENSOR]}"
             )
         if not is_sensor and self_class not in rules[SZ_ACTUATORS]:
             _TRACE.error(
-                f"RULES EXCEPTION: Actuator {self} must be {rules[SZ_ACTUATORS]} "
-                f"for parent {parent}"
+                "RULES EXCEPTION: Actuator %s must be %s for parent %s",
+                self,
+                rules[SZ_ACTUATORS],
+                parent,
             )
             raise exc.SchemaInconsistentError(
                 f"for Parent {parent}: Actuator {self} must be {rules[SZ_ACTUATORS]}"
@@ -449,7 +457,7 @@ class Child:
             parent._add_child(self, child_id=child_id, is_sensor=is_sensor)
 
         except (exc.SchemaInconsistentError, exc.SystemSchemaInconsistent) as err:
-            _TRACE.error(f"LINK EXCEPTION: Failed applying link for {self}: {err}")
+            _TRACE.error("LINK EXCEPTION: Failed applying link for %s: %s", self, err)
             raise
 
         self._child_id = child_id

--- a/src/ramses_tx/protocol/base.py
+++ b/src/ramses_tx/protocol/base.py
@@ -123,7 +123,7 @@ class _BaseProtocol(ProtocolInterface, asyncio.Protocol):
             try:
                 result = re.sub(k, v, result)
             except re.error as err:
-                _LOGGER.warning(f"{frame} < issue with regex ({k}, {v}): {err}")
+                _LOGGER.warning("%s < issue with regex (%s, %s): %s", frame, k, v, err)
         return result
 
     def add_handler(
@@ -343,7 +343,7 @@ class _BaseProtocol(ProtocolInterface, asyncio.Protocol):
         cmd = self._patch_cmd_if_needed(cmd)
 
         if qos and not self._context:
-            _LOGGER.warning(f"{cmd} < QoS is currently disabled by this Protocol")
+            _LOGGER.warning("%s < QoS is currently disabled by this Protocol", cmd)
 
         if cmd.addr1 != self.hgi_id:  # Was HGI_DEV_ADDR.id
             await self._send_impersonation_alert(cmd)
@@ -403,7 +403,7 @@ class _BaseProtocol(ProtocolInterface, asyncio.Protocol):
                 # + space prefix
                 pkt = Packet.from_port(pkt.dtm, f"{pkt.rssi} {hacked_frame}")
             except (ValueError, PacketInvalid) as err:
-                _LOGGER.debug(f"Regex modified frame is invalid, reverting: {err}")
+                _LOGGER.debug("Regex modified frame is invalid, reverting: %s", err)
                 # Fallback to original packet if regex broke it (pkt
                 # remains unchanged)
 
@@ -432,11 +432,11 @@ class _BaseProtocol(ProtocolInterface, asyncio.Protocol):
             self._tracked_sync_cycles.append(pkt)
 
         if _DBG_FORCE_LOG_PACKETS:
-            _LOGGER.warning(f"Recv'd: {pkt.rssi} {pkt}")
+            _LOGGER.warning("Recv'd: %s %s", pkt.rssi, pkt)
         elif _LOGGER.getEffectiveLevel() > logging.DEBUG:
-            _LOGGER.info(f"Recv'd: {pkt.rssi} {pkt}")
+            _LOGGER.info("Recv'd: %s %s", pkt.rssi, pkt)
         else:
-            _LOGGER.debug(f"Recv'd: {pkt.rssi} {pkt}")
+            _LOGGER.debug("Recv'd: %s %s", pkt.rssi, pkt)
 
         self._pkt_received(pkt)
 
@@ -448,7 +448,7 @@ class _BaseProtocol(ProtocolInterface, asyncio.Protocol):
             # We explicitly catch specific validation failures. Unhandled
             # internal errors like TypeError or AttributeError will
             # correctly bubble up and fail loudly.
-            _LOGGER.debug(f"Dropped invalid packet during parsing: {err}")
+            _LOGGER.debug("Dropped invalid packet during parsing: %s", err)
             return
 
         self._this_msg, self._prev_msg = msg, self._this_msg
@@ -460,7 +460,7 @@ class _BaseProtocol(ProtocolInterface, asyncio.Protocol):
         Also maintain _prev_msg, _this_msg attrs.
         """
         if self._msg_handler is not None:
-            _LOGGER.debug(f"Dispatching valid message to handler: {msg}")
+            _LOGGER.debug("Dispatching valid message to handler: %s", msg)
             # Ensure safe dispatch to either coroutine or standard handler
             res = self._msg_handler(msg)
             if asyncio.iscoroutine(res):
@@ -527,16 +527,18 @@ class _DeviceIdFilterMixin(_BaseProtocol):
             self._active_hgi = dev_id
 
         if dev_id in self._exclude:
-            _LOGGER.error(f"{msg} MUST NOT be in the {SZ_BLOCK_LIST}{TIP}")
+            _LOGGER.error("%s MUST NOT be in the %s%s", msg, SZ_BLOCK_LIST, TIP)
 
         elif dev_id not in self._include:
-            _LOGGER.warning(f"{msg} SHOULD be in the (enforced) {SZ_KNOWN_LIST}")
+            _LOGGER.warning("%s SHOULD be in the (enforced) %s", msg, SZ_KNOWN_LIST)
 
         elif not self.enforce_include:
-            _LOGGER.info(f"{msg} is in the {SZ_KNOWN_LIST}, which SHOULD be enforced")
+            _LOGGER.info(
+                "%s is in the %s, which SHOULD be enforced", msg, SZ_KNOWN_LIST
+            )
 
         else:
-            _LOGGER.debug(f"{msg} is in the {SZ_KNOWN_LIST}")
+            _LOGGER.debug("%s is in the %s", msg, SZ_KNOWN_LIST)
 
     def _is_wanted_addrs(
         self, src_id: DeviceIdT, dst_id: DeviceIdT, sending: bool = False
@@ -602,7 +604,7 @@ class _DeviceIdFilterMixin(_BaseProtocol):
             try:
                 dto = pkt.to_dto()
             except PacketInvalid as err:
-                _LOGGER.debug(f"Dropped invalid packet for raw handlers: {err}")
+                _LOGGER.debug("Dropped invalid packet for raw handlers: %s", err)
             else:
                 for handler in self._raw_pkt_handlers:
                     res = handler(dto)

--- a/src/ramses_tx/protocol/core.py
+++ b/src/ramses_tx/protocol/core.py
@@ -214,7 +214,7 @@ class PortProtocol(_DeviceIdFilterMixin):
 
         msg = f"{self}: Impersonating device: {cmd.addr1}, for pkt: {str(cmd)}"
         if self._is_evofw3 is False:
-            _LOGGER.error(f"{msg}, NB: non-evofw3 gateways can't impersonate!")
+            _LOGGER.error("%s, NB: non-evofw3 gateways can't impersonate!", msg)
         else:
             _LOGGER.info(msg)
 
@@ -252,10 +252,12 @@ class PortProtocol(_DeviceIdFilterMixin):
         try:
             return await self._context.send_cmd(send_cmd, cmd, priority, qos)
         except ProtocolTimeoutError as err:
-            _LOGGER.warning(f"{self}: Send timed out for {cmd.verb}|{cmd.code}: {err}")
+            _LOGGER.warning(
+                "%s: Send timed out for %s|%s: %s", self, cmd.verb, cmd.code, err
+            )
             raise
         except ProtocolError as err:
-            _LOGGER.info(f"{self}: Failed to send {cmd.verb}|{cmd.code}: {err}")
+            _LOGGER.info("%s: Failed to send %s|%s: %s", self, cmd.verb, cmd.code, err)
             raise
 
     async def send_cmd(
@@ -287,7 +289,7 @@ class PortProtocol(_DeviceIdFilterMixin):
         assert 0 <= num_repeats <= MAX_NUM_REPEATS, "Out of range: num_repeats"
 
         if qos and not self._context:
-            _LOGGER.warning(f"{cmd} < QoS is currently disabled by this Protocol")
+            _LOGGER.warning("%s < QoS is currently disabled by this Protocol", cmd)
 
         # Patch command with actual HGI ID if it uses the default placeholder.
         # PortProtocol.send_cmd overrides _BaseProtocol.send_cmd (which does this

--- a/src/ramses_tx/protocol/fsm.py
+++ b/src/ramses_tx/protocol/fsm.py
@@ -231,18 +231,23 @@ class ProtocolContext(StateMachineInterface):
                 self._qos_mgr.fut.set_exception(exception)
         elif result:
             _LOGGER.debug(
-                f"FSM state changed {transition}: result received (result={result._hdr}, ctx={self})"
+                "FSM state changed %s: result received (result=%s, ctx=%s)",
+                transition,
+                result._hdr,
+                self,
             )
             if not self._qos_mgr.fut.done():
                 self._qos_mgr.fut.set_result(result)
         elif expired:
-            _LOGGER.debug(f"FSM state changed {transition}: timer expired (ctx={self})")
+            _LOGGER.debug(
+                "FSM state changed %s: timer expired (ctx=%s)", transition, self
+            )
             if not self._qos_mgr.fut.done():
                 self._qos_mgr.fut.set_exception(
                     ProtocolSendFailed(f"{self}: Exceeded maximum retries")
                 )
         else:
-            _LOGGER.debug(f"FSM state changed {transition}: successful (ctx={self})")
+            _LOGGER.debug("FSM state changed %s: successful (ctx=%s)", transition, self)
 
         prev_state = self._state
         self._state = state_class(self)

--- a/src/ramses_tx/schemas.py
+++ b/src/ramses_tx/schemas.py
@@ -221,37 +221,42 @@ def select_device_filter_mode(
 
     if enforce_known_list and not known_list:
         _LOGGER.warning(
-            f"Best practice is to enforce a {SZ_KNOWN_LIST} (an allow list), "
-            f"but it is empty, so it can't be used. "
+            "Best practice is to enforce a %s (an allow list), but it is empty, so it can't be used.",
+            SZ_KNOWN_LIST,
         )
         enforce_known_list = False
 
     if enforce_known_list:
         _LOGGER.info(
-            f"A valid {SZ_KNOWN_LIST} was provided, "
-            f"and will be enforced as a allow list: length = {len(known_list)}"
+            "A valid %s was provided, and will be enforced as a allow list: length = %s",
+            SZ_KNOWN_LIST,
+            len(known_list),
         )
-        _LOGGER.debug(f"known_list = {known_list}")
+        _LOGGER.debug("known_list = %s", known_list)
 
     elif block_list:
         _LOGGER.info(
-            f"A valid {SZ_BLOCK_LIST} was provided, "
-            f"and will be used as a deny list: length = {len(block_list)}"
+            "A valid %s was provided, and will be used as a deny list: length = %s",
+            SZ_BLOCK_LIST,
+            len(block_list),
         )
-        _LOGGER.debug(f"block_list = {block_list}")
+        _LOGGER.debug("block_list = %s", block_list)
 
     elif known_list:
         _LOGGER.warning(
-            f"Best practice is to enforce the {SZ_KNOWN_LIST} as an allow "
-            "list, " + known_warn_line2 + known_warn_line3
+            "Best practice is to enforce the %s as an allow list, "
+            + known_warn_line2
+            + known_warn_line3,
+            SZ_KNOWN_LIST,
         )
-        _LOGGER.debug(f"known_list = {known_list}")
+        _LOGGER.debug("known_list = %s", known_list)
 
     else:
         _LOGGER.warning(
-            f"Best practice is to provide a {SZ_KNOWN_LIST} and enforce it, "
+            "Best practice is to provide a %s and enforce it, "
             + known_warn_line2
-            + known_warn_line3
+            + known_warn_line3,
+            SZ_KNOWN_LIST,
         )
 
     return enforce_known_list

--- a/src/ramses_tx/transport/base.py
+++ b/src/ramses_tx/transport/base.py
@@ -247,7 +247,7 @@ class _FullTransport(_ReadTransport):
     def _track_transmit_rate(self) -> None:
         """Track the Tx rate as period of seconds per x transmits."""
         self._transmit_times.append(dt.now())
-        _LOGGER.debug(f"Current Tx rate: {self._report_transmit_rate():.2f} pkts/min")
+        _LOGGER.debug("Current Tx rate: %.2f pkts/min", self._report_transmit_rate())
 
     def write(self, data: bytes) -> None:
         """Write the data to the underlying handler."""

--- a/src/ramses_tx/transport/file.py
+++ b/src/ramses_tx/transport/file.py
@@ -111,7 +111,7 @@ class FileTransport(_ReadTransport, _FileTransportAbstractor):
                     async for dtm_pkt_line in file:
                         await self._process_line_from_raw(dtm_pkt_line)
             except FileNotFoundError as err:
-                _LOGGER.warning(f"Correct the packet file name; {err}")
+                _LOGGER.warning("Correct the packet file name; %s", err)
 
         elif isinstance(self._pkt_source, TextIOWrapper):
             # Wrap the synchronous TextIOWrapper for asynchronous iteration

--- a/tests/tests_rf/conftest.py
+++ b/tests/tests_rf/conftest.py
@@ -154,7 +154,7 @@ async def real_evofw3_port() -> PortStrT | NoReturn:
     if port_names := [
         p.device for p in comports() if p.name[:6] == "ttyACM"
     ]:  # HACK: evofw3-esp
-        _LOGGER.warning(f"Assuming {port_names[0]} is evofw3-compatible")
+        _LOGGER.warning("Assuming %s is evofw3-compatible", port_names[0])
         return port_names[0]
 
     pytest.skip("No evofw3-based gateway device found")

--- a/tests/tests_rf/test_virtual_rf.py
+++ b/tests/tests_rf/test_virtual_rf.py
@@ -99,7 +99,9 @@ async def test_blocking_io_handling(virtual_rf: VirtualRf) -> None:
         ):
             virtual_rf._handle_data_ready(fd_0_master)
 
-        mock_log.assert_called_with(f"Buffer full writing to {port_1}, dropping packet")
+        mock_log.assert_called_with(
+            "Buffer full writing to %s, dropping packet", port_1
+        )
 
     virtual_rf._port_to_object[port_1] = original_io
 

--- a/tests/tests_rf/virtual_rf/virtual_rf.py
+++ b/tests/tests_rf/virtual_rf/virtual_rf.py
@@ -214,7 +214,7 @@ class VirtualRfBase:
                 fp.close()
             except (OSError, ValueError) as err:
                 # Log at DEBUG because this is often a side-effect of PTY closure
-                _LOGGER.debug(f"Note: Master FP for {port_name} closure: {err}")
+                _LOGGER.debug("Note: Master FP for %s closure: %s", port_name, err)
 
         # 2. Close slave FDs
         for port_name, fd in self._port_to_slave_.items():
@@ -224,10 +224,12 @@ class VirtualRfBase:
                 # EBADF (Error 9) is common if the OS already reclaimed it
                 if err.errno != 9:
                     _LOGGER.warning(
-                        f"Unexpected OSError closing slave FD for {port_name}: {err}"
+                        "Unexpected OSError closing slave FD for %s: %s",
+                        port_name,
+                        err,
                     )
             except ValueError as err:
-                _LOGGER.error(f"ValueError closing slave FD for {port_name}: {err}")
+                _LOGGER.error("ValueError closing slave FD for %s: %s", port_name, err)
 
         # 3. Clear maps so _handle_data_ready safely exits if called late
         self._master_to_port.clear()
@@ -255,7 +257,7 @@ class VirtualRfBase:
         try:
             data = self._port_to_object[src_port].read(1024)  # read the Tx'd data
         except OSError as err:
-            _LOGGER.warning(f"Read error on {src_port}: {err}")
+            _LOGGER.warning("Read error on %s: %s", src_port, err)
             return
 
         if not data:
@@ -283,7 +285,7 @@ class VirtualRfBase:
         :param src_port: The source port name.
         :param frame: The frame bytes to cast.
         """
-        _LOGGER.info(f"{src_port:<11} cast:  {frame!r}")
+        _LOGGER.info("%-11s cast:  %r", src_port, frame)
         for dst_port in self._port_to_master:
             self._push_frame_to_dst_port(dst_port, frame)
 
@@ -291,14 +293,14 @@ class VirtualRfBase:
         if not (reply := self._find_reply_for_cmd(frame)):
             return
 
-        _LOGGER.info(f"{src_port:<11} rply:  {reply!r}")
+        _LOGGER.info("%-11s rply:  %r", src_port, reply)
         for dst_port in self._port_to_master:
             self._push_frame_to_dst_port(dst_port, reply)  # is not echo only
 
     def add_reply_for_cmd(self, cmd: str, reply: str) -> None:
         """Add a reply packet for a given command frame (for a mocked device).
 
-        For example (note no RSSI, \\r\\n in reply pkt):
+        For example (note no RSSI, \r\n in reply pkt):
           cmd regex: r"RQ.* 18:.* 01:.* 0006 001 00"
           reply pkt: "RP --- 01:145038 18:013393 --:------ 0006 004 00050135",
         :param cmd: Regex pattern for the command.
@@ -329,9 +331,9 @@ class VirtualRfBase:
                 # Handle BlockingIOError (buffer full)
                 self._port_to_object[dst_port].write(data)
             except BlockingIOError:
-                _LOGGER.warning(f"Buffer full writing to {dst_port}, dropping packet")
+                _LOGGER.warning("Buffer full writing to %s, dropping packet", dst_port)
             except OSError as err:
-                _LOGGER.error(f"Write error to {dst_port}: {err}")
+                _LOGGER.error("Write error to %s: %s", dst_port, err)
 
     def _proc_after_rx(self, rcv_port: _PN, frame: bytes) -> bytes | None:
         """Allow the device to modify the frame after receiving.


### PR DESCRIPTION
### The Problem:
`_LOGGER` calls across `ramses_tx` and `ramses_rf` currently use Python `f-strings` (e.g. `_LOGGER.debug(f"Recv'd: {pkt.rssi} {pkt}")`). The `f-strings` are evaluated before the logger function is called, executing `pkt.__str__()` / `msg.__str__()` and allocating string objects on every packet even when `DEBUG` logging is disabled.

### The Fix:
Converted all `_LOGGER` calls across `ramses_tx` and `ramses_rf` to standard deferred `%`-formatting (e.g. `_LOGGER.debug("Recv'd: %s %s", pkt.rssi, pkt)`). When logging is disabled for `DEBUG`, Python evaluates the level check first and returns immediately—bypassing object string conversions and string allocations.

Fixes #960 (PR 1 of 3).

### Testing Performed:
- Pre-commit hooks (`.venv/bin/prek run -a`): Passed (100%).
- Code formatting (`.venv/bin/ruff format --check .`): Passed.
- Unit tests (`.venv/bin/pytest`): Passed (1,432 passed, 0 regressions).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.