### PR TITLE
fix(mqtt): set _topic_pub/_topic_sub in _on_connect before _establish_connection

### DIFF
--- a/src/ramses_tx/transport/mqtt.py
+++ b/src/ramses_tx/transport/mqtt.py
@@ -277,6 +277,20 @@ class MqttTransport(_FullTransport, _MqttTransportAbstractor):
                 parts = self._topic_base.split("/")
                 if len(parts) == 3:
                     gwy_id = DeviceIdT(parts[-1])
+                    # Set _topic_pub/_topic_sub now so that _publish() has a
+                    # valid topic before the retained "online" message is
+                    # processed.  Without this, the FSM sends an RQ via
+                    # _publish("") which the broker rejects as a malformed
+                    # packet, causing a disconnect/reconnect cycle.
+                    if not self._topic_pub:
+                        self._topic_pub = self._topic_base + "/tx"
+                        self._topic_sub = self._topic_base + "/rx"
+                        self.client.subscribe(self._topic_sub, qos=self._mqtt_qos)
+                        _LOGGER.debug(
+                            "Pre-set topic_pub/sub from topic_base: %s, %s",
+                            self._topic_pub,
+                            self._topic_sub,
+                        )
             self._establish_connection(gwy_id)
 
     def _on_connect_fail(
@@ -572,6 +586,10 @@ class MqttTransport(_FullTransport, _MqttTransportAbstractor):
         """Publish the payload to the MQTT broker."""
         if not self._connected:
             raise exc.TransportStateError("Cannot publish: MQTT not connected")
+
+        if not self._topic_pub:
+            _LOGGER.warning("Cannot publish: _topic_pub not yet set")
+            return
 
         info: mqtt.MQTTMessageInfo = self.client.publish(
             self._topic_pub, payload=payload, qos=self._mqtt_qos


### PR DESCRIPTION
## Summary
- Set `_topic_pub` and `_topic_sub` from `_topic_base` in `_on_connect` when the topic is specific (not a wildcard), before calling `_establish_connection`
- Add safety guard in `_publish` to skip if `_topic_pub` is still empty

## Problem
When the MQTT broker connection is established, `_on_connect` calls `_establish_connection`, which triggers `protocol.connection_made()`. The FSM may immediately attempt to publish (e.g. an RQ 2349 polling packet). Previously, `_topic_pub` was still empty at this point — it was only set when the retained "online" status message arrived later in `_create_connection`. Publishing to an empty topic caused the broker to disconnect with "malformed packet", creating a disconnect/reconnect cycle that lost packets.

This was particularly visible with a local Mosquitto 2.x broker and paho-mqtt 2.x clients, where the disconnect/reconnect cycle could lose injected simulator packets during ha_sim_test parallel runs.

## Test plan
- [x] `prek run -a` passes
- [x] `mypy --strict` passes
- [x] `pytest tests/` — 1457 passed, 4 skipped
- [x] ha_sim_test full parallel suite (4 containers, 62 recipes, 387 checks) — all pass, zero "malformed packet" disconnects