### PR TITLE
fix(tx): HGI80 reverse-patch source addr and match echoes with addr substitution

### DIFF
--- a/src/ramses_tx/protocol/base.py
+++ b/src/ramses_tx/protocol/base.py
@@ -9,6 +9,7 @@ logging and device ID filtering mechanisms.
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import logging
 import re
 from collections import deque
@@ -285,12 +286,14 @@ class _BaseProtocol(ProtocolInterface, asyncio.Protocol):
         return
 
     def _patch_cmd_if_needed(self, cmd: CommandDTO) -> CommandDTO:
-        """Patch the command with the actual HGI ID if it uses the
-        default placeholder.
+        """Patch the command source address to match the gateway.
 
-        Legacy HGI80s (TI 3410) require the default ID (18:000730), or
-        they will silent-fail. However, evofw3 devices prefer the real
-        ID.
+        evofw3: swap placeholder 18:000730 for the real HGI ID.
+
+        HGI80 (TI 3410): reverse — swap the real HGI ID back to
+        18:000730, as the HGI80 firmware requires the placeholder as
+        source for its own transmissions.  Using the real ID causes a
+        silent drop and WantEcho timeout (issue 835).
         """
         if (
             self.hgi_id
@@ -299,12 +302,32 @@ class _BaseProtocol(ProtocolInterface, asyncio.Protocol):
             and self.hgi_id != HGI_DEV_ADDR.id
         ):
             _LOGGER.debug(
-                f"Patching command with active HGI ID: swapped "
-                f"{HGI_DEV_ADDR.id} -> {self.hgi_id} for {cmd.verb}|{cmd.code}"
+                "Patching command with active HGI ID: swapped %s -> %s for %s|%s",
+                HGI_DEV_ADDR.id,
+                self.hgi_id,
+                cmd.verb,
+                cmd.code,
             )
-            import dataclasses
-
             return dataclasses.replace(cmd, addr1=self.hgi_id)
+
+        # HGI80: reverse-patch real HGI ID back to the placeholder.
+        # The HGI80 firmware requires 18:000730 as the source for
+        # frames it transmits; using the actual gateway ID causes a
+        # silent drop and WantEcho timeout (issue 835, cc 864).
+        if (
+            self.hgi_id
+            and not self._is_evofw3  # HGI80
+            and cmd.addr1 == self.hgi_id
+            and self.hgi_id != HGI_DEV_ADDR.id
+        ):
+            _LOGGER.debug(
+                "Patching command for HGI80: swapped %s -> %s for %s|%s",
+                self.hgi_id,
+                HGI_DEV_ADDR.id,
+                cmd.verb,
+                cmd.code,
+            )
+            return dataclasses.replace(cmd, addr1=HGI_DEV_ADDR.id)
 
         return cmd
 

--- a/src/ramses_tx/transport/base.py
+++ b/src/ramses_tx/transport/base.py
@@ -12,6 +12,7 @@ from datetime import datetime as dt
 from typing import TYPE_CHECKING, Any, TypeAlias
 
 from .. import exceptions as exc
+from ..address import HGI_DEV_ADDR
 from ..const import SZ_ACTIVE_HGI, SZ_IS_EVOFW3, SZ_SIGNATURE
 from ..helpers import dt_now
 from ..interfaces import TransportInterface
@@ -183,14 +184,18 @@ class _ReadTransport(_BaseTransport, TransportInterface):
             _LOGGER.debug("Event loop closed during _make_connection()")
 
     def _is_recent_tx(self, frame: str) -> bool:
-        """Check if frame matches a recent Tx packet within 3.0 seconds.
+        """Check if frame matches a recent Tx packet within 3.0s.
 
-        Prunes expired entries from the queue and lookup map, then performs
-        an O(1) dictionary hash lookup for the incoming packet key.
+        Prunes expired entries, then does an O(1) dict lookup for
+        the incoming packet key.
 
-        :param frame: Raw ASCII frame string received from transport.
+        HGI80 echoes arrive with the real HGI ID as addr1, but the
+        TX frame used the placeholder 18:000730.  Both variants are
+        checked (issue 835).
+
+        :param frame: Raw ASCII frame string from transport.
         :type frame: str
-        :returns: True if frame is a hardware echo of recent transmission.
+        :returns: True if frame is a hardware echo of recent Tx.
         :rtype: bool
         """
         now = self._dt_now()
@@ -211,15 +216,25 @@ class _ReadTransport(_BaseTransport, TransportInterface):
         except Exception:
             return False
 
-        rx_key: _TxKeyT = (
-            rx_dto.verb,
-            rx_dto.code,
-            rx_dto.addr1,
-            rx_dto.addr2,
-            rx_dto.addr3,
-            rx_dto.payload,
+        # HGI80 echoes arrive with the real HGI ID as addr1,
+        # but the TX frame used the placeholder 18:000730.
+        addr1_variants = (
+            (rx_dto.addr1, HGI_DEV_ADDR.id)
+            if rx_dto.addr1 != HGI_DEV_ADDR.id
+            else (rx_dto.addr1,)
         )
-        return rx_key in self._recent_tx_counts
+        for addr1 in addr1_variants:
+            rx_key: _TxKeyT = (
+                rx_dto.verb,
+                rx_dto.code,
+                addr1,
+                rx_dto.addr2,
+                rx_dto.addr3,
+                rx_dto.payload,
+            )
+            if rx_key in self._recent_tx_counts:
+                return True
+        return False
 
     def _frame_read(self, dtm_str: str, frame: str) -> None:
         """Make a Packet from the Frame and process it."""
@@ -353,7 +368,10 @@ class _FullTransport(_ReadTransport):
         :returns: None
         :rtype: None
         """
-        frame_clean = frame.strip()
+        # rstrip only — preserve leading space in verbs
+        # like " W", " I" which strip() would remove, making
+        # the frame unparsable (issue 835).
+        frame_clean = frame.rstrip()
         if not frame_clean:
             return
 

--- a/tests/tests_tx/protocol/test_base.py
+++ b/tests/tests_tx/protocol/test_base.py
@@ -286,3 +286,66 @@ async def test_patch_cmd_if_needed_evofw3(protocol: DummyProtocol) -> None:
     assert patched_cmd.addr1 == "18:123456"
     assert patched_cmd.addr2 == "01:222222"
     assert original_cmd.addr1 == "18:000730"  # Enforces immutability
+
+
+async def test_patch_cmd_if_needed_hgi80_reverse(protocol: DummyProtocol) -> None:
+    """Test that _patch_cmd_if_needed swaps the real HGI ID back to the
+    placeholder for HGI80 (TI 3410).
+
+    HGI80 firmware requires 18:000730 as the source address for frames it
+    transmits.  Using the actual gateway ID causes a silent drop and WantEcho
+    timeout (issue 835, cc 864).
+    """
+    from ramses_tx.dtos import CommandDTO as Command
+
+    protocol._is_evofw3 = False  # HGI80
+    protocol._known_hgi = DeviceIdT("18:123456")
+
+    original_cmd = Command.from_cli(" W --- 18:123456 01:222222 --:------ 12B0 001 00")
+
+    patched_cmd = protocol._patch_cmd_if_needed(original_cmd)
+
+    assert patched_cmd is not original_cmd
+    assert patched_cmd.addr1 == "18:000730"  # swapped back to placeholder
+    assert patched_cmd.addr2 == "01:222222"
+    assert original_cmd.addr1 == "18:123456"  # Enforces immutability
+
+
+async def test_patch_cmd_if_needed_hgi80_no_change_when_placeholder(
+    protocol: DummyProtocol,
+) -> None:
+    """Test that _patch_cmd_if_needed does not alter a command that already
+    uses the placeholder for HGI80."""
+    from ramses_tx.dtos import CommandDTO as Command
+
+    protocol._is_evofw3 = False  # HGI80
+    protocol._known_hgi = DeviceIdT("18:123456")
+
+    original_cmd = Command.from_cli(" W --- 18:000730 01:222222 --:------ 12B0 001 00")
+
+    patched_cmd = protocol._patch_cmd_if_needed(original_cmd)
+
+    assert patched_cmd is original_cmd  # no change needed
+    assert patched_cmd.addr1 == "18:000730"
+
+
+async def test_patch_cmd_if_needed_hgi80_no_change_when_impersonating(
+    protocol: DummyProtocol,
+) -> None:
+    """Test that _patch_cmd_if_needed does not alter a command that
+    impersonates a non-gateway device (e.g. a thermostat) on HGI80.
+
+    The HGI80 cannot impersonate, but the patching logic should not silently
+    rewrite the source — the impersonation alert handles that case.
+    """
+    from ramses_tx.dtos import CommandDTO as Command
+
+    protocol._is_evofw3 = False  # HGI80
+    protocol._known_hgi = DeviceIdT("18:123456")
+
+    original_cmd = Command.from_cli(" W --- 21:057310 01:222222 --:------ 12B0 001 00")
+
+    patched_cmd = protocol._patch_cmd_if_needed(original_cmd)
+
+    assert patched_cmd is original_cmd  # no change — not the HGI ID
+    assert patched_cmd.addr1 == "21:057310"

--- a/tests/tests_tx/test_logger.py
+++ b/tests/tests_tx/test_logger.py
@@ -394,3 +394,55 @@ async def test_hardware_echo_logging_suppressed() -> None:
         assert transport._protocol.pkt_received.called
     finally:
         PKT_LOGGER.removeHandler(handler)
+
+
+@pytest.mark.asyncio
+async def test_hardware_echo_logging_suppressed_hgi80_addr_substitution() -> None:
+    """HGI80 echoes arrive with the real HGI ID as addr1, but the TX frame
+    used the placeholder 18:000730.  _is_recent_tx must still recognise the
+    echo as a recent transmission (issue 835, cc 864).
+    """
+    from datetime import datetime as dt
+    from unittest.mock import MagicMock
+
+    from ramses_tx.transport.base import TransportConfig, _FullTransport
+
+    class DummyTransport(_FullTransport):
+        def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+            super().__init__(config=TransportConfig(disable_sending=False), loop=loop)
+            self._protocol = MagicMock()
+
+        async def _write_frame(self, frame: str) -> None:
+            pass
+
+    class LogCollector(logging.Handler):
+        def __init__(self) -> None:
+            super().__init__()
+            self.records: list[logging.LogRecord] = []
+
+        def emit(self, record: logging.LogRecord) -> None:
+            self.records.append(record)
+
+    loop = asyncio.get_running_loop()
+    handler = LogCollector()
+    PKT_LOGGER.addHandler(handler)
+    PKT_LOGGER.setLevel(logging.INFO)
+
+    transport = DummyTransport(loop)
+    # TX frame uses the placeholder 18:000730 (as _patch_cmd_if_needed
+    # ensures for HGI80).  01FF payload from issue 835.
+    _payload = "008026262AD0008000143C28320000C10280800280FF80040020"
+    frame = f" W --- 18:000730 21:057310 --:------ 01FF 026 {_payload}"
+    # HGI80 echo arrives with the real HGI ID (18:002965) as addr1.
+    rx_echo = f"000  W --- 18:002965 21:057310 --:------ 01FF 026 {_payload}"
+
+    try:
+        await transport.write_frame(frame)
+        transport._frame_read(dt.now().isoformat(), rx_echo)
+        await asyncio.sleep(0.01)
+
+        # Assert: Only 1 log entry (Tx), echo suppressed despite addr1 mismatch
+        assert len(handler.records) == 1
+        assert transport._protocol.pkt_received.called
+    finally:
+        PKT_LOGGER.removeHandler(handler)

--- a/tests/tests_tx/test_transport.py
+++ b/tests/tests_tx/test_transport.py
@@ -380,3 +380,82 @@ async def test_write_frame_dispatches_outbound_dto_with_is_tx_true() -> None:
     dto: PacketDTO = transport._protocol._msg_received.call_args[0][0]
     assert dto.is_tx is True
     assert dto.verb == "RQ"
+
+
+async def test_is_recent_tx_matches_hgi80_echo_with_addr_substitution() -> None:
+    """_is_recent_tx must match HGI80 echoes where addr1 has been substituted.
+
+    The HGI80 hardware replaces the placeholder 18:000730 with its real ID in
+    the echo.  The TX frame was recorded with 18:000730, so the echo's addr1
+    (e.g. 18:002965) won't match directly — _is_recent_tx must check both
+    variants (issue 835, cc 864).
+    """
+    from ramses_tx.transport.base import TransportConfig, _FullTransport
+
+    class DummyTransport(_FullTransport):
+        def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+            super().__init__(config=TransportConfig(disable_sending=False), loop=loop)
+            self._protocol = Mock()
+
+        async def _write_frame(self, frame: str) -> None:
+            pass
+
+    loop = asyncio.get_event_loop()
+    transport = DummyTransport(loop)
+
+    # TX frame uses the placeholder 18:000730 (as _patch_cmd_if_needed
+    # ensures for HGI80).  01FF payload from issue 835.
+    _payload = "008026262AD0008000143C28320000C10280800280FF80040020"
+    tx_frame = f" W --- 18:000730 21:057310 --:------ 01FF 026 {_payload}"
+    await transport.write_frame(tx_frame)
+
+    # HGI80 echo arrives with the real HGI ID (18:002965) as addr1.
+    echo_frame = f"000  W --- 18:002965 21:057310 --:------ 01FF 026 {_payload}"
+    assert transport._is_recent_tx(echo_frame) is True
+
+
+async def test_is_recent_tx_matches_evofw3_echo_directly() -> None:
+    """_is_recent_tx still matches evofw3 echoes where addr1 is unchanged."""
+    from ramses_tx.transport.base import TransportConfig, _FullTransport
+
+    class DummyTransport(_FullTransport):
+        def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+            super().__init__(config=TransportConfig(disable_sending=False), loop=loop)
+            self._protocol = Mock()
+
+        async def _write_frame(self, frame: str) -> None:
+            pass
+
+    loop = asyncio.get_event_loop()
+    transport = DummyTransport(loop)
+
+    _payload = "008026262AD0008000143C28320000C10280800280FF80040020"
+    tx_frame = f" W --- 18:002965 21:057310 --:------ 01FF 026 {_payload}"
+    await transport.write_frame(tx_frame)
+
+    echo_frame = f"000  W --- 18:002965 21:057310 --:------ 01FF 026 {_payload}"
+    assert transport._is_recent_tx(echo_frame) is True
+
+
+async def test_is_recent_tx_rejects_unrelated_frame() -> None:
+    """_is_recent_tx returns False for a frame that was not recently sent."""
+    from ramses_tx.transport.base import TransportConfig, _FullTransport
+
+    class DummyTransport(_FullTransport):
+        def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+            super().__init__(config=TransportConfig(disable_sending=False), loop=loop)
+            self._protocol = Mock()
+
+        async def _write_frame(self, frame: str) -> None:
+            pass
+
+    loop = asyncio.get_event_loop()
+    transport = DummyTransport(loop)
+
+    _payload = "008026262AD0008000143C28320000C10280800280FF80040020"
+    tx_frame = f" W --- 18:000730 21:057310 --:------ 01FF 026 {_payload}"
+    await transport.write_frame(tx_frame)
+
+    # Completely different frame
+    other_frame = "000  I --- 21:057310 18:002965 --:------ 22C9 006 00086608CA02"
+    assert transport._is_recent_tx(other_frame) is False


### PR DESCRIPTION
## Summary

Three fixes for HGI80 (TI 3410) gateways, traced to the `QosProtocol` timeout for `W|01FF` bind to Itho Spider (ramses-rf/ramses_cc#864, ramses-rf/ramses_rf#835).

**1. `_patch_cmd_if_needed`: reverse-patch for HGI80**

The existing code only patched evofw3 gateways (placeholder `18:000730` → real HGI ID). HGI80 firmware requires `18:000730` as the source address — using the real HGI ID causes a silent drop and WantEcho timeout. Now, for HGI80, the real HGI ID is swapped back to the placeholder.

**2. `_is_recent_tx`: match HGI80 echoes with addr substitution**

PR 957's `_is_recent_tx` didn't match HGI80 echoes where `addr1` is substituted (real ID instead of placeholder). Now both variants are checked.

**3. `_log_tx_packet`: use `rstrip` instead of `strip`**

`strip()` removed the leading space from ` W` / ` I` verbs, making the frame unparsable — TX key was never recorded for any I/W command on any gateway. Now `rstrip()` is used.

## References

- ramses-rf/ramses_cc#867 (original AttributeError fix)
- ramses-rf/ramses_cc#864
- ramses-rf/ramses_rf#835
- ramses-rf/ramses_rf#73 (01FF not understood — HW limitation)
- ramses-rf/ramses_rf#957 (echo suppression)

## Test plan

- [x] `test_patch_cmd_if_needed_hgi80_reverse` — HGI80 swaps real ID back to placeholder
- [x] `test_patch_cmd_if_needed_hgi80_no_change_when_placeholder` — no-op when already placeholder
- [x] `test_patch_cmd_if_needed_hgi80_no_change_when_impersonating` — no-op for non-gateway source
- [x] `test_is_recent_tx_matches_hgi80_echo_with_addr_substitution` — echo with real HGI ID matches TX with placeholder
- [x] `test_is_recent_tx_matches_evofw3_echo_directly` — evofw3 echo still matches directly
- [x] `test_is_recent_tx_rejects_unrelated_frame` — unrelated frame rejected
- [x] `test_hardware_echo_logging_suppressed_hgi80_addr_substitution` — end-to-end echo suppression
- [x] Full test suite: 1445 passed, 4 skipped
- [x] pre-commit: all hooks pass