### PR TITLE
fix(topology): refine CQRS parent re-binding and add unit tests

### DIFF
--- a/src/ramses_rf/topology.py
+++ b/src/ramses_rf/topology.py
@@ -345,12 +345,36 @@ class Child:
             child_id = child_id or getattr(parent, "idx", None)
 
         if self._parent and self._parent != parent:
-            err_msg = (
-                f"{self} can't change parent "
-                f"({self._parent}_{self._child_id} to {parent}_{child_id})"
-            )
-            _TRACE.error("PARENT CHANGE EXCEPTION: %s", err_msg)
-            raise exc.SystemSchemaInconsistent(err_msg)
+            prev_parent_class = self._parent.__class__.__name__
+            if prev_parent_class in ("System", "Evohome") and parent_class not in (
+                "System",
+                "Evohome",
+            ):
+                _TRACE.info(
+                    "PARENT PROMOTION: %s promoted parent from %s to %s",
+                    self,
+                    prev_parent_class,
+                    parent_class,
+                )
+                dev_id = getattr(self, "id", None)
+                if (
+                    hasattr(self._parent, "actuators")
+                    and self in self._parent.actuators
+                ):
+                    self._parent.actuators.remove(self)
+                if (
+                    hasattr(self._parent, "actuator_by_id")
+                    and dev_id is not None
+                    and dev_id in self._parent.actuator_by_id
+                ):
+                    del self._parent.actuator_by_id[dev_id]
+            else:
+                err_msg = (
+                    f"{self} can't change parent "
+                    f"({self._parent}_{self._child_id} to {parent}_{child_id})"
+                )
+                _TRACE.error("PARENT CHANGE EXCEPTION: %s", err_msg)
+                raise exc.SystemSchemaInconsistent(err_msg)
 
         PARENT_RULES: dict[str, dict[str, tuple[str, ...]]] = {
             "DhwZone": {SZ_ACTUATORS: ("BdrSwitch",), SZ_SENSOR: ("DhwSensor",)},

--- a/tests/tests_rf/test_topology.py
+++ b/tests/tests_rf/test_topology.py
@@ -15,7 +15,10 @@ from typing import Any
 
 import pytest
 
+import ramses_rf.exceptions as exc
 from ramses_rf.gateway import Gateway, GatewayConfig
+from ramses_rf.topology import Child, Parent
+from ramses_tx import DeviceIdT
 from ramses_tx.config import EngineConfig
 
 
@@ -146,3 +149,90 @@ async def test_ramses_rf_isolated_topology() -> None:
 
     # Assert the Evohome system was instantiated
     assert len(systems) > 0, "CRITICAL: TopologyBuilder failed to create a System!"
+
+
+# --- Unit Tests for Topology Parent Promotion & Re-binding ---
+
+
+class System(Parent):
+    def __init__(self, sys_id: str) -> None:
+        super().__init__()
+        self.id = sys_id
+        self.actuators: list[Any] = []
+        self.actuator_by_id: dict[DeviceIdT, Any] = {}
+
+
+class Zone(Parent):
+    def __init__(self, idx: str) -> None:
+        super().__init__()
+        self.idx = idx
+        self.id = idx
+        self.actuators: list[Any] = []
+        self.actuator_by_id: dict[DeviceIdT, Any] = {}
+
+
+class BdrSwitch(Child):
+    def __init__(self, dev_id: str) -> None:
+        super().__init__()
+        self.id = dev_id
+
+
+def test_child_set_parent_initial_assignment() -> None:
+    # Arrange
+    child = BdrSwitch("13:123456")
+    parent_system = System("01:145038")
+
+    # Act
+    child._apply_topology_link(parent_system, child_id="FC")
+
+    # Assert
+    assert child._parent is parent_system
+    assert child._child_id == "FC"
+
+
+def test_child_set_parent_promotion_from_system_to_zone() -> None:
+    # Arrange
+    child = BdrSwitch("13:123456")
+    parent_system = System("01:145038")
+    parent_zone = Zone("00")
+
+    # Act 1: Initial System parent binding
+    child_dev_id = DeviceIdT(child.id)
+    child._apply_topology_link(parent_system, child_id="FC")
+
+    # Act 2: Promote parent to Zone
+    child._apply_topology_link(parent_zone, child_id="00")
+
+    # Assert
+    assert child._parent is parent_zone
+    assert child not in parent_system.actuators
+    assert child_dev_id not in parent_system.actuator_by_id
+
+
+def test_child_set_parent_rejects_invalid_cross_zone_change() -> None:
+    # Arrange
+    child = BdrSwitch("13:123456")
+    zone_00 = Zone("00")
+    zone_01 = Zone("01")
+
+    # Act
+    child._apply_topology_link(zone_00, child_id="00")
+
+    # Assert
+    with pytest.raises(exc.SystemSchemaInconsistent) as exc_info:
+        child._apply_topology_link(zone_01, child_id="01")
+
+    assert "can't change parent" in str(exc_info.value)
+
+
+def test_child_set_parent_idempotent() -> None:
+    # Arrange
+    child = BdrSwitch("13:123456")
+    zone_00 = Zone("00")
+
+    # Act
+    child._apply_topology_link(zone_00, child_id="00")
+    child._apply_topology_link(zone_00, child_id="00")
+
+    # Assert
+    assert child._parent is zone_00


### PR DESCRIPTION
### The Problem:
When `TopologyBuilder` emitted parent-child bindings during CQRS state projection, child devices (such as `02:` UFC controllers or relays) initially bound to generic `System` / `Evohome` containers threw `SystemSchemaInconsistent` (`PARENT CHANGE EXCEPTION`) when promoted to specific `Zone` / `UfhZone` containers.

### The Fix:
- **Refined `Child._set_parent`**: Allowed safe parent promotion when child devices move from generic parent containers (`System` / `Evohome`) to specific `Zone` containers, removing old generic parent bindings cleanly without throwing exceptions.
- **Added Isolated Unit Tests**: Added unit tests to `tests/tests_rf/test_topology.py` covering initial assignment, parent promotion from `System` to `Zone`, rejection of invalid cross-zone changes, and idempotency.

Part of Phase 4.5 refactoring sub-plan (ramses-rf/ramses_rf#639).

### Testing Performed:
- `prek run -a`: 100% Passed.
- `mypy --strict`: 100% Passed across 238 source files.
- `pytest`: 1,450 passed, 0 failed, 4 skipped (99 snapshots passed).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.
