### PR TITLE
refactor(address): replace address string slicing with domain properties and DevType enums

### DIFF
--- a/src/ramses_rf/commands/builders/dhw.py
+++ b/src/ramses_rf/commands/builders/dhw.py
@@ -15,6 +15,7 @@ from ramses_tx.const import (
     W_,
     ZON_MODE_MAP,
     Code,
+    DevType,
     Priority,
 )
 from ramses_tx.dtos import CommandDTO
@@ -96,7 +97,7 @@ def build_put_dhw_temp(intent: Command) -> CommandDTO:
     dhw_idx = _check_idx(intent.get(SZ_DHW_IDX, 0))
     temperature = intent.get("temperature")
 
-    if intent.src.id[:2] != DEV_TYPE_MAP.DHW:
+    if getattr(intent.src, "type", None) not in (DEV_TYPE_MAP.DHW, DevType.DHW):
         raise ValueError(
             f"Faked device {intent.src.id} has an unsupported device type: "
             f"device_id should be like {DEV_TYPE_MAP.DHW}:xxxxxx"

--- a/src/ramses_rf/commands/builders/system.py
+++ b/src/ramses_rf/commands/builders/system.py
@@ -17,6 +17,7 @@ from ramses_tx.const import (
     SYS_MODE_MAP,
     W_,
     Code,
+    DevType,
     Priority,
 )
 from ramses_tx.dtos import CommandDTO
@@ -34,7 +35,7 @@ def build_put_weather_temp(intent: Command) -> CommandDTO:
     """Translate a PUT_WEATHER_TEMP intent into a CommandDTO."""
     temperature = intent.get("temperature")
 
-    if intent.src.id[:2] != DEV_TYPE_MAP.OUT:
+    if getattr(intent.src, "type", None) not in (DEV_TYPE_MAP.OUT, DevType.OUT):
         raise ValueError(
             f"Faked device {intent.src.id} has an unsupported device type: "
             f"device_id should be like {DEV_TYPE_MAP.OUT}:xxxxxx"
@@ -159,7 +160,11 @@ def build_get_tpi_params(intent: Command) -> CommandDTO:
     if domain_id is None:
         from ramses_tx.const import FC
 
-        domain_id = "00" if intent.dst.id[:2] == DEV_TYPE_MAP.BDR else FC
+        domain_id = (
+            "00"
+            if getattr(intent.dst, "type", None) in (DEV_TYPE_MAP.BDR, DevType.BDR)
+            else FC
+        )
 
     addr1, addr2, addr3 = resolve_addrs(intent.src, intent.dst)
     return CommandDTO(
@@ -406,7 +411,7 @@ def build_put_actuator_state(intent: Command) -> CommandDTO:
     """Translate a PUT_ACTUATOR_STATE intent into a CommandDTO."""
     modulation_level = intent.get("modulation_level")
 
-    if intent.src.id[:2] != DEV_TYPE_MAP.BDR:
+    if getattr(intent.src, "type", None) not in (DEV_TYPE_MAP.BDR, DevType.BDR):
         raise ValueError(
             f"Faked device {intent.src.id} has an unsupported device type: "
             f"device_id should be like {DEV_TYPE_MAP.BDR}:xxxxxx"
@@ -436,7 +441,7 @@ def build_put_actuator_cycle(intent: Command) -> CommandDTO:
     actuator_countdown = intent.get("actuator_countdown")
     cycle_countdown = intent.get("cycle_countdown")
 
-    if intent.src.id[:2] != DEV_TYPE_MAP.BDR:
+    if getattr(intent.src, "type", None) not in (DEV_TYPE_MAP.BDR, DevType.BDR):
         raise ValueError(
             f"Faked device {intent.src.id} has an unsupported device type: "
             f"device_id should be like {DEV_TYPE_MAP.BDR}:xxxxxx"

--- a/src/ramses_rf/devices/dev_registry.py
+++ b/src/ramses_rf/devices/dev_registry.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
 
 from ramses_rf.address import Address, is_valid_dev_id
 from ramses_rf.config import GatewayConfig
-from ramses_rf.const import DEV_TYPE_MAP, FA, FC, SZ_DEVICES
+from ramses_rf.const import DEV_TYPE_MAP, FA, FC, SZ_DEVICES, DevType
 from ramses_rf.devices.dev_base import DeviceHeat, DeviceHvac, Fakeable
 from ramses_rf.enums import TopologyAction
 from ramses_rf.exceptions import (
@@ -200,8 +200,16 @@ class DeviceRegistry:
             # If the event lacks a sensor flag, we must flag dedicated hardware
             # sensors before passing to the legacy graph so it doesn't crash.
             if is_sensor is None and event.child_id:
-                child_type = event.child_id[:2]
-                if child_type in ("00", "03", "12", "22", "34"):
+                child_type = Address(event.child_id).type
+                if child_type in (
+                    "00",
+                    "03",
+                    "12",
+                    "22",
+                    "34",
+                    DevType.THM,
+                    DevType.HCW,
+                ):
                     is_sensor = True
 
             # Route the binding back through get_device to ensure full
@@ -235,8 +243,15 @@ class DeviceRegistry:
                 cqrs_ufcs: set[str] = getattr(self, "_cqrs_ufcs", set())
                 cqrs_sensors: dict[str, str] = getattr(self, "_cqrs_sensors", {})
 
-                dev_type = child_dev.id[:2] if hasattr(child_dev, "id") else None
-                is_actuator_hw = dev_type in ("04", "13", "02")
+                dev_type = getattr(child_dev, "type", None)
+                is_actuator_hw = dev_type in (
+                    "04",
+                    "13",
+                    "02",
+                    DevType.TRV,
+                    DevType.BDR,
+                    DevType.UFC,
+                )
 
                 is_explicit_sensor = device_role == "sensor" or is_sensor is True
                 is_explicit_actuator = device_role == "actuator"

--- a/src/ramses_rf/dispatcher.py
+++ b/src/ramses_rf/dispatcher.py
@@ -248,7 +248,7 @@ def instantiate_devices(gwy: Gateway, msg: Message) -> bool:
                 # may: DeviceNotFoundError, but don't suppress
                 src_dev = gwy.device_registry.get_device(msg.src.id)
                 if (
-                    str(msg.src.id).startswith("01:")
+                    getattr(msg.src, "type", None) in ("01", DevType.CTL)
                     and hasattr(src_dev, "tcs")
                     and src_dev.tcs is None
                     and hasattr(src_dev, "_make_tcs_controller")
@@ -970,16 +970,18 @@ async def _update_topology_schema_state(
             zone_idx is not None
             and tcs
             and hasattr(tcs, "get_htg_zone")
-            and not str(getattr(msg.src, "id", "")).startswith("02:")
+            and getattr(msg.src, "type", None) not in ("02", DevType.UFC)
         ):
+            _non_zone_prefixes = (
+                f"{DevType.CTL}:",
+                f"{DevType.UFC}:",
+                f"{DevType.HGI}:",
+                "7F:",
+            )
             valid_devs = [
                 d
                 for d in devices
-                if not str(d).startswith("01:")
-                and not str(d).startswith("02:")
-                and not str(d).startswith("18:")
-                and not str(d).startswith("7F:")
-                and str(d) != "7FFFFFFF"
+                if not str(d).startswith(_non_zone_prefixes) and str(d) != "7FFFFFFF"
             ]
             zone_cls: str | None = None
             if valid_devs and zone_type is not None and zone_type in ZON_ROLE_MAP:
@@ -1008,14 +1010,15 @@ async def _update_topology_schema_state(
                     "07",
                     "0D",
                 )
+                _non_actuator_prefixes = (
+                    f"{DevType.CTL}:",
+                    f"{DevType.UFC}:",
+                    f"{DevType.HGI}:",
+                    "63:",
+                )
                 for d_id in valid_devs:
                     d_str = str(d_id)
-                    if (
-                        d_str.startswith("01:")
-                        or d_str.startswith("02:")
-                        or d_str.startswith("18:")
-                        or d_str.startswith("63:")
-                    ):
+                    if d_str.startswith(_non_actuator_prefixes):
                         continue
                     with contextlib.suppress(
                         exc.DeviceNotFoundError, exc.SchemaInconsistentError

--- a/src/ramses_rf/pipeline/topology_handlers/binding.py
+++ b/src/ramses_rf/pipeline/topology_handlers/binding.py
@@ -14,6 +14,7 @@ from ramses_rf.const import (
     W_,
     ZON_ROLE_MAP,
     Code,
+    DevType,
 )
 from ramses_rf.enums import TopologyAction
 from ramses_rf.messages.core import Message
@@ -89,7 +90,7 @@ class BindTopologyHandler(TopologyHandler):
             return
 
         # Always trigger controller creation if source or destination is a controller
-        if msg.src.id.startswith("01:"):
+        if getattr(msg.src, "type", None) in ("01", DevType.CTL):
             self._emit(
                 TopologyChangedEvent(
                     action=TopologyAction.CREATE_CONTROLLER,
@@ -98,7 +99,7 @@ class BindTopologyHandler(TopologyHandler):
                 )
             )
 
-        if msg.dst.id.startswith("01:"):
+        if getattr(msg.dst, "type", None) in ("01", DevType.CTL):
             self._emit(
                 TopologyChangedEvent(
                     action=TopologyAction.CREATE_CONTROLLER,
@@ -113,7 +114,9 @@ class BindTopologyHandler(TopologyHandler):
             opcode_hex = chunk[2:6]
             bound_dev_id = hex_id_to_dev_id(chunk[6:12])
 
-            if bound_dev_id.startswith("01:"):
+            if bound_dev_id.startswith(f"{DevType.CTL}:") or bound_dev_id.startswith(
+                "01:"
+            ):
                 self._emit(
                     TopologyChangedEvent(
                         action=TopologyAction.CREATE_CONTROLLER,
@@ -206,9 +209,9 @@ class BindTopologyHandler(TopologyHandler):
                     event_meta["child_id"] = str(zone_idx)
                     for child_id in devices:
                         if (
-                            child_id.startswith("01:")
-                            or child_id.startswith("02:")
-                            or child_id.startswith("18:")
+                            child_id.startswith(f"{DevType.CTL}:")
+                            or child_id.startswith(f"{DevType.UFC}:")
+                            or child_id.startswith(f"{DevType.HGI}:")
                             or child_id.startswith("63:")
                         ):
                             continue

--- a/src/ramses_rf/pipeline/topology_handlers/dhw.py
+++ b/src/ramses_rf/pipeline/topology_handlers/dhw.py
@@ -21,10 +21,9 @@ class DhwTopologyHandler(TopologyHandler):
         if not self._enable_eavesdrop:
             return
 
-        if (
-            msg.header.code in (Code._1260, Code._10A0)
-            and getattr(msg.src, "type", None) == "07"
-        ):
+        if msg.header.code in (Code._1260, Code._10A0) and getattr(
+            msg.src, "type", None
+        ) in ("07", DevType.DHW):
             event = TopologyChangedEvent(
                 action=TopologyAction.UPDATE_DEVICE_CLASS,
                 device_id=msg.src.id,

--- a/src/ramses_rf/pipeline/topology_handlers/hvac.py
+++ b/src/ramses_rf/pipeline/topology_handlers/hvac.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from ramses_rf.const import DevType
 from ramses_rf.enums import TopologyAction
 from ramses_rf.messages.core import Message
 from ramses_rf.models import TopologyChangedEvent
@@ -33,7 +34,10 @@ class HvacTopologyHandler(TopologyHandler):
                 break
 
         if dev_class:
-            if msg.src.id != "--:------" and getattr(msg.src, "type", None) != "01":
+            if msg.src.id != "--:------" and getattr(msg.src, "type", None) not in (
+                "01",
+                DevType.CTL,
+            ):
                 self._emit(
                     TopologyChangedEvent(
                         action=TopologyAction.UPDATE_DEVICE_CLASS,
@@ -46,7 +50,7 @@ class HvacTopologyHandler(TopologyHandler):
             if (
                 msg.dst.id != "--:------"
                 and msg.dst.id != msg.src.id
-                and getattr(msg.dst, "type", None) != "01"
+                and getattr(msg.dst, "type", None) not in ("01", DevType.CTL)
             ):
                 self._emit(
                     TopologyChangedEvent(

--- a/src/ramses_rf/pipeline/topology_handlers/rad.py
+++ b/src/ramses_rf/pipeline/topology_handlers/rad.py
@@ -117,7 +117,12 @@ class RadTopologyHandler(TopologyHandler):
             return
 
         prefix_map = {
-            # REMOVED: "02": DevType.UFC, - This greedy assumption breaks HVAC validation
+            # REMOVED: DevType.UFC / "02" - This greedy assumption
+            # breaks HVAC validation
+            DevType.HCW: DevType.HCW,
+            DevType.TRV: DevType.TRV,
+            DevType.BDR: DevType.BDR,
+            DevType.THM: DevType.THM,
             "03": DevType.HCW,
             "04": DevType.TRV,
             "12": DevType.THM,

--- a/src/ramses_rf/pipeline/topology_handlers/ufh.py
+++ b/src/ramses_rf/pipeline/topology_handlers/ufh.py
@@ -35,8 +35,8 @@ class UfhTopologyHandler(TopologyHandler):
         :returns: None
         :rtype: None
         """
-        is_ufc_src = getattr(msg.src, "type", None) == "02"
-        is_ufc_dst = getattr(msg.dst, "type", None) == "02"
+        is_ufc_src = getattr(msg.src, "type", None) in ("02", DevType.UFC)
+        is_ufc_dst = getattr(msg.dst, "type", None) in ("02", DevType.UFC)
 
         if not (is_ufc_src or is_ufc_dst):
             return
@@ -45,11 +45,11 @@ class UfhTopologyHandler(TopologyHandler):
 
         # Identify the Controller ID if present in the conversation
         ctl_id = None
-        if getattr(msg.src, "type", None) == "01":
+        if getattr(msg.src, "type", None) in ("01", DevType.CTL):
             ctl_id = msg.src.id
-        elif getattr(msg.dst, "type", None) == "01":
+        elif getattr(msg.dst, "type", None) in ("01", DevType.CTL):
             ctl_id = msg.dst.id
-        elif getattr(msg.addr3, "type", None) == "01":
+        elif getattr(msg.addr3, "type", None) in ("01", DevType.CTL):
             ctl_id = msg.addr3.id
 
         # 1. Conversational Binding: Promote and bind if communicating with a Controller

--- a/src/ramses_rf/systems/tcs.py
+++ b/src/ramses_rf/systems/tcs.py
@@ -27,6 +27,7 @@ from ramses_rf.const import (
     SZ_ZONE_TYPE,
     SZ_ZONES,
     ZON_ROLE_MAP,
+    DevType,
 )
 from ramses_rf.devices import BdrSwitch, Controller, Device, OtbGateway, UfhController
 from ramses_rf.entity import Entity, class_by_attr
@@ -218,20 +219,27 @@ class SystemBase(Parent, Entity):  # 3B00 (multi-relay)
         result: dict[str, Any] = {}
 
         try:
-            if schema[SZ_SYSTEM][SZ_APPLIANCE_CONTROL][:2] == DEV_TYPE_MAP.OTB:  # DEX
-                result[SZ_SYSTEM] = {
-                    SZ_APPLIANCE_CONTROL: schema[SZ_SYSTEM][SZ_APPLIANCE_CONTROL]
-                }
+            app_cntrl = schema[SZ_SYSTEM][SZ_APPLIANCE_CONTROL]
+            if app_cntrl and Address(app_cntrl).type in (
+                DEV_TYPE_MAP.OTB,
+                DevType.OTB,
+            ):  # DEX
+                result[SZ_SYSTEM] = {SZ_APPLIANCE_CONTROL: app_cntrl}
         except (IndexError, TypeError):
             result[SZ_SYSTEM] = {SZ_APPLIANCE_CONTROL: None}
 
         zones = {}
         for idx, zone in schema[SZ_ZONES].items():
             _zone = {}
-            if zone[SZ_SENSOR] and zone[SZ_SENSOR][:2] == DEV_TYPE_MAP.CTL:  # DEX
+            if zone[SZ_SENSOR] and Address(zone[SZ_SENSOR]).type in (
+                DEV_TYPE_MAP.CTL,
+                DevType.CTL,
+            ):  # DEX
                 _zone = {SZ_SENSOR: zone[SZ_SENSOR]}
             if devices := [
-                d for d in zone[SZ_ACTUATORS] if d[:2] == DEV_TYPE_MAP.TRV
+                d
+                for d in zone[SZ_ACTUATORS]
+                if Address(d).type in (DEV_TYPE_MAP.TRV, DevType.TRV)
             ]:  # DEX
                 _zone.update({SZ_ACTUATORS: devices})
             if _zone:

--- a/src/ramses_rf/systems/zones.py
+++ b/src/ramses_rf/systems/zones.py
@@ -515,7 +515,11 @@ class Zone(ZoneSchedule):
                 DevType.HGI,
             }
         )
-        _controller_prefixes = ("01:", "02:", "18:")
+        _controller_prefixes = (
+            f"{DevType.CTL}:",
+            f"{DevType.UFC}:",
+            f"{DevType.HGI}:",
+        )
 
         if sensor_id := schema.get(SZ_SENSOR):
             sensor_kl = self._gwy.config.known_list.get(str(sensor_id), {})

--- a/src/ramses_rf/topology.py
+++ b/src/ramses_rf/topology.py
@@ -27,7 +27,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from . import exceptions as exc
-from .const import F9, FA, FC, FF, SZ_ACTUATORS, SZ_SENSOR
+from .const import F9, FA, FC, FF, SZ_ACTUATORS, SZ_SENSOR, DevType
 from .schemas import SZ_CIRCUITS
 
 
@@ -135,7 +135,8 @@ class Parent:
                 if (
                     existing_sensor
                     and getattr(existing_sensor, "id", None) != child.id
-                    and not str(getattr(existing_sensor, "id", "")).startswith("01:")
+                    and getattr(existing_sensor, "type", None)
+                    not in ("01", DevType.CTL)
                 ):
                     raise exc.SystemSchemaInconsistent(
                         f"{self} changed zone sensor (from {existing_sensor} to {child})"


### PR DESCRIPTION
### ⚠️ STACKED PR: Depends on #973 and #976 < both merged

### The Problem:
Throughout the codebase (`dev_registry.py`, `tcs.py`, `commands/builders/`, `dispatcher.py`, and subsystem topology handlers), address type checking relied heavily on raw string slicing (`addr[:2]`, `dev_id[:2]`, `str(id).startswith("01:")`). Maintainer @silverailscolo noted in PR #965 reviews: *"Still a lot of slicing in addresses to fetch their 'type'. Can that be refactored?"*

Furthermore, PR #973 (@wimpie70) fixed a bug in `Zone._update_schema` where raw address prefix filtering blocked faked sensors in `known_list` with controller-class IDs (e.g. `01:150003`) from binding to parent zones.

### The Fix:
- **Incorporated PR #973**: Included commit `e4c654c` by @wimpie70 in `src/ramses_rf/systems/zones.py` and updated `_controller_prefixes` to use `DevType` enum constants.
- **Eliminated Address String Slicing**:
  - Replaced `dev_id[:2]`, `addr[:2]`, `intent.src.id[:2]` in `dev_registry.py`, `tcs.py`, `commands/builders/system.py`, `commands/builders/dhw.py`, and `dispatcher.py` with domain properties `Address.type` and `dev.type`.
- **Standardised CQRS Subsystem Handlers**:
  - Refactored `binding.py`, `rad.py`, `ufh.py`, `dhw.py`, `hvac.py`, and `topology.py` to evaluate `DevType` enum constants instead of raw string prefixes.

Part of Phase 4.5 refactoring sub-plan (ramses-rf/ramses_rf#639).

### Testing Performed:
- `prek run -a`: 100% Passed.
- `mypy --strict`: 100% Passed across 238 source files.
- `pytest`: 1,454 passed, 0 failed, 4 skipped (99 snapshots passed).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.
