### PR TITLE
fix(config): default HVAC class 'HVC' must pass its own validator

### DIFF
--- a/src/ramses_rf/config.py
+++ b/src/ramses_rf/config.py
@@ -106,8 +106,15 @@ def sch_global_traits_dict_factory(
     SCH_TRAITS_HVAC = SCH_TRAITS_BASE.extend(
         {
             vol.Optional("_domain", default="hvac"): "hvac",
-            vol.Optional(SZ_CLASS, default="HVC"): vol.Any(
-                None, *hvac_slugs, *(str(DEV_TYPE_MAP[s]) for s in hvac_slugs)
+            # "HVC" (generic/promotable HVAC device) is the default class
+            # but is not itself one of DEV_TYPE_MAP.HVAC_SLUGS, so it must
+            # be listed explicitly or the default value fails its own
+            # validator whenever a device has no explicit _class.
+            vol.Optional(SZ_CLASS, default=DevType.HVC): vol.Any(
+                None,
+                str(DevType.HVC),
+                *hvac_slugs,
+                *(str(DEV_TYPE_MAP[s]) for s in hvac_slugs),
             ),
             vol.Optional(SZ_BOUND_TO): vol.Any(
                 None,

--- a/tests/tests_rf/test_config.py
+++ b/tests/tests_rf/test_config.py
@@ -193,6 +193,21 @@ class TestSchTraitsHvacBound:
         result = SCH_TRAITS({"class": "FAN", "scheme": "vasco"})
         assert "bound" not in result or result.get("bound") is None
 
+    def test_bound_without_class_uses_default_hvc(self) -> None:
+        """bound is valid even without an explicit class (regression).
+
+        SCH_TRAITS_HVAC defaults ``class`` to ``DevType.HVC`` when absent,
+        but that default value must itself pass the class validator, or
+        voluptuous falls through to SCH_TRAITS_HEAT (which rejects
+        ``bound``) and raises a generic, hard-to-diagnose "not a valid
+        value @ data['bound']" error for any HVAC device that has a
+        ``bound`` trait but no ``class`` (e.g. a REM/FAN discovered from
+        traffic before its class trait was learned).
+        """
+        result = SCH_TRAITS({"bound": "37:168270"})
+        assert result["bound"] == "37:168270"
+        assert result["class"] == "HVC"
+
 
 class TestStripTraits:
     """Unit tests for strip_traits() (stage 1 only — strip, no mapping)."""


### PR DESCRIPTION
## Summary

`SCH_TRAITS_HVAC` defaults the `class` trait to `DevType.HVC` when a
device has no explicit `_class`, but `HVC` (a generic/promotable device
type) is not itself listed in `DEV_TYPE_MAP.HVAC_SLUGS`. The `class`
validator is built purely from `HVAC_SLUGS`, so the schema's own
default value fails its own validation.

In practice, any HVAC device with a `bound` trait but no explicit
`class` (e.g. a REM/FAN discovered from live traffic before its class
trait was learned/persisted) fails the whole `SCH_TRAITS` `Any()`
(voluptuous falls through to `SCH_TRAITS_HEAT`, which rejects `bound`
via `PREVENT_EXTRA`), surfacing as a generic and hard-to-diagnose:

```
voluptuous.error.MultipleInvalid: not a valid value @ data['bound']
```

during `known_list`/schema validation — with no indication that the
real problem is a missing `_class` on an HVAC device.

- `src/ramses_rf/config.py`: explicitly allow `DevType.HVC` in the
  HVAC class validator, alongside the existing `hvac_slugs` values.
- `tests/tests_rf/test_config.py`: regression test proving `SCH_TRAITS`
  accepts a `bound`-only trait dict (no explicit `class`) and defaults
  `class` to `"HVC"`.

## Test plan

- [x] New regression test fails on `master` (reproduces the reported
      error) and passes with the fix.
- [x] Full `pytest` suite passes (1439 passed, 4 skipped).
- [x] `ruff check`, `ruff format`, `mypy --strict`, and `prek run -a`
      all pass on the changed files.